### PR TITLE
fix(maze): fix player trail animation drifting during movement

### DIFF
--- a/demos/webmcp-maze/src/rendering/PlayerView.ts
+++ b/demos/webmcp-maze/src/rendering/PlayerView.ts
@@ -158,8 +158,9 @@ export class PlayerView {
       this.animating = false;
       this.resolveAnim?.();
       this.resolveAnim = null;
-      this.redrawTrail();
     }
+
+    this.redrawTrail();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Trail dots were stored in stage-space coordinates but drawn relative to the player container
- `redrawTrail()` was only called when animation ended, so during movement the trail dots drifted in the player's direction instead of staying at their previous positions
- Fix: call `redrawTrail()` every tick so the stage→local coordinate conversion is updated each frame