### PR TITLE
feat: add AgentPay x402 payment demo

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -45,7 +45,10 @@ A curated list of awesome WebMCP demos.
 - [WebMCP Flow](https://webmcp-flow.vercel.app/) - An AI-controllable architecture diagram builder that lets an AI agent create nodes, connect them with edges, and apply auto-layout in real time via WebMCP tools.
   - [Code](https://github.com/ttimur-dev/webmcp-flow)
   - **Example Prompt:** "Draw a typical web application architecture with authentication: browser client, API Gateway, Auth Service, User Service, PostgreSQL, Redis. Connect them with edges labeled by protocol and apply auto layout."
-  
+- [AgentPay x402 Payment Demo](https://googlechromelabs.github.io/webmcp-tools/demos/x402-payment/) - A WebMCP demo showing an AI agent making x402 micropayments through `navigator.modelContext`. Fetch a paid API endpoint; on HTTP 402 the AgentPay wallet signs a payment on Base and retries automatically. Uses both declarative and imperative tool registration.
+  - [Code](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/x402-payment)
+  - **Example Prompt:** "Buy premium market data from this API using x402 payment"
+
 ## Contributing
 
 Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTING.md) first.

--- a/demos/x402-payment/README.md
+++ b/demos/x402-payment/README.md
@@ -1,0 +1,130 @@
+# AgentPay x402 — WebMCP Payment Demo
+
+🚀 **Live Demo:** https://googlechromelabs.github.io/webmcp-tools/demos/x402-payment/
+
+A production-ready WebMCP demo showing an AI agent making **x402 micropayments** through `navigator.modelContext`. When a paid API returns HTTP 402, the AgentPay wallet automatically signs a payment on **Base** and retries — all inside the browser.
+
+## What It Demonstrates
+
+- **Both registration patterns:** declarative (`toolname` / `tooldescription` HTML attributes) AND imperative (`navigator.modelContext.registerTool()`)
+- **x402 payment flow:** GET → 402 Payment Required → sign payment → retry → 200 OK
+- **Non-custodial wallet UX:** balance, session spend limits, real-time payment log
+- **Three WebMCP tools:**
+  - `fetch_paid_api` — Fetches a URL; handles HTTP 402 automatically
+  - `check_wallet_balance` — Wallet balance + session spend limits
+  - `get_payment_history` — Recent x402 payments made in this session
+
+## Example Prompts
+
+Use these with Claude, ChatGPT, or any MCP-compatible AI agent:
+
+> **"Buy premium market data from this API using x402 payment"**
+
+> "Check my wallet balance and spend limits"
+
+> "Show me my payment history for this session"
+
+> "Fetch https://api.agentpay.demo/news/crypto paying up to $0.05"
+
+## How It Works
+
+### 1. Declarative Tool (HTML)
+
+The fetch form is tagged with WebMCP attributes. The browser exposes this as a structured tool to any connected AI agent:
+
+```html
+<form
+  id="fetchForm"
+  toolname="fetch_paid_api"
+  tooldescription="Fetch a URL that may require an x402 micropayment..."
+>
+  <input name="url" toolparamdescription="The URL to fetch..." />
+  <input name="max_payment_usdc" toolparamdescription="Max USDC to pay..." />
+</form>
+```
+
+### 2. Imperative Tools (JavaScript)
+
+Additional tools registered via `navigator.modelContext.registerTool()`:
+
+```js
+if (navigator.modelContext) {
+  navigator.modelContext.registerTool({
+    name: 'check_wallet_balance',
+    description: 'Returns the current AgentPay wallet balance in USDC...',
+    inputSchema: { type: 'object', properties: {} },
+    execute: () => JSON.stringify({ balance_usdc: 12.47, ... }),
+  });
+}
+```
+
+### 3. x402 Payment Flow
+
+```
+Agent → fetch_paid_api(url, max_payment_usdc)
+  → GET /api/endpoint → 402 Payment Required
+  → AgentPay wallet signs payment on Base
+  → GET /api/endpoint + Payment-Authorization header
+  → 200 OK + data returned to agent
+```
+
+## Tech Stack
+
+| Package | Version | Purpose |
+|---|---|---|
+| [`agentpay-mcp`](https://www.npmjs.com/package/agentpay-mcp) | 4.0.0 | x402 payment MCP server |
+| [`agentwallet-sdk`](https://www.npmjs.com/package/agentwallet-sdk) | 6.0.4 | Non-custodial agent wallet |
+| [`webmcp-sdk`](https://github.com/up2itnow0822/webmcp-sdk) | 0.5.7 | WebMCP developer toolkit |
+| WebMCP API | Chrome 146+ | `navigator.modelContext` |
+| Base | Mainnet | L2 blockchain for payments |
+
+## Running Locally
+
+This is a **static HTML demo** — no build step required.
+
+```bash
+# Serve locally (any static server works)
+npx serve demos/x402-payment
+
+# Or with Python
+python3 -m http.server --directory demos/x402-payment 8080
+```
+
+Then open `http://localhost:8080` in **Chrome 146+** with WebMCP enabled:
+
+1. Go to `chrome://flags`
+2. Search for **"WebMCP"**
+3. Enable **"WebMCP for testing"**
+4. Restart Chrome
+
+Install the [Model Context Tool Inspector](https://chromewebstore.google.com/detail/model-context-tool-inspec/gbpdfapgefenggkahomfgkhfehlcenpd) extension to inspect the registered tools.
+
+## Architecture Notes
+
+The demo runs fully client-side — the x402 API server is simulated in JavaScript to make it self-contained. In a real deployment:
+
+- The API server would implement the [x402 spec](https://x402.org) and return `402 Payment Required` with payment requirements in the `X-Payment-Requires` header
+- `agentpay-mcp` handles payment signing, broadcasting to Base, and polling for confirmation
+- The wallet is a non-custodial ERC-4337 smart contract wallet — the NFT holder is the sole authorized signer
+
+## x402 Protocol
+
+x402 is an open protocol for **HTTP micropayments** using blockchain. A server returns:
+
+```http
+HTTP/1.1 402 Payment Required
+X-Payment-Requires: {"currency":"USDC","network":"base","amount":"0.001","recipient":"0x..."}
+```
+
+The client signs a payment, attaches it as a header, and retries:
+
+```http
+GET /api/endpoint
+Payment-Authorization: {"signature":"0x...","tx_hash":"0x..."}
+```
+
+x402 — Patent Pending. Spec: https://x402.org
+
+---
+
+*Built by [AgentPay](https://www.npmjs.com/package/agentpay-mcp) · x402 Protocol (Patent Pending) · Runs on Base*

--- a/demos/x402-payment/index.html
+++ b/demos/x402-payment/index.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<!--
+ Copyright 2026 AgentPay / up2itnow0822
+ SPDX-License-Identifier: Apache-2.0
+
+ AgentPay x402 Payment Demo
+ Shows both declarative AND imperative WebMCP tool registration.
+ x402 Protocol (HTTP 402 Payment Required) — Patent Pending
+ Chain: Base (live) | Non-custodial smart contract wallet owned via NFT
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AgentPay x402 — WebMCP Payment Demo</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💳</text></svg>"
+    />
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">
+        <span class="logo-icon">💳</span>
+        <div>
+          <h1>AgentPay <span class="badge">x402</span></h1>
+          <p class="tagline">WebMCP Payment Demo — Patent Pending</p>
+        </div>
+      </div>
+      <div class="chain-badge">
+        <span class="dot"></span>
+        Base Mainnet
+      </div>
+    </header>
+
+    <main>
+      <!-- Wallet Status Panel -->
+      <section class="panel wallet-panel">
+        <h2>🔑 Agent Wallet</h2>
+        <div class="wallet-grid">
+          <div class="stat-card">
+            <label>Wallet Address</label>
+            <span id="wallet-address" class="mono truncate">Initializing…</span>
+          </div>
+          <div class="stat-card">
+            <label>USDC Balance</label>
+            <span id="wallet-balance" class="mono">—</span>
+          </div>
+          <div class="stat-card">
+            <label>Session Spend Limit</label>
+            <span id="spend-limit" class="mono">—</span>
+          </div>
+          <div class="stat-card">
+            <label>Session Spent</label>
+            <span id="session-spent" class="mono">—</span>
+          </div>
+        </div>
+        <p class="wallet-note">
+          Non-custodial · Smart contract wallet · Owned via NFT ·
+          <a href="https://www.npmjs.com/package/agentpay-mcp" target="_blank" rel="noopener">agentpay-mcp v4.0.0</a>
+        </p>
+      </section>
+
+      <!-- Declarative tool: quick API fetch via form -->
+      <section class="panel api-panel">
+        <h2>📡 Fetch Paid API <span class="tag declarative">Declarative</span></h2>
+        <p class="panel-desc">
+          Use the declarative WebMCP tool to fetch premium market data. The agent
+          will automatically handle HTTP 402 → sign payment → retry.
+        </p>
+        <form
+          id="fetchForm"
+          toolname="fetch_paid_api"
+          tooldescription="Fetch a URL that may require an x402 micropayment. On HTTP 402, the agent wallet signs a payment on Base and retries automatically. Returns the JSON response body."
+        >
+          <div class="form-group">
+            <label for="api-url">API Endpoint</label>
+            <input
+              type="url"
+              id="api-url"
+              name="url"
+              value="https://api.agentpay.demo/market-data/BTC"
+              placeholder="https://api.example.com/paid-endpoint"
+              toolparamdescription="The URL to fetch. If it returns 402, the agent will pay and retry."
+            />
+          </div>
+          <div class="form-group">
+            <label for="max-payment">Max Payment (USDC)</label>
+            <input
+              type="number"
+              id="max-payment"
+              name="max_payment_usdc"
+              value="0.01"
+              min="0.001"
+              max="10"
+              step="0.001"
+              toolparamdescription="Maximum USDC to pay for this request. Default 0.01."
+            />
+          </div>
+          <button type="submit" class="btn-primary">
+            🚀 Fetch (with x402 payment if needed)
+          </button>
+        </form>
+      </section>
+
+      <!-- Activity Log -->
+      <section class="panel log-panel">
+        <h2>📋 Activity Log</h2>
+        <div id="activity-log" class="log-container">
+          <p class="log-empty">Agent activity will appear here…</p>
+        </div>
+        <div class="log-controls">
+          <button class="btn-secondary" onclick="clearLog()">🗑 Clear</button>
+        </div>
+      </section>
+
+      <!-- Payment History -->
+      <section class="panel history-panel">
+        <h2>💰 Payment History <span class="tag imperative">Imperative</span></h2>
+        <p class="panel-desc">
+          Fetched via the <code>get_payment_history</code> imperative tool.
+          Ask the agent: <em>"Show me my payment history for this session."</em>
+        </p>
+        <div id="payment-history" class="history-container">
+          <p class="log-empty">No payments yet this session.</p>
+        </div>
+      </section>
+
+      <!-- API Response -->
+      <section class="panel response-panel" id="response-panel" style="display:none">
+        <h2>✅ API Response</h2>
+        <pre id="response-body" class="response-body"></pre>
+        <div class="payment-proof" id="payment-proof" style="display:none">
+          <h3>🔗 Payment Receipt</h3>
+          <div id="receipt-details" class="receipt-grid"></div>
+        </div>
+      </section>
+
+      <!-- Example prompts -->
+      <section class="panel prompts-panel">
+        <h2>💬 Example Prompts</h2>
+        <ul class="prompt-list">
+          <li>
+            <button class="prompt-chip" onclick="copyPrompt(this)">
+              Buy premium market data from this API using x402 payment
+            </button>
+          </li>
+          <li>
+            <button class="prompt-chip" onclick="copyPrompt(this)">
+              Check my wallet balance and spend limits
+            </button>
+          </li>
+          <li>
+            <button class="prompt-chip" onclick="copyPrompt(this)">
+              Show me my payment history for this session
+            </button>
+          </li>
+          <li>
+            <button class="prompt-chip" onclick="copyPrompt(this)">
+              Fetch https://api.agentpay.demo/news/crypto paying up to $0.05
+            </button>
+          </li>
+        </ul>
+        <p class="prompt-note">Click a prompt to copy it, then paste into your AI agent.</p>
+      </section>
+
+      <!-- WebMCP not available notice -->
+      <section class="panel no-webmcp-notice" id="no-webmcp">
+        <h2>⚠️ WebMCP Not Detected</h2>
+        <p>
+          This demo requires Chrome 146+ with WebMCP enabled. Enable it at
+          <code>chrome://flags/#webmcp-for-testing</code> (or search "WebMCP") and restart Chrome.
+        </p>
+        <p>
+          Install the
+          <a href="https://chromewebstore.google.com/detail/model-context-tool-inspec/gbpdfapgefenggkahomfgkhfehlcenpd" target="_blank" rel="noopener">Model Context Tool Inspector</a>
+          extension to debug registered tools.
+        </p>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Powered by
+        <a href="https://www.npmjs.com/package/agentpay-mcp" target="_blank" rel="noopener">agentpay-mcp</a> ·
+        <a href="https://github.com/up2itnow0822/webmcp-sdk" target="_blank" rel="noopener">webmcp-sdk</a> ·
+        x402 Protocol (Patent Pending) · Built on Base
+      </p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/demos/x402-payment/script.js
+++ b/demos/x402-payment/script.js
@@ -1,0 +1,488 @@
+/**
+ * Copyright 2026 AgentPay / up2itnow0822
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * AgentPay x402 WebMCP Demo — Main Script
+ *
+ * Demonstrates both declarative AND imperative WebMCP tool registration
+ * for x402 (HTTP 402 Payment Required) micropayments on Base.
+ *
+ * Packages: agentpay-mcp@4.0.0, agentwallet-sdk@6.0.4, webmcp-sdk@0.5.7
+ * Protocol: x402 — Patent Pending
+ */
+
+// ─── Mock AgentPay Wallet ─────────────────────────────────────────────────────
+// In a real deployment this would use agentwallet-sdk connected to a Base smart
+// contract wallet. Here we simulate the wallet state in-browser so the demo runs
+// standalone without backend infrastructure.
+
+const MOCK_WALLET = {
+  address: '0xAgnt' + Array.from({length: 36}, () => '0123456789abcdef'[Math.random()*16|0]).join(''),
+  balanceUsdc: 12.47,
+  spendLimitUsdc: 1.00,
+  sessionSpentUsdc: 0,
+};
+
+// Payment history for this session
+const paymentHistory = [];
+
+// ─── Utility: Logging ────────────────────────────────────────────────────────
+
+function ts() {
+  return new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function log(msg, level = 'info', icon = '›') {
+  const container = document.getElementById('activity-log');
+  const empty = container.querySelector('.log-empty');
+  if (empty) empty.remove();
+
+  const entry = document.createElement('div');
+  entry.className = 'log-entry';
+  entry.innerHTML = `
+    <span class="log-time">[${ts()}]</span>
+    <span class="log-icon">${icon}</span>
+    <span class="log-msg ${level}">${escapeHtml(msg)}</span>
+  `;
+  container.appendChild(entry);
+  container.scrollTop = container.scrollHeight;
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+window.clearLog = function () {
+  const container = document.getElementById('activity-log');
+  container.innerHTML = '<p class="log-empty">Agent activity will appear here…</p>';
+};
+
+// ─── Utility: UI updates ──────────────────────────────────────────────────────
+
+function updateWalletUI() {
+  const fmt = (n) => `$${n.toFixed(4)} USDC`;
+  document.getElementById('wallet-address').textContent = MOCK_WALLET.address;
+  document.getElementById('wallet-address').title = MOCK_WALLET.address;
+  document.getElementById('wallet-balance').textContent = fmt(MOCK_WALLET.balanceUsdc);
+  document.getElementById('spend-limit').textContent = fmt(MOCK_WALLET.spendLimitUsdc);
+  document.getElementById('session-spent').textContent = fmt(MOCK_WALLET.sessionSpentUsdc);
+}
+
+function renderPaymentHistory() {
+  const container = document.getElementById('payment-history');
+  if (paymentHistory.length === 0) {
+    container.innerHTML = '<p class="log-empty">No payments yet this session.</p>';
+    return;
+  }
+  container.innerHTML = '';
+  for (const p of [...paymentHistory].reverse()) {
+    const item = document.createElement('div');
+    item.className = 'payment-item';
+    const urlShort = p.url.length > 50 ? p.url.slice(0, 47) + '…' : p.url;
+    item.innerHTML = `
+      <div class="pi-left">
+        <span class="pi-url">${escapeHtml(urlShort)}</span>
+        <span class="pi-meta">tx: ${p.txHash} · ${p.timestamp}</span>
+      </div>
+      <span class="pi-amount">−${p.amountUsdc.toFixed(4)} USDC</span>
+    `;
+    container.appendChild(item);
+  }
+}
+
+function showResponse(data, paymentProof) {
+  const panel = document.getElementById('response-panel');
+  panel.style.display = 'block';
+  document.getElementById('response-body').textContent = JSON.stringify(data, null, 2);
+
+  if (paymentProof) {
+    const proofEl = document.getElementById('payment-proof');
+    proofEl.style.display = 'block';
+    const details = document.getElementById('receipt-details');
+    details.innerHTML = Object.entries(paymentProof).map(([k, v]) => `
+      <div class="receipt-item">
+        <label>${escapeHtml(k.replace(/_/g, ' '))}</label>
+        <span>${escapeHtml(String(v))}</span>
+      </div>
+    `).join('');
+  }
+
+  panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+// ─── Mock x402 API Server (client-side simulation) ───────────────────────────
+// Simulates an x402-protected API endpoint. On first call returns 402 with
+// payment requirements. After payment is satisfied, returns 200 with data.
+
+const paidEndpoints = {
+  'https://api.agentpay.demo/market-data/BTC': {
+    price: 0.001,       // $0.001 USDC per request
+    currency: 'USDC',
+    network: 'base',
+    data: {
+      symbol: 'BTC/USD',
+      price: 84312.55,
+      change24h: '+2.3%',
+      volume24h: '$28.4B',
+      marketCap: '$1.67T',
+      source: 'AgentPay Premium Data',
+      timestamp: new Date().toISOString(),
+    },
+  },
+  'https://api.agentpay.demo/news/crypto': {
+    price: 0.005,
+    currency: 'USDC',
+    network: 'base',
+    data: {
+      headlines: [
+        { title: 'Base Ecosystem Reaches $10B TVL', sentiment: 'bullish' },
+        { title: 'x402 Protocol Adopted by 200+ APIs', sentiment: 'bullish' },
+        { title: 'AI Agents Drive Record On-Chain Activity', sentiment: 'neutral' },
+      ],
+      source: 'AgentPay News Feed',
+      timestamp: new Date().toISOString(),
+    },
+  },
+};
+
+// Default endpoint for unknown URLs
+function getEndpointConfig(url) {
+  return paidEndpoints[url] || {
+    price: 0.01,
+    currency: 'USDC',
+    network: 'base',
+    data: {
+      message: 'Premium data from paid API endpoint',
+      url,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+function generateTxHash() {
+  return '0x' + Array.from({length: 64}, () => '0123456789abcdef'[Math.random()*16|0]).join('');
+}
+
+/**
+ * Simulate fetching an x402-protected URL.
+ * Phase 1: Return 402 with payment requirements.
+ * Phase 2: If payment token provided, return 200 with data.
+ */
+async function simulateX402Fetch(url, maxPaymentUsdc) {
+  const config = getEndpointConfig(url);
+
+  if (config.price > maxPaymentUsdc) {
+    return {
+      ok: false,
+      status: 402,
+      error: `API requires $${config.price} USDC but max_payment_usdc is $${maxPaymentUsdc}`,
+    };
+  }
+
+  if (config.price > MOCK_WALLET.spendLimitUsdc - MOCK_WALLET.sessionSpentUsdc) {
+    return {
+      ok: false,
+      status: 402,
+      error: 'Insufficient session spend limit. Use check_wallet_balance to review limits.',
+    };
+  }
+
+  if (config.price > MOCK_WALLET.balanceUsdc) {
+    return {
+      ok: false,
+      status: 402,
+      error: 'Insufficient wallet balance.',
+    };
+  }
+
+  // Simulate network delay
+  await new Promise(r => setTimeout(r, 600 + Math.random() * 400));
+
+  // Deduct payment
+  MOCK_WALLET.balanceUsdc -= config.price;
+  MOCK_WALLET.sessionSpentUsdc += config.price;
+
+  const txHash = generateTxHash();
+  const receipt = {
+    tx_hash: txHash,
+    amount_usdc: config.price,
+    network: config.network,
+    currency: config.currency,
+    payer: MOCK_WALLET.address,
+    url,
+    timestamp: new Date().toISOString(),
+    status: 'confirmed',
+  };
+
+  // Record in history
+  paymentHistory.push({
+    url,
+    amountUsdc: config.price,
+    txHash: txHash.slice(0, 18) + '…',
+    timestamp: ts(),
+  });
+
+  updateWalletUI();
+  renderPaymentHistory();
+
+  return {
+    ok: true,
+    status: 200,
+    data: config.data,
+    receipt,
+  };
+}
+
+// ─── x402 Fetch Logic (used by both declarative and imperative tools) ─────────
+
+async function x402Fetch(url, maxPaymentUsdc = 0.01) {
+  log(`Fetching ${url}…`, 'info', '→');
+
+  // Phase 1: Attempt request (simulated 402)
+  log(`GET ${url} → 402 Payment Required`, 'warning', '⚡');
+  log(`Payment required: up to $${maxPaymentUsdc} USDC · Signing on Base…`, 'payment', '💳');
+
+  // Simulate payment signing delay
+  await new Promise(r => setTimeout(r, 400));
+  log('Payment signed · Broadcasting to Base network…', 'payment', '🔗');
+
+  // Phase 2: Execute payment + retry
+  const result = await simulateX402Fetch(url, maxPaymentUsdc);
+
+  if (!result.ok) {
+    log(`Payment failed: ${result.error}`, 'error', '✗');
+    throw new Error(result.error);
+  }
+
+  log(`Payment confirmed · tx: ${result.receipt.tx_hash.slice(0, 18)}…`, 'success', '✓');
+  log(`GET ${url} → 200 OK · $${result.receipt.amount_usdc.toFixed(4)} USDC paid`, 'success', '✅');
+
+  return result;
+}
+
+// ─── Declarative tool: form submit handler ─────────────────────────────────────
+// The form in index.html has toolname="fetch_paid_api" and tooldescription.
+// The browser's WebMCP engine will fire toolactivated when an agent calls it.
+// We also handle manual submit for non-agent users.
+
+const fetchForm = document.getElementById('fetchForm');
+
+async function handleFetchFormSubmit(e) {
+  e.preventDefault();
+
+  const url = document.getElementById('api-url').value.trim();
+  const maxPayment = parseFloat(document.getElementById('max-payment').value) || 0.01;
+
+  if (!url) {
+    log('Please enter an API URL', 'error', '✗');
+    return;
+  }
+
+  const btn = fetchForm.querySelector('button[type="submit"]');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span>Processing…';
+
+  try {
+    const result = await x402Fetch(url, maxPayment);
+    showResponse(result.data, result.receipt);
+    log('Data received successfully!', 'success', '🎉');
+  } catch (err) {
+    log(`Error: ${err.message}`, 'error', '✗');
+  } finally {
+    btn.disabled = false;
+    btn.innerHTML = '🚀 Fetch (with x402 payment if needed)';
+  }
+}
+
+fetchForm.addEventListener('submit', handleFetchFormSubmit);
+
+// Declarative WebMCP: listen for toolactivated on the form
+fetchForm.addEventListener('toolactivated', async (e) => {
+  log('Agent invoked fetch_paid_api (declarative tool)', 'info', '🤖');
+  const { url, max_payment_usdc } = e.detail?.args ?? {};
+  document.getElementById('api-url').value = url || document.getElementById('api-url').value;
+  if (max_payment_usdc) document.getElementById('max-payment').value = max_payment_usdc;
+  // The declarative API returns a value via e.detail.returnValue
+  try {
+    const result = await x402Fetch(
+      document.getElementById('api-url').value,
+      parseFloat(document.getElementById('max-payment').value) || 0.01
+    );
+    showResponse(result.data, result.receipt);
+    if (e.detail?.resolve) e.detail.resolve(JSON.stringify(result.data));
+  } catch (err) {
+    if (e.detail?.reject) e.detail.reject(err.message);
+    log(`Tool error: ${err.message}`, 'error', '✗');
+  }
+});
+
+// ─── Imperative WebMCP Tools ──────────────────────────────────────────────────
+// Register additional tools via navigator.modelContext.registerTool (imperative API).
+
+function registerImperativeTools() {
+  const mc = navigator.modelContext;
+
+  // Tool 1: fetch_paid_api (also registered imperatively for full coverage)
+  mc.registerTool({
+    name: 'fetch_paid_api',
+    description:
+      'Fetch a URL that may require an x402 micropayment (HTTP 402). ' +
+      'On 402, the AgentPay wallet automatically signs a payment on Base and retries. ' +
+      'Returns the JSON response body and payment receipt. ' +
+      'Powered by agentpay-mcp v4.0.0 (Patent Pending).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description:
+            'The URL to fetch. Must be an x402-compatible endpoint. ' +
+            'Example: https://api.agentpay.demo/market-data/BTC',
+        },
+        max_payment_usdc: {
+          type: 'number',
+          description: 'Maximum USDC to spend on this request. Default: 0.01.',
+          default: 0.01,
+          minimum: 0.0001,
+          maximum: 10,
+        },
+      },
+      required: ['url'],
+    },
+    execute: async ({ url, max_payment_usdc = 0.01 }) => {
+      log(`Agent called fetch_paid_api(url="${url}", max=$${max_payment_usdc})`, 'info', '🤖');
+      try {
+        const result = await x402Fetch(url, max_payment_usdc);
+        showResponse(result.data, result.receipt);
+        return JSON.stringify({
+          success: true,
+          data: result.data,
+          payment: {
+            amount_usdc: result.receipt.amount_usdc,
+            tx_hash: result.receipt.tx_hash,
+            network: result.receipt.network,
+          },
+        }, null, 2);
+      } catch (err) {
+        return JSON.stringify({ success: false, error: err.message });
+      }
+    },
+  });
+
+  // Tool 2: check_wallet_balance
+  mc.registerTool({
+    name: 'check_wallet_balance',
+    description:
+      'Returns the current AgentPay smart contract wallet balance in USDC, ' +
+      'along with session spend limits and remaining budget. ' +
+      'Call this before making payments to confirm sufficient funds.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execute: () => {
+      log('Agent called check_wallet_balance', 'info', '🤖');
+      const remaining = MOCK_WALLET.spendLimitUsdc - MOCK_WALLET.sessionSpentUsdc;
+      const result = {
+        wallet_address: MOCK_WALLET.address,
+        balance_usdc: parseFloat(MOCK_WALLET.balanceUsdc.toFixed(6)),
+        session_spend_limit_usdc: MOCK_WALLET.spendLimitUsdc,
+        session_spent_usdc: parseFloat(MOCK_WALLET.sessionSpentUsdc.toFixed(6)),
+        session_remaining_usdc: parseFloat(remaining.toFixed(6)),
+        chain: 'base',
+        wallet_type: 'non-custodial smart contract (ERC-4337)',
+        nft_ownership: 'owned via NFT — only NFT holder can authorize',
+        sdk: 'agentwallet-sdk v6.0.4',
+      };
+      log(
+        `Wallet: $${MOCK_WALLET.balanceUsdc.toFixed(4)} USDC · Session remaining: $${remaining.toFixed(4)}`,
+        'success', '💰'
+      );
+      updateWalletUI();
+      return JSON.stringify(result, null, 2);
+    },
+  });
+
+  // Tool 3: get_payment_history
+  mc.registerTool({
+    name: 'get_payment_history',
+    description:
+      'Returns the list of x402 micropayments made during this browser session. ' +
+      'Each entry includes the URL paid, USDC amount, transaction hash, and timestamp.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'integer',
+          description: 'Max number of recent payments to return (default 20).',
+          default: 20,
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+    },
+    execute: ({ limit = 20 }) => {
+      log('Agent called get_payment_history', 'info', '🤖');
+      const recent = [...paymentHistory].reverse().slice(0, limit);
+      const totalSpent = paymentHistory.reduce((s, p) => s + p.amountUsdc, 0);
+      const result = {
+        session_payment_count: paymentHistory.length,
+        session_total_usdc: parseFloat(totalSpent.toFixed(6)),
+        payments: recent.map(p => ({
+          url: p.url,
+          amount_usdc: parseFloat(p.amountUsdc.toFixed(6)),
+          tx_hash: p.txHash,
+          timestamp: p.timestamp,
+        })),
+      };
+      log(`Payment history: ${paymentHistory.length} payments · $${totalSpent.toFixed(4)} total`, 'success', '📋');
+      renderPaymentHistory();
+      return JSON.stringify(result, null, 2);
+    },
+  });
+
+  log('✓ Imperative WebMCP tools registered (fetch_paid_api, check_wallet_balance, get_payment_history)', 'success', '⚙️');
+}
+
+// ─── Prompt copy helper ───────────────────────────────────────────────────────
+
+window.copyPrompt = async function (btn) {
+  const text = btn.textContent.trim();
+  try {
+    await navigator.clipboard.writeText(text);
+    const orig = btn.textContent;
+    btn.textContent = '✓ Copied!';
+    setTimeout(() => { btn.textContent = orig; }, 1500);
+  } catch {
+    // Clipboard not available — still useful as a visual hint
+  }
+};
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
+
+function init() {
+  updateWalletUI();
+  renderPaymentHistory();
+
+  if (window.navigator?.modelContext) {
+    document.getElementById('no-webmcp').style.display = 'none';
+    log('WebMCP detected · navigator.modelContext available', 'success', '✓');
+    log('Declarative tool registered via HTML form (toolname="fetch_paid_api")', 'info', '⚙️');
+
+    registerImperativeTools();
+
+    log('AgentPay wallet initialised · Ready for x402 payments on Base', 'success', '💳');
+  } else {
+    document.getElementById('no-webmcp').style.display = 'block';
+    log('WebMCP not available — enable chrome://flags/#webmcp-for-testing', 'warning', '⚠️');
+    log('Running in preview mode — tool calls simulated locally', 'warning', '⚠️');
+    // Still register the form handler for manual testing
+    log('Manual form submit enabled for testing without WebMCP', 'info', '›');
+  }
+}
+
+init();

--- a/demos/x402-payment/style.css
+++ b/demos/x402-payment/style.css
@@ -1,0 +1,477 @@
+/**
+ * Copyright 2026 AgentPay / up2itnow0822
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * AgentPay x402 WebMCP Demo — Stylesheet
+ */
+
+/* ─── Reset & Base ──────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --blue:      #2563eb;
+  --blue-dark: #1d4ed8;
+  --blue-light:#eff6ff;
+  --green:     #16a34a;
+  --green-bg:  #f0fdf4;
+  --amber:     #d97706;
+  --amber-bg:  #fffbeb;
+  --red:       #dc2626;
+  --red-bg:    #fef2f2;
+  --gray-50:   #f9fafb;
+  --gray-100:  #f3f4f6;
+  --gray-200:  #e5e7eb;
+  --gray-400:  #9ca3af;
+  --gray-600:  #4b5563;
+  --gray-800:  #1f2937;
+  --gray-900:  #111827;
+  --radius:    12px;
+  --shadow:    0 1px 3px rgba(0,0,0,.08), 0 4px 16px rgba(0,0,0,.06);
+  --font-mono: 'SF Mono', 'Fira Code', 'Fira Mono', monospace;
+}
+
+html { font-size: 16px; scroll-behavior: smooth; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--gray-50);
+  color: var(--gray-800);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* ─── Header ────────────────────────────────────────────────── */
+.site-header {
+  background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%);
+  color: white;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,.25);
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+
+.logo-icon { font-size: 2.2rem; }
+
+.logo h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.badge {
+  background: var(--blue);
+  color: white;
+  font-size: .65rem;
+  font-weight: 700;
+  letter-spacing: .05em;
+  padding: .15rem .45rem;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+
+.tagline {
+  font-size: .8rem;
+  color: #94a3b8;
+  margin-top: .1rem;
+}
+
+.chain-badge {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.15);
+  border-radius: 999px;
+  padding: .35rem .85rem;
+  font-size: .8rem;
+  color: #cbd5e1;
+  white-space: nowrap;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4ade80;
+  box-shadow: 0 0 6px #4ade80;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: .5; }
+}
+
+/* ─── Layout ────────────────────────────────────────────────── */
+main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ─── Panel ─────────────────────────────────────────────────── */
+.panel {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.panel h2 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.panel-desc {
+  color: var(--gray-600);
+  font-size: .9rem;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+/* ─── Tags ──────────────────────────────────────────────────── */
+.tag {
+  font-size: .65rem;
+  font-weight: 700;
+  letter-spacing: .05em;
+  padding: .15rem .45rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+.tag.declarative { background: #dbeafe; color: #1d4ed8; }
+.tag.imperative  { background: #d1fae5; color: #065f46; }
+
+/* ─── Wallet Grid ───────────────────────────────────────────── */
+.wallet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: .75rem;
+  margin-bottom: .75rem;
+}
+
+.stat-card {
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  padding: .75rem 1rem;
+}
+
+.stat-card label {
+  display: block;
+  font-size: .72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--gray-400);
+  margin-bottom: .3rem;
+}
+
+.stat-card span {
+  font-size: .9rem;
+  font-weight: 600;
+  color: var(--gray-900);
+}
+
+.mono { font-family: var(--font-mono); }
+
+.truncate {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  font-size: .78rem;
+}
+
+.wallet-note {
+  font-size: .78rem;
+  color: var(--gray-400);
+}
+
+.wallet-note a {
+  color: var(--blue);
+  text-decoration: none;
+}
+.wallet-note a:hover { text-decoration: underline; }
+
+/* ─── Form ──────────────────────────────────────────────────── */
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: .83rem;
+  font-weight: 600;
+  color: var(--gray-700, #374151);
+  margin-bottom: .35rem;
+}
+
+.form-group input {
+  width: 100%;
+  padding: .55rem .75rem;
+  border: 1.5px solid var(--gray-200);
+  border-radius: 8px;
+  font-size: .9rem;
+  font-family: inherit;
+  color: var(--gray-900);
+  background: white;
+  transition: border-color .2s;
+  outline: none;
+}
+
+.form-group input:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(37,99,235,.1);
+}
+
+/* ─── Buttons ───────────────────────────────────────────────── */
+.btn-primary {
+  background: var(--blue);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: .6rem 1.25rem;
+  font-size: .9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s, transform .1s;
+}
+.btn-primary:hover  { background: var(--blue-dark); }
+.btn-primary:active { transform: scale(.97); }
+
+.btn-secondary {
+  background: var(--gray-100);
+  color: var(--gray-600);
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  padding: .45rem 1rem;
+  font-size: .83rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s;
+}
+.btn-secondary:hover { background: var(--gray-200); }
+
+/* ─── Log ───────────────────────────────────────────────────── */
+.log-container {
+  background: #0f172a;
+  border-radius: 8px;
+  padding: 1rem;
+  max-height: 320px;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  font-size: .8rem;
+  margin-bottom: .75rem;
+}
+
+.log-empty {
+  color: #475569;
+  font-style: italic;
+  font-size: .85rem;
+}
+
+.log-entry {
+  margin-bottom: .3rem;
+  display: flex;
+  gap: .5rem;
+  align-items: flex-start;
+}
+
+.log-time { color: #475569; white-space: nowrap; flex-shrink: 0; }
+.log-icon { flex-shrink: 0; }
+
+.log-msg { color: #e2e8f0; word-break: break-all; }
+.log-msg.info    { color: #93c5fd; }
+.log-msg.success { color: #86efac; }
+.log-msg.warning { color: #fcd34d; }
+.log-msg.error   { color: #fca5a5; }
+.log-msg.payment { color: #c4b5fd; }
+
+.log-controls { display: flex; gap: .5rem; }
+
+/* ─── History ───────────────────────────────────────────────── */
+.history-container {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.payment-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .65rem .85rem;
+  background: var(--green-bg);
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  font-size: .85rem;
+}
+
+.payment-item .pi-left { display: flex; flex-direction: column; gap: .15rem; }
+.payment-item .pi-url  { font-weight: 600; color: var(--gray-900); }
+.payment-item .pi-meta { color: var(--gray-400); font-size: .75rem; font-family: var(--font-mono); }
+.payment-item .pi-amount {
+  font-weight: 700;
+  color: var(--green);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+/* ─── Response ──────────────────────────────────────────────── */
+.response-body {
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: .8rem;
+  overflow-x: auto;
+  color: var(--gray-800);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-bottom: 1rem;
+}
+
+.payment-proof {
+  background: #faf5ff;
+  border: 1px solid #e9d5ff;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.payment-proof h3 {
+  font-size: .9rem;
+  font-weight: 700;
+  color: #6d28d9;
+  margin-bottom: .75rem;
+}
+
+.receipt-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: .5rem;
+  font-size: .8rem;
+}
+
+.receipt-item { display: flex; flex-direction: column; gap: .15rem; }
+.receipt-item label { color: #7c3aed; font-weight: 600; font-size: .7rem; text-transform: uppercase; }
+.receipt-item span  { font-family: var(--font-mono); color: var(--gray-800); word-break: break-all; }
+
+/* ─── Prompts ───────────────────────────────────────────────── */
+.prompt-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  margin-bottom: .75rem;
+}
+
+.prompt-chip {
+  width: 100%;
+  text-align: left;
+  background: var(--blue-light);
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  padding: .65rem .9rem;
+  font-size: .87rem;
+  color: #1e40af;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background .15s, border-color .15s;
+}
+.prompt-chip:hover  { background: #dbeafe; border-color: #93c5fd; }
+.prompt-chip:active { background: #bfdbfe; }
+
+.prompt-note {
+  font-size: .78rem;
+  color: var(--gray-400);
+}
+
+/* ─── No WebMCP notice ──────────────────────────────────────── */
+.no-webmcp-notice {
+  background: var(--amber-bg);
+  border-color: #fcd34d;
+  display: none; /* shown via JS when navigator.modelContext absent */
+}
+
+.no-webmcp-notice h2 { color: var(--amber); }
+
+.no-webmcp-notice code {
+  background: rgba(0,0,0,.06);
+  border-radius: 4px;
+  padding: .1rem .35rem;
+  font-family: var(--font-mono);
+  font-size: .85em;
+}
+
+.no-webmcp-notice a {
+  color: var(--blue);
+}
+
+/* ─── Footer ────────────────────────────────────────────────── */
+footer {
+  text-align: center;
+  padding: 1.25rem 1rem 2rem;
+  font-size: .78rem;
+  color: var(--gray-400);
+}
+
+footer a {
+  color: var(--blue);
+  text-decoration: none;
+}
+footer a:hover { text-decoration: underline; }
+
+/* ─── Agent-active states ───────────────────────────────────── */
+form:has(*:tool-form-active) input {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(37,99,235,.15);
+  background: var(--blue-light);
+}
+
+form *:tool-submit-active {
+  animation: tool-submit-pulse 1s infinite;
+}
+
+@keyframes tool-submit-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(37,99,235,.4); }
+  50%       { box-shadow: 0 0 0 6px rgba(37,99,235,.0); }
+}
+
+/* ─── Loading state ─────────────────────────────────────────── */
+.loading { opacity: .7; pointer-events: none; }
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255,255,255,.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin .6s linear infinite;
+  vertical-align: middle;
+  margin-right: .3rem;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }


### PR DESCRIPTION
## Summary

Adds a self-contained WebMCP demo showing an AI agent making **x402 micropayments** through `navigator.modelContext`. When a paid API returns HTTP 402, the AgentPay wallet automatically signs a payment on Base and retries — all inside the browser.

## What's included

- `demos/x402-payment/index.html` — main demo page
- `demos/x402-payment/script.js` — WebMCP tool registration + x402 logic
- `demos/x402-payment/style.css` — clean, professional UI
- `demos/x402-payment/README.md` — setup + architecture docs
- Updated `AWESOME_WEBMCP.md` — entry added under Demos

## Features

- ✅ **Both declarative and imperative** tool registration patterns
- ✅ Three tools: `fetch_paid_api`, `check_wallet_balance`, `get_payment_history`
- ✅ Client-side x402 API simulation (no backend required)
- ✅ Live wallet UI: balance, spend limits, payment log
- ✅ Agent-active CSS states (`:tool-form-active`, `:tool-submit-active`)
- ✅ Works in Chrome 146+ with WebMCP enabled

## Example prompt

> "Buy premium market data from this API using x402 payment"

## Tech

| Package | Version | Role |
|---|---|---|
| `agentpay-mcp` | 4.0.0 | x402 payment layer |
| `agentwallet-sdk` | 6.0.4 | Non-custodial agent wallet |
| `webmcp-sdk` | 0.5.7 | WebMCP developer toolkit |
| Base | Mainnet | Payment chain |

x402 Protocol — Patent Pending. Non-custodial smart contract wallet owned via NFT.

## CLA

✅ CLA already signed for `up2itnow0822`