### PR TITLE
fix(react-flightsearch): switch from HashRouter to BrowserRouter

### DIFF
--- a/demos/react-flightsearch/src/App.tsx
+++ b/demos/react-flightsearch/src/App.tsx
@@ -5,7 +5,7 @@
 
 import { useMemo } from "react";
 import {
-  HashRouter as Router,
+  BrowserRouter as Router,
   Routes,
   Route,
   useSearchParams,


### PR DESCRIPTION
Replaces `HashRouter` with `BrowserRouter` in the react-flightsearch demo so URLs use clean query parameters (`/results?origin=...`) instead of hash-based routing (`/#/results?origin=...`).