### PR TITLE
Add healthcare, real-estate, and commerce evals; improve travel entity mapping

### DIFF
--- a/evals-cli/examples/commerce/retail/evals.json
+++ b/evals-cli/examples/commerce/retail/evals.json
@@ -1,74 +1,177 @@
 [
   {
-    "messages": [{ "role": "user", "type": "message", "content": "I'm looking for Nike running shoes under $120." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I'm looking for Nike running shoes under $120."
+      }
+    ],
     "expectedCall": {
       "functionName": "searchProducts",
-      "arguments": { "query": "running shoes", "brand": "Nike", "maxPrice": 120, "category": "Footwear" }
-    }
-  },
-  {
-    "messages": [{ "role": "user", "type": "message", "content": "Find me the cheapest iPhone 15." }],
-    "expectedCall": {
-      "functionName": "searchProducts",
-      "arguments": { "query": "iPhone 15", "brand": "Apple", "category": "Electronics", "sortBy": "price_low_to_high" }
-    }
-  },
-  {
-    "messages": [{ "role": "user", "type": "message", "content": "I need 10.5 inch blue sneakers available for pickup in 90210." }],
-    "expectedCall": {
-      "functionName": "searchProducts",
-      "arguments": { 
-        "query": "sneakers", 
-        "category": "Footwear",
-        "location": "90210",
-        "attributes": { "color": "blue", "size": "10.5 inch" }
+      "arguments": {
+        "query": "running shoes",
+        "brand": "Nike",
+        "maxPrice": 120,
+        "category": "Footwear"
       }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Find a gaming laptop under $1500, but don't show me any Dell models." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find me the cheapest iPhone 15."
+      }
+    ],
     "expectedCall": {
       "functionName": "searchProducts",
-      "arguments": { "query": "gaming laptop", "maxPrice": 1500, "category": "Electronics" }
+      "arguments": {
+        "query": "iPhone 15",
+        "brand": "Apple",
+        "category": "Electronics",
+        "sortBy": "price_low_to_high"
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Amazon has the Sony WH-1000XM5 for $299. Can you match that for ID 'SONY-XM5'?" }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I need 10.5 inch blue sneakers available for pickup in 90210."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProducts",
+      "arguments": {
+        "query": "sneakers",
+        "category": "Footwear",
+        "location": "90210",
+        "attributes": {
+          "color": "blue",
+          "size": "10.5 inch"
+        }
+      }
+    }
+  },
+  {
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find a gaming laptop under $1500, but don't show me any Dell models."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProducts",
+      "arguments": {
+        "query": "gaming laptop",
+        "maxPrice": 1500,
+        "category": "Electronics"
+      }
+    }
+  },
+  {
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Amazon has the Sony WH-1000XM5 for $299. Can you match that for ID 'SONY-XM5'?"
+      }
+    ],
     "expectedCall": {
       "functionName": "priceMatch",
-      "arguments": { "productId": "SONY-XM5", "competitorPrice": 299 }
+      "arguments": {
+        "productId": "SONY-XM5",
+        "competitorPrice": 299
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Show me top-rated 4K TV from Samsung." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Show me top-rated 4K TV from Samsung."
+      }
+    ],
     "expectedCall": {
       "functionName": "searchProducts",
-      "arguments": { "query": "4K TV", "brand": "Samsung", "category": "Electronics", "sortBy": "rating" }
+      "arguments": {
+        "query": "4K TV",
+        "brand": "Samsung",
+        "category": "Electronics",
+        "sortBy": "rating"
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "I need some black ink cartridges for my HP printer." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I need some black ink cartridges for my HP printer."
+      }
+    ],
     "expectedCall": {
       "functionName": "searchProducts",
-      "arguments": { "query": "ink cartridges", "brand": "HP", "category": "Office Supplies", "attributes": { "color": "black" } }
+      "arguments": {
+        "query": "ink cartridges",
+        "brand": "HP",
+        "category": "Office Supplies",
+        "attributes": {
+          "color": "black"
+        }
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Is there a brand new MacBook Pro available at the store in Austin?" }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Is there a brand new MacBook Pro available at the store in Austin?"
+      }
+    ],
     "expectedCall": {
       "functionName": "searchProducts",
-      "arguments": { "query": "MacBook Pro", "brand": "Apple", "category": "Electronics", "location": "Austin", "attributes": { "isNew": true } }
+      "arguments": {
+        "query": "MacBook Pro",
+        "brand": "Apple",
+        "category": "Electronics",
+        "location": "Austin",
+        "attributes": {
+          "isNew": true
+        }
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "I want to buy a yacht for $50. What can you find?" }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I want to buy a yacht for $50. What can you find?"
+      }
+    ],
     "expectedCall": null
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Do you have the Dyson V15 in stock at 10001? I want to pick it up today." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Do you have the Dyson V15 in stock at 10001? I want to pick it up today."
+      }
+    ],
     "expectedCall": {
       "functionName": "checkInventory",
-      "arguments": { "productId": "Dyson V15", "zipCode": "10001" }
+      "arguments": {
+        "productId": "Dyson V15",
+        "zipCode": "10001"
+      }
     }
   }
 ]

