### PR TITLE
Fixing linkability for our demos

### DIFF
--- a/demos/hotel-chain/src/App.tsx
+++ b/demos/hotel-chain/src/App.tsx
@@ -3,43 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import Home from './pages/Home';
 import SearchResults from './pages/SearchResults';
 import HotelDetails from './pages/HotelDetails';
 import Booking from './pages/Booking';
 
-const getBasename = () => {
-  const path = window.location.pathname;
-  
-  // We use trailing slashes for ID-based routes to avoid prefix conflicts
-  const deepRoutes = ['/search', '/hotel/', '/book/'];
-  for (const route of deepRoutes) {
-    const index = path.indexOf(route);
-    if (index !== -1) {
-      return path.slice(0, index);
-    }
-  }
 
-  if (path.length > 1 && path.endsWith("/")) {
-    return path.slice(0, -1);
-  }
-  return path;
-};
 
 function App() {
   return (
-    <BrowserRouter basename={getBasename()}>
+    <HashRouter>
       <Routes>
         <Route path="/" element={<Layout />}>
-            <Route index element={<Home />} />
-            <Route path="search" element={<SearchResults />} />
-            <Route path="hotel/:id" element={<HotelDetails />} />
+          <Route index element={<Home />} />
+          <Route path="search" element={<SearchResults />} />
+          <Route path="hotel/:id" element={<HotelDetails />} />
           <Route path="book/:id" element={<Booking />} />
         </Route>
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   );
 }
 

--- a/demos/react-flightsearch/src/App.tsx
+++ b/demos/react-flightsearch/src/App.tsx
@@ -5,7 +5,7 @@
 
 import { useMemo } from "react";
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Routes,
   Route,
   useSearchParams,
@@ -83,26 +83,11 @@ function AppContent() {
   );
 }
 
-const getBasename = () => {
-  const path = window.location.pathname;
-  // Check if the path ends with a known deep route.
-  if (path.endsWith("/results")) {
-    // If so, the basename is the part of the path before that route.
-    const basename = path.slice(0, -"/results".length);
-    // If the basename is empty, it means we are at the root.
-    return basename || "/";
-  }
-  // Otherwise, the path itself is the basename. We need to remove any trailing slash
-  // unless it's the root path itself.
-  if (path.length > 1 && path.endsWith("/")) {
-    return path.slice(0, -1);
-  }
-  return path;
-};
+
 
 export default function App() {
   return (
-    <Router basename={getBasename()}>
+    <Router>
       <AppContent />
     </Router>
   );

--- a/demos/sport-shop-angular/src/app/app.config.ts
+++ b/demos/sport-shop-angular/src/app/app.config.ts
@@ -4,13 +4,13 @@
  */
 
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withHashLocation } from '@angular/router';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes)
+    provideRouter(routes, withHashLocation())
   ]
 };


### PR DESCRIPTION
Switched React and Angular demos to use **Hash Routing** to fix deep link breakages when hosted on GitHub Pages (which does not natively support SPA fallback to `index.html`).

#### React Demos
-   **`hotel-chain`** & **`react-flightsearch`**:
    -   Replaced `BrowserRouter` with `HashRouter`.
    -   Removed complex `basename` auto-detection logic, as hash routing is relative to the `index.html` location and does not require path guessing.

#### Angular Demo
-   **`sport-shop-angular`**:
    -   Enabled hash location strategy by updating `provideRouter` with `withHashLocation()`.

This standardizes all routing demos to work out-of-the-box on static hosting environments like GitHub Pages.