### PR TITLE
Improving error messages and adding postinstall script for ui

### DIFF
--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -42,6 +42,8 @@ The project is structured as follows:
     ```bash
     npm install
     ```
+    
+    *Note: This will also automatically install dependencies for the `ui` sub-project via a `postinstall` script.*
 
 2.  **Configure Environment**
 

--- a/evals-cli/package-lock.json
+++ b/evals-cli/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "webmcp-evals-cli",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.47",

--- a/evals-cli/package.json
+++ b/evals-cli/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
+    "postinstall": "npm install --prefix ui",
     "build": "tsc",
     "test": "tsc && node --test dist/test/matcher.test.js",
     "serve": "tsc && npm run build --prefix ui && node dist/bin/serve.js"

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -102,7 +102,7 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
 
     if (rawTools === null) {
       throw new Error(
-        "The WebMCP API (window.navigator.modelContext or modelContextTesting) is not available on this page.\n" +
+        "The WebMCP API (window.navigator.modelContextTesting) is not available on this page.\n" +
           "Please ensure:\n" +
           "  1. You are using Chrome Canary version 146 or later.\n" +
           "  2. The flag chrome://flags/#enable-webmcp-testing is enabled.\n" +
@@ -113,7 +113,7 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
     if (!Array.isArray(rawTools) || rawTools.length === 0) {
       throw new Error(
         `The WebMCP API returned no tools from ${url}. ` +
-        "Ensure the page exposes tools via modelContext.listTools().",
+        "Ensure the page exposes tools via modelContextTesting.listTools().",
       );
     }
 


### PR DESCRIPTION
Updated the root `package.json` to include "postinstall": "npm install --prefix ui" + README.md file

Improved error messages to only mention currently available modelContextTesting

This PR fixes #33 and #34 