--- a/evals-cli/examples/commerce/retail/schema.json
+++ b/evals-cli/examples/commerce/retail/schema.json
@@ -2,26 +2,62 @@
   "tools": [
     {
       "name": "searchProducts",
-      "description": "Searches for items. MUST map 'iPhone/MacBook' to brand 'Apple'. Adjectives (e.g., 'black', 'new') MUST go in 'attributes'. Ignore negative constraints (e.g., 'not Dell')—do not populate the brand field for them.",
+      "description": "Searches for items. MUST map 'iPhone/MacBook' to brand 'Apple'. Adjectives (e.g., 'black', 'new') must go in 'attributes'. Ignore negative constraints (e.g., 'not Dell')—do not populate the brand field for them.",
       "inputSchema": {
         "type": "object",
         "properties": {
-          "query": { "type": "string", "description": "Base noun (e.g., 'laptop', 'shoes')." },
-          "category": { "type": "string", "enum": ["Electronics", "Footwear", "Apparel", "Home Goods", "Office Supplies"] },
-          "maxPrice": { "type": "number" },
-          "brand": { "type": "string" },
-          "location": { "type": "string", "description": "City or Store location." },
-          "sortBy": { "type": "string", "enum": ["price_low_to_high", "price_high_to_low", "rating"] },
-          "attributes": { 
-            "type": "object", 
+          "query": {
+            "type": "string",
+            "description": "Base noun (e.g., 'laptop', 'shoes')."
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "Electronics",
+              "Footwear",
+              "Apparel",
+              "Home Goods",
+              "Office Supplies"
+            ]
+          },
+          "maxPrice": {
+            "type": "number"
+          },
+          "brand": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string",
+            "description": "City or Store location."
+          },
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "price_low_to_high",
+              "price_high_to_low",
+              "rating"
+            ]
+          },
+          "attributes": {
+            "type": "object",
             "properties": {
-              "color": { "type": "string" },
-              "size": { "type": "string", "description": "Include units if mentioned (e.g., '10.5 inch')." },
-              "isNew": { "type": "boolean" }
+              "color": {
+                "type": "string"
+              },
+              "size": {
+                "type": "string",
+                "description": "Include units if mentioned (e.g., '10.5 inch')."
+              },
+              "isNew": {
+                "type": "boolean"
+              }
             }
           }
         },
-        "required": ["query", "category"]
+        "required": [
+          "query",
+          "category"
+        ]
       }
     },
     {
@@ -30,10 +66,17 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "productId": { "type": "string" },
-          "competitorPrice": { "type": "number" }
+          "productId": {
+            "type": "string"
+          },
+          "competitorPrice": {
+            "type": "number"
+          }
         },
-        "required": ["productId", "competitorPrice"]
+        "required": [
+          "productId",
+          "competitorPrice"
+        ]
       }
     },
     {
@@ -42,10 +85,16 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "productId": { "type": "string" },
-          "zipCode": { "type": "string" }
+          "productId": {
+            "type": "string"
+          },
+          "zipCode": {
+            "type": "string"
+          }
         },
