### PR TITLE
Add multiple backend support 

### DIFF
--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -4,7 +4,7 @@ A TypeScript framework for evaluating the tool-calling capabilities of Large Lan
 
 ## Features
 
-- **Backends**: Supports Google GenAI (Gemini) and has experimental support for the OpenAI API, Anthropic API, and Ollama.
+- **Backends**: Execution support for `@google/genai` (`gemini`). Integrations for local models (`ollama`), as well as full **Vercel AI SDK** (`vercel`) integration for robust multi-provider support (OpenAI, Anthropic) are available but currently considered experimental.
 - **Evaluation Loop**: Automatically runs defined test cases against the model and compares actual tool calls with expected ones.
 - **Extensible**: Easy to add new backends or evaluation sets.
 
@@ -78,12 +78,13 @@ With Ollama:
 node dist/bin/runevals.js --model=qwen3:8b --backend=ollama --tools=examples/travel/schema.json --evals=examples/travel/evals.json
 ```
 
-| Argument    | Required | Default            | Description                                                  |
-| ----------- | -------- | ------------------ | ------------------------------------------------------------ |
-| `--tools`   | Yes      | —                  | Path to the tool schema JSON file                            |
-| `--evals`   | Yes      | —                  | Path to the evals JSON file                                  |
-| `--backend` | No       | `gemini`           | Backend to use (`gemini`, `openai`, `anthropic` or `ollama`) |
-| `--model`   | No       | `gemini-2.5-flash` | Model name                                                   |
+| Argument     | Required | Default            | Description                                                              |
+| ------------ | -------- | ------------------ | ------------------------------------------------------------------------ |
+| `--tools`    | Yes      | —                  | Path to the tool schema JSON file                                        |
+| `--evals`    | Yes      | —                  | Path to the evals JSON file                                              |
+| `--backend`  | No       | `gemini`           | Execution backend (`gemini`, `ollama`, or `vercel`)                      |
+| `--provider` | No       | `google`           | Model provider (e.g., `openai`, `anthropic`, `google`) if using `vercel` |
+| `--model`    | No       | `gemini-2.5-flash` | Model name                                                               |
 
 ### `webmcpevals` — live tool schemas via WebMCP
 
@@ -93,12 +94,13 @@ Launches Chrome Canary, navigates to the given URL, and retrieves tool schemas l
 node dist/bin/webmcpevals.js --url=https://example.com/my-webmcp-app --evals=examples/travel/evals.json
 ```
 
-| Argument    | Required | Default            | Description                                                  |
-| ----------- | -------- | ------------------ | ------------------------------------------------------------ |
-| `--url`     | Yes      | —                  | URL of the page exposing WebMCP tools                        |
-| `--evals`   | Yes      | —                  | Path to the evals JSON file                                  |
-| `--backend` | No       | `gemini`           | Backend to use (`gemini`, `openai`, `anthropic` or `ollama`) |
-| `--model`   | No       | `gemini-2.5-flash` | Model name                                                   |
+| Argument     | Required | Default            | Description                                                            |
+| ------------ | -------- | ------------------ | ---------------------------------------------------------------------- |
+| `--url`      | Yes      | —                  | URL of the page exposing WebMCP tools                                  |
+| `--evals`    | Yes      | —                  | Path to the evals JSON file                                            |
+| `--backend`  | No       | `vercel`           | Must be `vercel` (live browser evaluation requires `ToolLoopAgent`)    |
+| `--provider` | No       | `gemini`           | Model provider to use with Vercel (e.g., `openai`, `anthropic`)        |
+| `--model`    | No       | `gemini-2.5-flash` | Model name                                                             |
 
 ### `serve` — WebMCP Evals UI sidecar
 

--- a/evals-cli/package-lock.json
+++ b/evals-cli/package-lock.json
@@ -12,6 +12,7 @@
         "@ai-sdk/anthropic": "^3.0.47",
         "@ai-sdk/google": "^3.0.31",
         "@ai-sdk/openai": "^3.0.33",
+        "@google/genai": "^1.38.0",
         "@types/cli-progress": "^3.11.6",
         "@types/minimist": "^1.2.5",
         "ai": "^6.0.98",
@@ -20,6 +21,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "minimist": "^1.2.8",
+        "ollama": "^0.6.3",
         "puppeteer-core": "^24.37.5",
         "zod": "^4.3.6"
       },
