### PR TITLE
Add React Chess demo to Awesome WebMCP list

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -17,6 +17,8 @@ A curated list of awesome WebMCP demos.
   - **Example Prompt:** "I want to book a flight from New York to Los Angeles for two people on next Thursday."
 - [Animal Viewer](https://65s6dw.csb.app/) - A simple codesandbox demo page that shows either a dog or a cat image.
   - **Example Prompt:** "Show me a dog on this page"
+- [React Chess](https://matipojo.github.io/WebMCP-React-Chess) - A chess game that exposes WebMCP tools (`get-board-state`, `make-move`, `get-possible-moves`, `restart-game`, `promote-pawn`) so an AI agent can play chess through `navigator.modelContext`.
+  - **Example Prompt:** "Let's play chess. You play white. Make your opening move."
 - **Moving Beyond Screen Scraping**: A hands-on example of using WebMCP to create an agentic first experience with 10x fewer tokens
   - [Article](https://lnkd.in/daPRAtMX) | [Code](https://lnkd.in/dkZ3Jizn)
 


### PR DESCRIPTION
## Summary

- Adds [React Chess](https://matipojo.github.io/WebMCP-React-Chess) to the Awesome WebMCP demos list
- A chess game built with React that exposes 5 WebMCP tools (`get-board-state`, `make-move`, `get-possible-moves`, `restart-game`, `promote-pawn`) via `navigator.modelContext`, allowing AI agents to play a full game of chess
- Source: https://github.com/matipojo/WebMCP-React-Chess

## Details

The demo showcases a more interactive, game-oriented use case for WebMCP — an AI agent can query the board state, discover legal moves, and make moves through structured tool calls rather than screen scraping.

**Example prompt:** "Let's play chess. You play white. Make your opening move."


Made with [Cursor](https://cursor.com)