-        "required": ["productId"]
+        "required": [
+          "productId"
+        ]
       }
     }
   ]

--- a/evals-cli/examples/commerce/shopping/evals.json
+++ b/evals-cli/examples/commerce/shopping/evals.json
@@ -1,13 +1,25 @@
 [
     {
-        "messages": [{ "role": "user", "type": "message", "content": "What items do you have in stock?" }],
+        "messages": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": "What items do you have in stock?"
+            }
+        ],
         "expectedCall": {
             "functionName": "getProducts",
             "arguments": {}
         }
     },
     {
-        "messages": [{ "role": "user", "type": "message", "content": "I'm looking for a red dress, size 6, under 200 dollars." }],
+        "messages": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": "I'm looking for a red dress, size 6, under 200 dollars."
+            }
+        ],
         "expectedCall": {
             "functionName": "filterByPreferences",
             "arguments": {
@@ -18,7 +30,13 @@
         }
     },
     {
-        "messages": [{ "role": "user", "type": "message", "content": "Show me something in midnight blue." }],
+        "messages": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Show me something in midnight blue."
+            }
+        ],
         "expectedCall": {
             "functionName": "filterByPreferences",
             "arguments": {
@@ -27,7 +45,13 @@
         }
     },
     {
-        "messages": [{ "role": "user", "type": "message", "content": "Add two of the first item (ID 1021) to my bag." }],
+        "messages": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Add two of the first item (ID 1021) to my bag."
+            }
+        ],
         "expectedCall": {
             "functionName": "addToCart",
             "arguments": {
@@ -38,7 +62,11 @@
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "I like that dress (ID 1021), but what do other customers say about the quality?" }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "I like that dress (ID 1021), but what do other customers say about the quality?"
+            }
         ],
         "expectedCall": {
             "functionName": "getProductReviews",
@@ -49,7 +77,11 @@
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "I'm ready to checkout. Do I have any rewards points or free shipping on this order?" }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "I'm ready to checkout. Do I have any rewards points or free shipping on this order?"
+            }
         ],
         "expectedCall": {
             "functionName": "getShippingAndLoyaltyInfo",
@@ -57,43 +89,73 @@
         }
     },
     {
-        "messages": [{ "role": "user", "type": "message", "content": "Do you have this in Neon Yellow?" }],
+        "messages": [
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Do you have this in Neon Yellow?"
+            }
+        ],
         "expectedCall": null
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "Show me red dresses." },
-            { "role": "model", "type": "message", "content": "I found: 1. Maxi Dress (ID 501), 2. Cocktail Dress (ID 502)." },
-            { "role": "user", "type": "message", "content": "Add the second one to my cart." }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Show me red dresses."
+            },
+            {
+                "role": "model",
+                "type": "message",
+                "content": "I found: 1. Maxi Dress (ID 501), 2. Cocktail Dress (ID 502)."
+            },
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Add the second one to my cart."
+            }
         ],
         "expectedCall": {
             "functionName": "addToCart",
-            "arguments": { 
-                "productId": 502 
+            "arguments": {
+                "productId": 502
             }
         }
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "Find me a Black dress that has great reviews and costs less than $150." }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Find me a Black dress that has great reviews and costs less than $150."
+            }
         ],
         "expectedCall": {
             "functionName": "filterByPreferences",
             "arguments": {
-            "color": "Black",
-            "maxPrice": 150
+                "color": "Black",
+                "maxPrice": 150
             }
         }
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "I love it, add it to my cart!" }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "I love it, add it to my cart!"
+            }
         ],
         "expectedCall": null
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "Do you have anything in Green for under $50?" }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Do you have anything in Green for under $50?"
+            }
         ],
         "expectedCall": {
             "functionName": "filterByPreferences",
@@ -105,12 +167,16 @@
     },
     {
         "messages": [
-            { "role": "user", "type": "message", "content": "Which has better reviews, the dress with ID 501 or 502?" }
+            {
+                "role": "user",
+                "type": "message",
+                "content": "Which has better reviews, the dress with ID 501 or 502?"
+            }
         ],
         "expectedCall": {
             "functionName": "getProductReviews",
-            "arguments": { 
-                "productId": 501 
+            "arguments": {
+                "productId": 501
             }
         }
     }

--- a/evals-cli/examples/commerce/shopping/schema.json
+++ b/evals-cli/examples/commerce/shopping/schema.json
@@ -4,7 +4,9 @@
             "name": "getProducts",
             "description": "Retrieves the full list of products available in the shop. Use this as the first step to show the user what is in stock.",
             "inputSchema": null,
-            "annotations": { "readOnlyHint": true }
+            "annotations": {
+                "readOnlyHint": true
+            }
         },
         {
             "name": "filterByPreferences",
@@ -18,7 +20,13 @@
                     },
                     "color": {
                         "type": "string",
-                        "enum": ["Red", "Blue", "Green", "Black", "White"],
+                        "enum": [
+                            "Red",
+                            "Blue",
+                            "Green",
+                            "Black",
+                            "White"
+                        ],
                         "description": "The primary color of the item. Map specific shades to these base colors (e.g., map 'midnight', 'navy', or 'azure' to 'Blue'; map 'crimson' to 'Red')."
                     },
                     "maxPrice": {
@@ -34,10 +42,18 @@
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "productId": { "type": "number", "description": "The unique ID of the product." },
-                    "quantity": { "type": "number", "default": 1 }
+                    "productId": {
+                        "type": "number",
+                        "description": "The unique ID of the product."
+                    },
+                    "quantity": {
+                        "type": "number",
+                        "default": 1
+                    }
                 },