@@ -124,6 +126,69 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.42.0.tgz",
+      "integrity": "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -132,6 +197,80 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
@@ -267,6 +406,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -347,6 +492,30 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -371,6 +540,15 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bare-events": {
@@ -465,6 +643,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-ftp": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
@@ -472,6 +670,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -498,6 +705,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -506,6 +725,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -721,6 +946,29 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -791,6 +1039,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -990,6 +1253,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -1025,6 +1294,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1044,6 +1336,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -1071,6 +1391,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -1155,6 +1504,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -1294,11 +1690,74 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1355,6 +1814,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1362,6 +1836,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -1394,6 +1877,44 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1415,6 +1936,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ollama": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
+      "integrity": "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-fetch": "^3.6.20"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1434,6 +1964,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -1468,6 +2011,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1475,6 +2024,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1500,6 +2074,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1625,6 +2223,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1640,6 +2262,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1709,6 +2351,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1780,6 +2443,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/smart-buffer": {
@@ -1864,6 +2539,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1881,6 +2592,43 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2002,11 +2750,135 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/evals-cli/package.json
+++ b/evals-cli/package.json
@@ -19,6 +19,7 @@
     "@ai-sdk/anthropic": "^3.0.47",
     "@ai-sdk/google": "^3.0.31",
     "@ai-sdk/openai": "^3.0.33",
+    "@google/genai": "^1.38.0",
     "@types/cli-progress": "^3.11.6",
     "@types/minimist": "^1.2.5",
     "ai": "^6.0.98",
@@ -27,6 +28,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "minimist": "^1.2.8",
+    "ollama": "^0.6.3",
     "puppeteer-core": "^24.37.5",
     "zod": "^4.3.6"
   }

--- a/evals-cli/src/backends/gemini.ts
+++ b/evals-cli/src/backends/gemini.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Content, FunctionDeclaration, GoogleGenAI } from "@google/genai";
+import { WebmcpConfig } from "../types/config.js";
+import { Eval, Message, TestResults } from "../types/evals.js";
+import { Tool, ToolCall } from "../types/tools.js";
+import { Backend, RunEvent } from "./index.js";
+
+export class GeminiBackend implements Backend {
+  private googleGenAI: GoogleGenAI;
+
+  constructor(
+    apiKey: string,
+    private model: string,
+    private systemPrompt: string,
+    private tools: Array<Tool>,
+  ) {
+    this.googleGenAI = new GoogleGenAI({ apiKey });
+  }
+
+  async executeLocalEvals(test: Eval): Promise<any> {
+    const toolCall = await this.execute(test.messages);
+    if (toolCall) {
+      return {
+        functionName: toolCall.functionName,
+        args: toolCall.args || {}
+      };
+    } else {
+      return { text: "No tool calls generated." };
+    }
+  }
+
+  executeInBrowserEvals(tests: Array<Eval>, tools: Array<Tool>, config: WebmcpConfig, onEvent?: (event: RunEvent) => void): Promise<TestResults> {
+    throw new Error("Method not implemented.");
+  }
+
+  describe(): string {
+    return `Gemini Backend using model: ${this.model}`;
+  }
+
+  async execute(messages: Message[]): Promise<ToolCall | null> {
+    const functionDeclarations: Array<FunctionDeclaration> = this.tools.map(
+      (t) => {
+        return {
+          name: t.functionName,
+          description: t.description,
+          parametersJsonSchema: t.parameters,
+        };
+      },
+    );
+
+    const contents: Array<Content> = messages.map((m) => {
+      switch (m.type) {
+        case "message":
+          return {
+            role: m.role,
+            parts: [{ text: m.content }],
+          };
+
+        case "functioncall":
+          return {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: m.name,
+                  args: m.arguments as Record<string, unknown>,
+                },
+              },
+            ],
+          };
+
+        case "functionresponse":
+          return {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  name: m.name,
+                  response: m.response as Record<string, unknown>,
+                },
+              },
+            ],
+          };
+      }
+    });
+
+    const request = {
+      model: this.model,
+      contents: contents,
+      config: {
+        systemInstruction: this.systemPrompt,
+        tools: [{ functionDeclarations: functionDeclarations }],
+      },
+    };
+
+    const response = await this.googleGenAI.models.generateContent(request);
+
+    if (!response.functionCalls) {
+      return null;
+    }
+
+    const functionCalls: Array<ToolCall> = response.functionCalls
+      .filter((f) => f.name && f.args)
+      .map((f) => {
+        return {
+          args: f.args!,
+          functionName: f.name!,
+        };
+      });
+
+    return functionCalls[0];
+  }
+}

--- a/evals-cli/src/backends/index.ts
+++ b/evals-cli/src/backends/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WebmcpConfig } from "../types/config.js";
+import { Eval, TestResult, TestResults } from "../types/evals.js";
+import { Tool } from "../types/tools.js";
+
+export interface Backend {
+  executeLocalEvals(test: Eval): Promise<any>
+
+  executeInBrowserEvals(
+    tests: Array<Eval>,
+    tools: Array<Tool>,
+    config: WebmcpConfig,
+    onEvent?: (event: RunEvent) => void
+  ): Promise<TestResults>;
+
+  describe(): string;
+}
+
+export type RunEvent =
+  | { type: 'start'; total: number; message: string }
+  | { type: 'progress'; testNumber: number; result: TestResult }
+  | { type: 'completed'; results: TestResults; reportFile?: string }
+  | { type: 'error'; message: string };

