### PR TITLE
fix: make return flight properties optional in Flight interface

### DIFF
--- a/demos/react-flightsearch/src/data/flights.ts
+++ b/demos/react-flightsearch/src/data/flights.ts
@@ -13,10 +13,10 @@ export interface Flight {
   arrivalTime: string;
   duration: string;
   stops: number;
-  returnDepartureTime: string;
-  returnArrivalTime: string;
-  returnDuration: string;
-  returnStops: number;
+  returnDepartureTime?: string;
+  returnArrivalTime?: string;
+  returnDuration?: string;
+  returnStops?: number;
   price: number;
 }
 


### PR DESCRIPTION
This PR fixes the build error in the react-flightsearch demo. The data in `src/data/flights.ts` does not include return flight properties, but the `Flight` interface required them. Making them optional resolves the build failure.