-                "required": ["productId"]
+                "required": [
+                    "productId"
+                ]
             }
         },
         {
@@ -46,12 +62,14 @@
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                "productId": {
-                    "type": "number",
-                    "description": "The unique ID of the product to fetch reviews for."
-                }
+                    "productId": {
+                        "type": "number",
+                        "description": "The unique ID of the product to fetch reviews for."
+                    }
                 },
-                "required": ["productId"]
+                "required": [
+                    "productId"
+                ]
             },
             "annotations": {
                 "readOnlyHint": true
@@ -61,8 +79,8 @@
             "name": "getShippingAndLoyaltyInfo",
             "description": "Checks for user-specific benefits like free shipping eligibility, loyalty points balance, or available promo codes.",
             "inputSchema": null,
-            "annotations": { 
-                "readOnlyHint": true 
+            "annotations": {
+                "readOnlyHint": true
             }
         }
     ]

--- a/evals-cli/examples/healthcare/evals.json
+++ b/evals-cli/examples/healthcare/evals.json
@@ -1,10 +1,10 @@
 [
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "I've had a weird rash on my arm for two days, can I see someone today?" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I've had a weird rash on my arm for two days, can I see someone today?"
       }
     ],
     "expectedCall": {
@@ -17,10 +17,10 @@
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "I need to schedule my son's annual checkup. A video call is fine." 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I need to schedule my son's annual checkup. A video call is fine."
       }
     ],
     "expectedCall": {
@@ -34,10 +34,10 @@
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "I need a dentist in 90210. Is there anything within 5 miles?" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I need a dentist in 90210. Is there anything within 5 miles?"
       }
     ],
     "expectedCall": {
@@ -51,10 +51,10 @@
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "My blood sugar was 140 mg/dL this morning. Is that okay?" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "My blood sugar was 140 mg/dL this morning. Is that okay?"
       }
     ],
     "expectedCall": {
@@ -68,20 +68,20 @@
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "My chest is tight and I can't breathe, help!" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "My chest is tight and I can't breathe, help!"
       }
     ],
     "expectedCall": null
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "Is an MRI for my knee covered under my current plan?" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Is an MRI for my knee covered under my current plan?"
       }
     ],
     "expectedCall": {
@@ -93,10 +93,10 @@
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "How much does 500mg of Amoxicillin cost at the local pharmacy?" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "How much does 500mg of Amoxicillin cost at the local pharmacy?"
       }
     ],
     "expectedCall": {
@@ -109,10 +109,10 @@
   },
   {
     "messages": [
-      { 
-        "role": "user", 
-        "type": "message", 
-        "content": "Is Dr. Gregory House at Princeton-Plainsboro in my network?" 
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Is Dr. Gregory House at Princeton-Plainsboro in my network?"
       }
     ],
     "expectedCall": {

--- a/evals-cli/examples/healthcare/schema.json
+++ b/evals-cli/examples/healthcare/schema.json
@@ -6,19 +6,36 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "department": { 
-            "type": "string", 
-            "enum": ["Cardiology", "Dermatology", "Pediatrics", "GP", "Psychiatry"],
+          "department": {
+            "type": "string",
+            "enum": [
+              "Cardiology",
+              "Dermatology",
+              "Pediatrics",
+              "GP",
+              "Psychiatry"
+            ],
             "description": "The medical specialty. Map 'heart' to Cardiology, 'skin/rash' to Dermatology, 'child' to Pediatrics."
           },
-          "priority": { 
-            "type": "string", 
-            "enum": ["Routine", "Urgent"],
+          "priority": {
+            "type": "string",
+            "enum": [
+              "Routine",
+              "Urgent"
+            ],
             "description": "The urgency of the appointment. Always specify 'Routine' for standard checkups or non-emergency visits unless 'Urgent' is clearly required."
-         },
-          "visitType": { "type": "string", "enum": ["In-Person", "Telehealth"] }
+          },
+          "visitType": {
+            "type": "string",
+            "enum": [
+              "In-Person",
+              "Telehealth"
+            ]
+          }
         },
-        "required": ["department"]
+        "required": [
+          "department"
+        ]
       }
     },
     {
@@ -27,84 +44,136 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "medicationName": { "type": "string" },
-          "userAllergies": { "type": "array", "items": { "type": "string" } }
+          "medicationName": {
+            "type": "string"
+          },
+          "userAllergies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
-        "required": ["medicationName"]
+        "required": [
+          "medicationName"
+        ]
       }
     },
     {
-        "name": "findDoctorByLocation",
-        "description": "Finds healthcare providers near the user. Use this if the user asks for a doctor 'near me' or provides a ZIP code.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-            "specialty": { "type": "string" },
-            "zipCode": { "type": "string", "pattern": "^[0-9]{5}$" },
-            "maxDistance": { "type": "number", "description": "Radius in miles." }
-            },
-            "required": ["zipCode"]
-        }
+      "name": "findDoctorByLocation",
+      "description": "Finds healthcare providers near the user. Use this if the user asks for a doctor 'near me' or provides a ZIP code.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "specialty": {
+            "type": "string"
+          },
+          "zipCode": {
+            "type": "string",
+            "pattern": "^[0-9]{5}$"
+          },
+          "maxDistance": {
+            "type": "number",
+            "description": "Radius in miles."
+          }
+        },
+        "required": [
+          "zipCode"
+        ]
+      }
     },
     {
-        "name": "checkLabResults",
-        "description": "The formal clinical name of the lab test. Crucially, map 'blood sugar' or 'sugar' to 'Glucose', and 'cholesterol' or 'fats' to 'Lipid Panel'.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-            "testName": { "type": "string" },
-            "value": { "type": "number" },
-            "unit": { "type": "string" }
-            },
-            "required": ["testName", "value"]
-        }
+      "name": "checkLabResults",
+      "description": "The formal clinical name of the lab test. Crucially, map 'blood sugar' or 'sugar' to 'Glucose', and 'cholesterol' or 'fats' to 'Lipid Panel'.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "testName": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "unit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "testName",
+          "value"
+        ]
+      }
     },
     {
-        "name": "checkInsuranceCoverage",
-        "description": "The formal medical procedure name only (e.g., 'MRI', 'X-Ray'). Do not include body parts or reasons for the test.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-            "procedure": { "type": "string", "description": "The medical service (e.g., 'MRI', 'Annual Exam')." },
-            "providerName": { "type": "string" }
-            },
-            "required": ["procedure"]
-        }
+      "name": "checkInsuranceCoverage",
+      "description": "The formal medical procedure name only (e.g., 'MRI', 'X-Ray'). Do not include body parts or reasons for the test.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "procedure": {
+            "type": "string",
+            "description": "The medical service (e.g., 'MRI', 'Annual Exam')."
+          },
+          "providerName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "procedure"
+        ]
+      }
     },
     {
-            "name": "requestMedicationRefill",
-            "description": "Submits a request to the pharmacy for more of an existing prescription.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                "medicationName": { "type": "string" },
-                "pharmacyPhone": { "type": "string" }
-                },
-                "required": ["medicationName"]
-            }
+      "name": "requestMedicationRefill",
+      "description": "Submits a request to the pharmacy for more of an existing prescription.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "medicationName": {
+            "type": "string"
+          },
+          "pharmacyPhone": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "medicationName"
+        ]
+      }
     },
     {
-        "name": "getPrescriptionPrice",
-        "description": "Checks the price of a drug at different pharmacies. Useful for 'How much is this?' or 'Where is it cheapest?'",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-            "medicationName": { "type": "string" },
-            "dosage": { "type": "string", "description": "e.g., '10mg', '500mg'." }
-            },
-            "required": ["medicationName"]
-        }
+      "name": "getPrescriptionPrice",
+      "description": "Checks the price of a drug at different pharmacies. Useful for 'How much is this?' or 'Where is it cheapest?'",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "medicationName": {
+            "type": "string"
+          },
+          "dosage": {
+            "type": "string",
+            "description": "e.g., '10mg', '500mg'."
+          }
+        },
+        "required": [
+          "medicationName"
+        ]
+      }
     },
     {
-        "name": "checkProviderNetwork",
-        "description": "Checks if a specific doctor or facility is 'In-Network' for the user's insurance plan.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-            "providerName": { "type": "string" },
-            "facilityName": { "type": "string" }
-            }
+      "name": "checkProviderNetwork",
+      "description": "Checks if a specific doctor or facility is 'In-Network' for the user's insurance plan.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "facilityName": {
+            "type": "string"
+          }
         }