--- a/evals-cli/src/backends/ollama.ts
+++ b/evals-cli/src/backends/ollama.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Ollama, Message as OllamaMessage, Tool as OllamaTool } from "ollama";
+import { WebmcpConfig } from "../types/config.js";
+import { Eval, Message, TestResults } from "../types/evals.js";
+import { Tool, ToolCall } from "../types/tools.js";
+import { Backend, RunEvent } from "./index.js";
+
+export class OllamaBackend implements Backend {
+  private ollama: Ollama;
+
+  constructor(
+    host: string,
+    private model: string,
+    private systemPrompt: string,
+    private tools: Array<Tool>,
+  ) {
+    this.ollama = new Ollama({ host });
+  }
+
+  async executeLocalEvals(test: Eval): Promise<any> {
+    const toolCall = await this.execute(test.messages);
+    if (toolCall) {
+      return {
+        functionName: toolCall.functionName,
+        args: toolCall.args || {}
+      };
+    } else {
+      return { text: "No tool calls generated." };
+    }
+  }
+
+  executeInBrowserEvals(tests: Array<Eval>, tools: Array<Tool>, config: WebmcpConfig, onEvent?: (event: RunEvent) => void): Promise<TestResults> {
+    throw new Error("Method not implemented.");
+  }
+
+  describe(): string {
+    return `Ollama Backend using model: ${this.model}`;
+  }
+
+  async execute(messages: Message[]): Promise<ToolCall | null> {
+    let ollamaTools: Array<OllamaTool> = this.tools.map((t) => {
+      return {
+        function: {
+          description: t.description,
+          name: t.functionName,
+          parameters: t.parameters,
+          type: "object",
+        },
+        type: "function",
+      };
+    });
+
+    let userMessages: Array<OllamaMessage> = messages.map((m) => {
+      switch (m.type) {
+        case "message":
+          return {
+            content: m.content,
+            role: m.role,
+          };
+
+        case "functioncall":
+          return {
+            role: "model",
+            // Technically, `content` is not required by the Ollama REST API, but required
+            // by the library type system.
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: m.name,
+                  arguments: m.arguments,
+                },
+              },
+            ],
+          };
+
+        case "functionresponse":
+          return {
+            role: "tool",
+            tool_name: m.name,
+            content: String(m.response),
+          };
+      }
+    });
+
+    let systemMessage: OllamaMessage = {
+      content: this.systemPrompt,
+      role: "system",
+    };
+
+    let requestMessages = [systemMessage, ...userMessages];
+    const response = await this.ollama.chat({
+      model: this.model,
+      tools: ollamaTools,
+      messages: requestMessages,
+      stream: false,
+    });
+
+    if (!response.message.tool_calls) {
+      return null;
+    }
+
+    const toolCalls: Array<ToolCall> = response.message.tool_calls.map((t) => {
+      return {
+        args: t.function.arguments,
+        functionName: t.function.name,
+      };
+    });
+
+    return toolCalls[0];
+  }
+}

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { generateText, ToolLoopAgent } from "ai";
+import puppeteer, { Browser, Page } from "puppeteer-core";
+import { Config, WebmcpConfig } from "../types/config.js";
+import { Eval, TestResult, TestResults } from "../types/evals.js";
+import { Tool } from "../types/tools.js";
+import { findChromePath, functionCallOutcome } from "../utils.js";
+
+import { Backend, RunEvent } from "../backends/index.js";
+import { createBrowserTool } from "../evaluator/browser.js";
+import { mapJsonSchemaToVercelTools, mapMessages, mapRawBrowserToolsToConfig } from "../evaluator/mappers.js";
+import { getModel } from "../evaluator/models.js";
+import { SYSTEM_PROMPT } from "../evaluator/prompts.js";
+
+export class VercelBackend implements Backend {
+  private aiModel: any;
+  private modelName: string;
+
+  constructor(
+    config: Config | WebmcpConfig,
+    private tools: Array<Tool>,
+  ) {
+    this.modelName = config.model || "gemini-2.5-flash";
+    this.aiModel = getModel(config);
+  }
+
+  async executeLocalEvals(test: Eval): Promise<any> {
+    try {
+      const aiMessages = mapMessages(test.messages);
+      let aiResult;
+
+      aiResult = await generateText({
+        model: this.aiModel,
+        system: SYSTEM_PROMPT,
+        messages: aiMessages,
+        tools: mapJsonSchemaToVercelTools(this.tools)
+      });
+
+      if (aiResult.toolCalls && aiResult.toolCalls.length > 0) {
+        const call: any = aiResult.toolCalls[0];
+        return {
+          functionName: call.toolName,
+          args: call.input || call.args || call.arguments || {}
+        };
+      } else {
+        return { text: aiResult.text };
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async executeInBrowserEvals(
+    tests: Array<Eval>,
+    tools: Array<Tool>,
+    config: WebmcpConfig,
+    onEvent?: (event: RunEvent) => void
+  ): Promise<TestResults> {
+    console.log("Executing in-browser evals for config:", config);
+    const executablePath = findChromePath();
+    let browser: Browser | null = null;
+    let page: Page | null = null;
+
+    try {
+      browser = await puppeteer.launch({
+        executablePath,
+        headless: true,
+        args: [
+          "--enable-features=WebMCPTesting",
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+        ],
+      });
+
+      console.log("Browser initialized for actual evals");
+    } catch (error) {
+      if (browser) await browser.close();
+      throw new Error(`Failed to initialize browser for actual evals: ${error}`);
+    }
+
+    const totalSteps = tests.reduce((sum, test) => {
+      return sum + (Array.isArray(test.expectedCall) ? test.expectedCall.length : 1);
+    }, 0);
+
+    if (onEvent) {
+      onEvent({ type: 'start', total: totalSteps, message: `Running evals using ${this.describe()}` });
+    }
+
+    let testCount = 0;
+    let passCount = 0;
+    let failCount = 0;
+    let errorCount = 0;
+    const testResults: Array<TestResult> = [];
+
+    for (const test of tests) {
+      if (page) {
+        await page.close();
+      }
+      page = await browser!.newPage();
+      await page.goto(config.url, {
+        waitUntil: "networkidle2",
+        timeout: 30000,
+      });
+
+      testCount++;
+      const expectedCalls = Array.isArray(test.expectedCall) ? test.expectedCall : [test.expectedCall];
+      let currentMessages = [...test.messages];
+      let currentTools = [...tools];
+
+      try {
+        const model = getModel(config);
+
+        const aiToolsWithExecution: Record<string, any> = {};
+        for (const t of currentTools) {
+          aiToolsWithExecution[t.functionName] = createBrowserTool(t, page!);
+        }
+
+        const agentWithExec = new ToolLoopAgent({
+          model,
+          tools: aiToolsWithExecution,
+          instructions: SYSTEM_PROMPT,
+          prepareCall: async (_opts: any): Promise<any> => {
+            // Dynamically fetch tools from the browser extension integration framework
+            const rawTools = await page!.evaluate(async () => {
+              let modelContext = null;
+              if (typeof (navigator as any).modelContext?.listTools === 'function') {
+                modelContext = (navigator as any).modelContext;
+              } else if (typeof (navigator as any).modelContextTesting?.listTools === 'function') {
+                modelContext = (navigator as any).modelContextTesting;
+              }
+              if (!modelContext) return null;
+              return await modelContext.listTools();
+            });
+
+            currentTools = mapRawBrowserToolsToConfig(rawTools, currentTools);
+
+            // We need to re-bind the execute methods to the newly loaded tools
+            const updatedAiTools: Record<string, any> = {};
+            for (const t of currentTools) {
+              updatedAiTools[t.functionName] = createBrowserTool(t, page!);
+            }
+
+            return { ..._opts, tools: updatedAiTools };
+          }
+        });
+
+        // Let the agent loop run
+        const promptMsg: any = test.messages[0];
+        const promptString = promptMsg?.content || "No prompt provided";
+        const resultPayload = await agentWithExec.generate({ prompt: promptString });
+
+        // Gather executed tool calls across all steps
+        const executedCalls: any[] = [];
+        if (resultPayload.steps && resultPayload.steps.length > 0) {
+          for (const step of resultPayload.steps) {
+            if (step.toolCalls && step.toolCalls.length > 0) {
+              for (const call of step.toolCalls) {
+                executedCalls.push({
+                  functionName: call.toolName,
+                  args: (call as any).input || (call as any).args || (call as any).arguments || {}
+                });
+              }
+            }
+          }
+        }
+
+        // If no tool was called at all, record a failure against the first expected call
+        if (executedCalls.length === 0) {
+          const response: any = { text: resultPayload.text };
+          const stepResult: TestResult = { test, response, outcome: "fail" };
+          testResults.push(stepResult);
+          failCount++;
+          if (onEvent) {
+            onEvent({ type: 'progress', testNumber: testCount, result: stepResult });
+          }
+        } else {
+          // Evaluate each expected call sequentially against what was executed
+          for (let i = 0; i < expectedCalls.length; i++) {
+            const currentFunctionCall = expectedCalls[i] || null;
+            const currentExecutionCall = executedCalls.length > i ? executedCalls[i] : null;
+            let response = currentExecutionCall;
+
+            if (!response) {
+              // Did not execute enough tools
+              response = { missing: "Did not execute this step" };
+            }
+
+            const outcome = functionCallOutcome(currentFunctionCall, response);
+            const stepResult: TestResult = { test: { messages: currentMessages, expectedCall: currentFunctionCall ? [currentFunctionCall] : null }, response, outcome };
+            testResults.push(stepResult);
+            outcome === "pass" ? passCount++ : failCount++;
+
+            if (onEvent) {
+              onEvent({ type: 'progress', testNumber: testCount, result: stepResult });
+            }
+          }
+        }
+
+      } catch (e: any) {
+        console.warn("Error running test:", e);
+        errorCount++;
+        const result: TestResult = {
+          test,
+          response: null as any,
+          outcome: "error"
+        };
+        testResults.push(result);
+        if (onEvent) {
+          onEvent({ type: 'progress', testNumber: testCount, result });
+        }
+      }
+    }
+
+    if (browser) {
+      await browser.close();
+    }
+
+    return {
+      results: testResults,
+      testCount,
+      passCount,
+      failCount,
+      errorCount
+    };
+  }
+
+  describe(): string {
+    return `Vercel Backend using model: ${this.modelName}`;
+  }
+}

--- a/evals-cli/src/bin/runevals.ts
+++ b/evals-cli/src/bin/runevals.ts
@@ -12,7 +12,7 @@ import { SingleBar } from "cli-progress";
 import minimist from "minimist";
 import { Config } from "../types/config.js";
 import { renderReport } from "../report/report.js";
-import { executeEvals } from "../evaluator/index.js";
+import { executeLocalEvals } from "../evaluator/index.js";
 
 dotenv.config();
 
@@ -38,6 +38,7 @@ const config: Config = {
   toolSchemaFile: args.tools,
   evalsFile: args.evals,
   backend: args.backend || "gemini",
+  provider: args.provider,
   model: args.model || "gemini-2.5-flash",
 };
 
@@ -62,8 +63,9 @@ const progressBar = new SingleBar({
 
 let passCount = 0;
 let stepCount = 0;
-const finalResults = await executeEvals(tests, tools, config, (event) => {
+const finalResults = await executeLocalEvals(tests, tools, config, (event) => {
   if (event.type === 'start') {
+    console.log(event.message);
     progressBar.start(event.total, 0, { accuracy: "0.00" });
   } else if (event.type === 'progress') {
     stepCount++;

--- a/evals-cli/src/bin/webmcpevals.ts
+++ b/evals-cli/src/bin/webmcpevals.ts
@@ -11,7 +11,7 @@ import { WebmcpConfig } from "../types/config.js";
 import { SingleBar } from "cli-progress";
 import minimist from "minimist";
 import { renderWebmcpReport } from "../report/report.js";
-import { executeInBrowserEvals, executeEvals, listToolsFromPage } from "../evaluator/index.js";
+import { executeInBrowserEvals, listToolsFromPage } from "../evaluator/index.js";
 
 dotenv.config();
 
@@ -37,7 +37,8 @@ if (args.backend && args.backend === "ollama" && !args.model) {
 const config: WebmcpConfig = {
   url: args.url,
   evalsFile: args.evals,
-  backend: args.backend || "gemini",
+  backend: args.backend || "vercel",
+  provider: args.provider || "gemini",
   model: args.model || "gemini-2.5-flash",
 };
 
@@ -56,6 +57,7 @@ let passCount = 0;
 let stepCount = 0;
 const finalResults = await executeInBrowserEvals(tests, tools, config, (event) => {
   if (event.type === 'start') {
+    console.log(event.message);
     progressBar.start(event.total, 0, { accuracy: "0.00" });
   } else if (event.type === 'progress') {
     stepCount++;

--- a/evals-cli/src/evaluator/index.ts
+++ b/evals-cli/src/evaluator/index.ts
@@ -1,24 +1,19 @@
-import { generateText, ToolLoopAgent } from "ai";
-import puppeteer, { Browser, Page } from "puppeteer-core";
+import { Config, WebmcpConfig } from "../types/config.js";
 import { Eval, TestResult, TestResults } from "../types/evals.js";
 import { Tool } from "../types/tools.js";
-import { Config, WebmcpConfig } from "../types/config.js";
-import { functionCallOutcome, findChromePath } from "../utils.js";
+import { functionCallOutcome } from "../utils.js";
 
+import { GeminiBackend } from "../backends/gemini.js";
+import { Backend, RunEvent } from "../backends/index.js";
+import { OllamaBackend } from "../backends/ollama.js";
+import { VercelBackend } from "../backends/vercel.js";
+import { listToolsFromPage } from "./browser.js";
 import { getModel } from "./models.js";
 import { SYSTEM_PROMPT } from "./prompts.js";
-import { mapMessages, mapJsonSchemaToVercelTools, mapRawBrowserToolsToConfig } from "./mappers.js";
-import { createBrowserTool, listToolsFromPage } from "./browser.js";
 
 export { listToolsFromPage };
 
-export type RunEvent =
-  | { type: 'start'; total: number }
-  | { type: 'progress'; testNumber: number; result: TestResult }
-  | { type: 'completed'; results: TestResults; reportFile?: string }
-  | { type: 'error'; message: string };
-
-export async function executeEvals(
+export async function executeLocalEvals(
   tests: Array<Eval>,
   tools: Array<Tool>,
   config: Config | WebmcpConfig,
@@ -30,37 +25,33 @@ export async function executeEvals(
     return sum + (Array.isArray(test.expectedCall) ? test.expectedCall.length : 1);
   }, 0);
 
-  if (onEvent) {
-    onEvent({ type: 'start', total: totalSteps });
-  }
-
   let testCount = 0;
   let passCount = 0;
   let failCount = 0;
   let errorCount = 0;
   const testResults: Array<TestResult> = [];
 
+  let backendImpl: Backend;
+  if (config.backend === 'gemini') {
+    const apiKey = process.env.GOOGLE_AI || process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    if (!apiKey) throw new Error("Missing Google API key");
+    backendImpl = new GeminiBackend(apiKey, config.model || "gemini-2.5-flash", SYSTEM_PROMPT, tools);
+  } else if (config.backend === 'ollama') {
+    const host = process.env.OLLAMA_HOST || "http://127.0.0.1:11434";
+    backendImpl = new OllamaBackend(host, config.model || "qwen2.5:14b", SYSTEM_PROMPT, tools);
+  } else {
+    // Vercel
+    backendImpl = new VercelBackend(config, tools);
+  }
+
+  if (onEvent) {
+    onEvent({ type: 'start', total: totalSteps, message: `Running evals using ${backendImpl.describe()}` });
+  }
   for (const test of tests) {
     testCount++;
     try {
-      const aiMessages = mapMessages(test.messages);
-      const aiResult = await generateText({
-        model,
-        system: SYSTEM_PROMPT,
-        messages: aiMessages,
-        tools: mapJsonSchemaToVercelTools(tools)
-      });
+      const response = await backendImpl.executeLocalEvals(test);
 
-      let response: any = null;
-      if (aiResult.toolCalls && aiResult.toolCalls.length > 0) {
-        const call: any = aiResult.toolCalls[0];
-        response = {
-          functionName: call.toolName,
-          args: call.input || call.args || call.arguments || {}
-        };
-      } else {
-        response = { text: aiResult.text };
-      }
       const outcome = functionCallOutcome(Array.isArray(test.expectedCall) ? test.expectedCall[0] : test.expectedCall, response);
       const result: TestResult = { test, response, outcome };
       testResults.push(result);
@@ -92,176 +83,17 @@ export async function executeEvals(
   };
 }
 
+// FIXME: This needs to be adapted in similar way to executeLocalEvals when we add support for backends other than Vercel
 export async function executeInBrowserEvals(
   tests: Array<Eval>,
   tools: Array<Tool>,
   config: WebmcpConfig,
   onEvent?: (event: RunEvent) => void
 ): Promise<TestResults> {
-  console.log("Executing in-browser evals for config:", config);
-  const executablePath = findChromePath();
-  let browser: Browser | null = null;
-  let page: Page | null = null;
-
-  try {
-    browser = await puppeteer.launch({
-      executablePath,
-      headless: true,
-      args: [
-        "--enable-features=WebMCPTesting",
-        "--no-sandbox",
-        "--disable-setuid-sandbox",
-      ],
-    });
-
-    console.log("Browser initialized for actual evals");
-  } catch (error) {
-    if (browser) await browser.close();
-    throw new Error(`Failed to initialize browser for actual evals: ${error}`);
+  if (config.backend !== 'vercel') {
+    throw new Error(`executeInBrowserEvals only supports the 'vercel' backend because it relies on the Vercel AI SDK ToolLoopAgent framework. You provided '${config.backend}'.`);
   }
 
-  const totalSteps = tests.reduce((sum, test) => {
-    return sum + (Array.isArray(test.expectedCall) ? test.expectedCall.length : 1);
-  }, 0);
-
-  if (onEvent) {
-    onEvent({ type: 'start', total: totalSteps });
-  }
-
-  let testCount = 0;
-  let passCount = 0;
-  let failCount = 0;
-  let errorCount = 0;
-  const testResults: Array<TestResult> = [];
-
-  for (const test of tests) {
-    if (page) {
-      await page.close();
-    }
-    page = await browser!.newPage();
-    await page.goto(config.url, {
-      waitUntil: "networkidle2",
-      timeout: 30000,
-    });
-
-    testCount++;
-    const expectedCalls = Array.isArray(test.expectedCall) ? test.expectedCall : [test.expectedCall];
-    let currentMessages = [...test.messages];
-    let currentTools = [...tools];
-
-    try {
-      const model = getModel(config);
-
-      const aiToolsWithExecution: Record<string, any> = {};
-      for (const t of currentTools) {
-        aiToolsWithExecution[t.functionName] = createBrowserTool(t, page!);
-      }
-
-      const agentWithExec = new ToolLoopAgent({
-        model,
-        tools: aiToolsWithExecution,
-        instructions: SYSTEM_PROMPT,
-        prepareCall: async (_opts: any): Promise<any> => {
-          // Dynamically fetch tools from the browser extension integration framework
-          const rawTools = await page!.evaluate(async () => {
-            let modelContext = null;
-            if (typeof (navigator as any).modelContext?.listTools === 'function') {
-              modelContext = (navigator as any).modelContext;
-            } else if (typeof (navigator as any).modelContextTesting?.listTools === 'function') {
-              modelContext = (navigator as any).modelContextTesting;
-            }
-            if (!modelContext) return null;
-            return await modelContext.listTools();
-          });
-
-          currentTools = mapRawBrowserToolsToConfig(rawTools, currentTools);
-
-          // We need to re-bind the execute methods to the newly loaded tools
-          const updatedAiTools: Record<string, any> = {};
-          for (const t of currentTools) {
-            updatedAiTools[t.functionName] = createBrowserTool(t, page!);
-          }
-
-          return { ..._opts, tools: updatedAiTools };
-        }
-      });
-
-      // Let the agent loop run
-      const promptMsg: any = test.messages[0];
-      const promptString = promptMsg?.content || "No prompt provided";
-      const resultPayload = await agentWithExec.generate({ prompt: promptString });
-
-      // Gather executed tool calls across all steps
-      const executedCalls: any[] = [];
-      if (resultPayload.steps && resultPayload.steps.length > 0) {
-        for (const step of resultPayload.steps) {
-          if (step.toolCalls && step.toolCalls.length > 0) {
-            for (const call of step.toolCalls) {
-              executedCalls.push({
-                functionName: call.toolName,
-                args: (call as any).input || (call as any).args || (call as any).arguments || {}
-              });
-            }
-          }
-        }
-      }
-
-      // If no tool was called at all, record a failure against the first expected call
-      if (executedCalls.length === 0) {
-        const response: any = { text: resultPayload.text };
-        const stepResult: TestResult = { test, response, outcome: "fail" };
-        testResults.push(stepResult);
-        failCount++;
-        if (onEvent) {
-          onEvent({ type: 'progress', testNumber: testCount, result: stepResult });
-        }
-      } else {
-        // Evaluate each expected call sequentially against what was executed
-        for (let i = 0; i < expectedCalls.length; i++) {
-          const currentFunctionCall = expectedCalls[i] || null;
-          const currentExecutionCall = executedCalls.length > i ? executedCalls[i] : null;
-          let response = currentExecutionCall;
-
-          if (!response) {
-            // Did not execute enough tools
-            response = { missing: "Did not execute this step" };
-          }
-
-          const outcome = functionCallOutcome(currentFunctionCall, response);
-          const stepResult: TestResult = { test: { messages: currentMessages, expectedCall: currentFunctionCall ? [currentFunctionCall] : null }, response, outcome };
-          testResults.push(stepResult);
-          outcome === "pass" ? passCount++ : failCount++;
-
-          if (onEvent) {
-            onEvent({ type: 'progress', testNumber: testCount, result: stepResult });
-          }
-        }
-      }
-
-    } catch (e: any) {
-      console.warn("Error running test:", e);
-      errorCount++;
-      const result: TestResult = {
-        test,
-        response: null as any,
-        outcome: "error"
-      };
-      testResults.push(result);
-      if (onEvent) {
-        onEvent({ type: 'progress', testNumber: testCount, result });
-      }
-    }
-  }
-
-  if (browser) {
-    await browser.close();
-  }
-
-  return {
-    results: testResults,
-    testCount,
-    passCount,
-    failCount,
-    errorCount
-  };
+  let backendImpl = new VercelBackend(config, tools);
+  return await backendImpl.executeInBrowserEvals(tests, tools, config, onEvent);
 }

--- a/evals-cli/src/evaluator/mappers.ts
+++ b/evals-cli/src/evaluator/mappers.ts
@@ -6,12 +6,17 @@ export function mapMessages(messages: any[]): any[] {
     if (m.type === 'functioncall') {
       return {
         role: 'assistant',
-        content: [{ type: 'tool-call', toolName: m.name, toolCallId: 'call-' + m.name, args: m.arguments }]
+        content: [{ type: 'tool-call', toolName: m.name, toolCallId: 'call-' + m.name, input: m.arguments }]
       };
     } else if (m.type === 'functionresponse') {
       return {
         role: 'tool',
-        content: [{ type: 'tool-result', toolName: m.name, toolCallId: 'call-' + m.name, result: m.response?.result ?? m.response }]
+        content: [{
+          type: 'tool-result',
+          toolName: m.name,
+          toolCallId: 'call-' + m.name,
+          output: { type: 'json', value: m.response?.result ?? m.response }
+        }]
       };
     } else {
       return { role: (m.role === 'model' ? 'assistant' : m.role) as any, content: m.content || '' };

--- a/evals-cli/src/evaluator/models.ts
+++ b/evals-cli/src/evaluator/models.ts
@@ -6,19 +6,19 @@ import { Config, WebmcpConfig } from "../types/config.js";
 export function getModel(config: Config | WebmcpConfig) {
   const modelId = config.model || "google:gemini-2.5-flash";
 
-  if (config.backend === "openai" || modelId.startsWith("openai:")) {
+  if (config.provider === "openai" || modelId.startsWith("openai:")) {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) console.warn("Warning: OPENAI_API_KEY is missing for OpenAI provider.");
     return createOpenAI({ apiKey })(modelId.replace("openai:", ""));
   }
 
-  if (config.backend === "anthropic" || modelId.startsWith("anthropic:")) {
+  if (config.provider === "anthropic" || modelId.startsWith("anthropic:")) {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) console.warn("Warning: ANTHROPIC_API_KEY is missing for Anthropic provider.");
     return createAnthropic({ apiKey })(modelId.replace("anthropic:", ""));
   }
 
-  if (config.backend === "ollama" || modelId.startsWith("ollama:")) {
+  if (config.provider === "ollama" || modelId.startsWith("ollama:")) {
     const ollama = createOpenAI({
       baseURL: process.env.OLLAMA_HOST || "http://127.0.0.1:11434/v1",
       apiKey: "ollama", // Required by standard but ignored by Ollama locally

--- a/evals-cli/src/server/runner.ts
+++ b/evals-cli/src/server/runner.ts
@@ -7,11 +7,11 @@ import { readFile, writeFile } from "fs/promises";
 import { Eval, TestResults } from "../types/evals.js";
 import { Tool, ToolsSchema } from "../types/tools.js";
 import { Config, WebmcpConfig } from "../types/config.js";
-import { executeInBrowserEvals, executeEvals, RunEvent, listToolsFromPage } from "../evaluator/index.js";
+import { executeInBrowserEvals, executeLocalEvals, listToolsFromPage } from "../evaluator/index.js";
 import { renderReport, renderWebmcpReport } from "../report/report.js";
 import * as dotenv from "dotenv";
+import { RunEvent } from "../backends/index.js";
 
-export { RunEvent };
 
 export async function runEvaluations(
   config: Config | WebmcpConfig,
@@ -47,7 +47,7 @@ export async function runEvaluations(
       const tests: Array<Eval> = JSON.parse(
         await readFile(config.evalsFile, "utf-8"),
       );
-      finalResults = await executeEvals(tests, tools, config, onEvent);
+      finalResults = await executeLocalEvals(tests, tools, config, onEvent);
       reportHtml = renderReport(config as Config, finalResults);
     }
 

--- a/evals-cli/src/types/config.ts
+++ b/evals-cli/src/types/config.ts
@@ -7,6 +7,7 @@ export type Config = {
   toolSchemaFile: string;
   evalsFile: string;
   backend: string;
+  provider?: string;
   model: string;
 };
 
@@ -14,5 +15,6 @@ export type WebmcpConfig = {
   url: string;
   evalsFile: string;
   backend: string;
+  provider?: string;
   model: string;
 };

--- a/evals-cli/ui/src/components/WebsitePanel.tsx
+++ b/evals-cli/ui/src/components/WebsitePanel.tsx
@@ -63,6 +63,18 @@ export function WebsitePanel({
             disabled={running}
           />
         </div>
+        <div className={`form-group ${styles.flex1}`}>
+          <label>Backend</label>
+          <select
+            value={config.backend || 'gemini'}
+            onChange={(e) => setConfig({ ...config, backend: e.target.value })}
+            disabled={running}
+          >
+            <option value="vercel">Vercel</option>
+            <option value="gemini">Gemini</option>
+            <option value="ollama">Ollama</option>
+          </select>
+        </div>
       </div>
 
       {tools.length > 0 && (

--- a/evals-cli/ui/src/index.css
+++ b/evals-cli/ui/src/index.css
@@ -97,6 +97,7 @@ p, span, div {
 }
 
 textarea,
+select,
 input[type="text"] {
   width: 100%;
   padding: 12px;
@@ -109,7 +110,14 @@ input[type="text"] {
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 
+select {
+  appearance: none;
+  padding-right: 36px;
+  cursor: pointer;
+}
+
 textarea:focus,
+select:focus,
 input[type="text"]:focus {
   outline: none;
   border-color: var(--primary-color);


### PR DESCRIPTION


- Re-Introduced a unified `Backend` interface and implemented dedicated backend handlers for gemini, ollama, and vercel, allowing for flexible local and remote model execution.

- Enhanced CLI Configuration: Updated the CLI commands (runevals and webmcpevals) and internal configuration objects to accept explicit --backend (e.g., gemini, ollama, vercel) and --provider (e.g., google, openai) flags.

- Resolved Vercel AI SDK Multi-Turn Crashes: Fixed the AI_InvalidPromptError encountered during multi-turn evaluations by updating the message mappers (`src/evaluator/mappers.ts`)

- Temp Browser Execution Guardrails: Added runtime validation to ensure `executeInBrowserEvals` strictly enforces the use of the vercel backend, as it relies heavily on the Vercel AI SDK's DOM bridging and ToolLoopAgent. 


<img width="1097" height="498" alt="image" src="https://github.com/user-attachments/assets/839a04d1-7f9a-49a1-86cc-b0c579b9e231" />

<img width="1012" height="406" alt="image" src="https://github.com/user-attachments/assets/d60f4589-2ae8-472b-9d45-506fcf7144c0" />