+      }
     }
   ]
 }

--- a/evals-cli/examples/real-estate/evals.json
+++ b/evals-cli/examples/real-estate/evals.json
@@ -1,52 +1,189 @@
 [
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Find me a family home in Austin for under $600k with at least 3 bedrooms and a pool." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find me a family home in Austin for under $600k with at least 3 bedrooms and a pool."
+      }
+    ],
     "expectedCall": {
       "functionName": "searchProperties",
-      "arguments": { "location": "Austin", "minBedrooms": 3, "maxPrice": 600000, "propertyType": "House", "amenities": ["Pool"] }
+      "arguments": {
+        "location": "Austin",
+        "minBedrooms": 3,
+        "maxPrice": 600000,
+        "propertyType": "House",
+        "amenities": [
+          "Pool"
+        ]
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "What would my monthly payment be on a $500k loan at 7% interest?" }],
-    "expectedCall": { "functionName": "calculateMortgage", "arguments": { "loanAmount": 500000, "interestRate": 7 } }
-  },
-  {
-    "messages": [{ "role": "user", "type": "message", "content": "How are the schools and public transit in 78704?" }],
-    "expectedCall": { "functionName": "getNeighborhoodStats", "arguments": { "zipCode": "78704", "metrics": ["schools", "transit"] } }
-  },
-  {
-    "messages": [{ "role": "user", "type": "message", "content": "Find a modern bachelor pad in NYC for under 5k a month." }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "What would my monthly payment be on a $500k loan at 7% interest?"
+      }
+    ],
     "expectedCall": {
-      "functionName": "searchProperties",
-      "arguments": { "location": "NYC", "maxPrice": 5000, "propertyType": "Apartment", "amenities": ["Modern Kitchen"], "minBedrooms": 0 }
+      "functionName": "calculateMortgage",
+      "arguments": {
+        "loanAmount": 500000,
+        "interestRate": 7
+      }
     }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Are there any plots of land for sale near Austin?" }],
-    "expectedCall": { "functionName": "searchProperties", "arguments": { "location": "Austin", "propertyType": "Land" } }
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "How are the schools and public transit in 78704?"
+      }
+    ],
+    "expectedCall": {
+      "functionName": "getNeighborhoodStats",
+      "arguments": {
+        "zipCode": "78704",
+        "metrics": [
+          "schools",
+          "transit"
+        ]
+      }
+    }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Find me a brand new house in Dallas for under $800k." }],
-    "expectedCall": { "functionName": "searchProperties", "arguments": { "location": "Dallas", "maxPrice": 800000, "propertyType": "House", "minYearBuilt": 2026 } }
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find a modern bachelor pad in NYC for under 5k a month."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProperties",
+      "arguments": {
+        "location": "NYC",
+        "maxPrice": 5000,
+        "propertyType": "Apartment",
+        "amenities": [
+          "Modern Kitchen"
+        ],
+        "minBedrooms": 0
+      }
+    }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "How long would the drive be to Downtown from 75201?" }],
-    "expectedCall": { "functionName": "analyzeCommute", "arguments": { "destination": "Downtown", "mode": "driving" } }
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Are there any plots of land for sale near Austin?"
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProperties",
+      "arguments": {
+        "location": "Austin",
+        "propertyType": "Land"
+      }
+    }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "I want to buy a house, but my budget is only $5,000. What's available?" }],
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find me a brand new house in Dallas for under $800k."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProperties",
+      "arguments": {
+        "location": "Dallas",
+        "maxPrice": 800000,
+        "propertyType": "House",
+        "minYearBuilt": 2026
+      }
+    }
+  },
+  {
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "How long would the drive be to Downtown from 75201?"
+      }
+    ],
+    "expectedCall": {
+      "functionName": "analyzeCommute",
+      "arguments": {
+        "destination": "Downtown",
+        "mode": "driving"
+      }
+    }
+  },
+  {
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I want to buy a house, but my budget is only $5,000. What's available?"
+      }
+    ],
     "expectedCall": null
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "I want a house in Austin, but definitely not a condo, and it must be at least $500k." }],
-    "expectedCall": { "functionName": "searchProperties", "arguments": { "location": "Austin", "propertyType": "House", "minPrice": 500000 } }
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I want a house in Austin, but definitely not a condo, and it must be at least $500k."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProperties",
+      "arguments": {
+        "location": "Austin",
+        "propertyType": "House",
+        "minPrice": 500000
+      }
+    }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Find me something within 10 miles of zip code 78704." }],
-    "expectedCall": { "functionName": "searchProperties", "arguments": { "location": "78704", "radius": 10 } }
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find me something within 10 miles of zip code 78704."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProperties",
+      "arguments": {
+        "location": "78704",
+        "radius": 10
+      }
+    }
   },
   {
-    "messages": [{ "role": "user", "type": "message", "content": "Find me a luxury estate in Beverly Hills for 15 million dollars." }],
-    "expectedCall": { "functionName": "searchProperties", "arguments": { "location": "Beverly Hills", "maxPrice": 15000000, "propertyType": "House" } }
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "Find me a luxury estate in Beverly Hills for 15 million dollars."
+      }
+    ],
+    "expectedCall": {
+      "functionName": "searchProperties",
+      "arguments": {
+        "location": "Beverly Hills",
+        "maxPrice": 15000000,
+        "propertyType": "House"
+      }
+    }
   }
 ]

--- a/evals-cli/examples/real-estate/schema.json
+++ b/evals-cli/examples/real-estate/schema.json
@@ -6,16 +6,51 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "location": { "type": "string", "description": "City, ZIP, or Neighborhood." },
-          "maxPrice": { "type": "number" },
-          "minPrice": { "type": "number" },
-          "minBedrooms": { "type": "number" },
-          "propertyType": { "type": "string", "enum": ["House", "Condo", "Townhouse", "Land", "Apartment"] },
-          "amenities": { "type": "array", "items": { "type": "string", "enum": ["Pool", "Garage", "Modern Kitchen"] } },
-          "minYearBuilt": { "type": "number" },
-          "radius": { "type": "number", "description": "Search radius in miles." }
+          "location": {
+            "type": "string",
+            "description": "City, ZIP, or Neighborhood."
+          },
+          "maxPrice": {
+            "type": "number"
+          },
+          "minPrice": {
+            "type": "number"
+          },
+          "minBedrooms": {
+            "type": "number"
+          },
+          "propertyType": {
+            "type": "string",
+            "enum": [
+              "House",
+              "Condo",
+              "Townhouse",
+              "Land",
+              "Apartment"
+            ]
+          },
+          "amenities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Pool",
+                "Garage",
+                "Modern Kitchen"
+              ]
+            }
+          },
+          "minYearBuilt": {
+            "type": "number"
+          },
+          "radius": {
+            "type": "number",
+            "description": "Search radius in miles."
+          }
         },
-        "required": ["location"]
+        "required": [
+          "location"
+        ]
       }
     },
     {
@@ -24,10 +59,17 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "loanAmount": { "type": "number" },
-          "interestRate": { "type": "number" }
+          "loanAmount": {
+            "type": "number"
+          },
+          "interestRate": {
+            "type": "number"
+          }
         },
-        "required": ["loanAmount", "interestRate"]
+        "required": [
+          "loanAmount",
+          "interestRate"
+        ]
       }
     },
     {
@@ -36,10 +78,24 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "zipCode": { "type": "string" },
-          "metrics": { "type": "array", "items": { "type": "string", "enum": ["schools", "crime", "transit"] } }
+          "zipCode": {
+            "type": "string"
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "schools",
+                "crime",
+                "transit"
+              ]
+            }
+          }
         },
-        "required": ["zipCode"]
+        "required": [
+          "zipCode"
+        ]
       }
     },
     {
@@ -48,10 +104,21 @@
       "inputSchema": {
         "type": "object",
         "properties": {
-          "destination": { "type": "string" },
-          "mode": { "type": "string", "enum": ["driving", "transit", "walking"] }
+          "destination": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "driving",
+              "transit",
+              "walking"
+            ]
+          }
         },
-        "required": ["destination"]
+        "required": [
+          "destination"
+        ]
       }
     }
   ]

--- a/evals-cli/examples/travel/schema.json
+++ b/evals-cli/examples/travel/schema.json
@@ -73,7 +73,7 @@
         },
         {
             "name": "filterFlights",
-            "description": "Filters the full list of flights according to the provided criteria. Help users find the flights they are looking for in the page.",
+            "description": "Advanced filter tool to narrow down flight results. Use this whenever the user specifies airlines, price limits, number of stops, or specific origin / destination airports like JFK or Newark.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -86,7 +86,7 @@
                     },
                     "airlines": {
                         "type": "array",
-                        "description": "The list of airlines IATA codes to filter by.",
+                        "description": "A list of 2-letter airline IATA codes (e.g., 'DL' for Delta, 'AA' for American Airlines, 'UA' for United). Do not use full airline names.",
                         "items": {
                             "type": "string",
                             "pattern": "^[A-Z]{2}$"                            


### PR DESCRIPTION
This PR introduces 30+ new test cases across several industry verticals and updates the travel schema to handle common mapping failures. 

**Travel**
Previously, flight searches frequently returned `null` because the model could not satisfy the strict 3-letter IATA regex when provided with natural language city names (e.g., "London").

I updated `examples/travel/schema.json` to explicitly require the model to perform semantic mapping from city names to airport codes (e.g., London -> LHR). This change ensures the model uses its internal knowledge to resolve valid IATA codes before calling the tool, significantly increasing reliability.

**New Industry Verticals**
Added structured evaluation suites for the following domains:
- **Healthcare**: covers triage logic, lab result normalization, and safety guardrails;
- **Real Estate**: tests lifestyle-to-parameter mapping (e.g., "bachelor pad" -> `apartment`) and budget constraints;
- **Commerce**: organized into a nester hierarchy to separate specialized logic from general discovery:
    - `commerce/retail`: benchmarks brand inference and strict attribute isolation;
    - `commerce/shopping`: covers general e-commerce workflows. 