### PR TITLE
fix: topping button when WebMCP is not enabled

### DIFF
--- a/demos/pizza-maker/index.html
+++ b/demos/pizza-maker/index.html
@@ -46,16 +46,16 @@
         <button class="btn-add" onclick="toggleLayer('cheese-layer')">🧀 Cheese</button>
       </div>
       <div class="btn-group">
-        <button class="btn-add" onclick="addTopping('🍕')">Pepperoni</button>
-        <button class="btn-add" onclick="addTopping('🍄')">Mushrooms</button>
-        <button class="btn-add" onclick="addTopping('🌿')">Basil</button>
-        <button class="btn-add" onclick="addTopping('🍍')">Pineapple</button>
-        <button class="btn-add" onclick="addTopping('🫑')">Peppers</button>
-        <button class="btn-add" onclick="addTopping('🥓')">Bacon</button>
-        <button class="btn-add" onclick="addTopping('🧅')">Onion</button>
-        <button class="btn-add" onclick="addTopping('🫒')">Olive</button>
-        <button class="btn-add" onclick="addTopping('🌽')">Corn</button>
-        <button class="btn-add" onclick="addTopping('🌶️')">Hot Pepper</button>
+        <button class="btn-add" onclick="addTopping('🍕', document.getElementById('size-text'), 1)">Pepperoni</button>
+        <button class="btn-add" onclick="addTopping('🍄', document.getElementById('size-text'), 1)">Mushrooms</button>
+        <button class="btn-add" onclick="addTopping('🌿', document.getElementById('size-text'), 1)">Basil</button>
+        <button class="btn-add" onclick="addTopping('🍍', document.getElementById('size-text'), 1)">Pineapple</button>
+        <button class="btn-add" onclick="addTopping('🫑', document.getElementById('size-text'), 1)">Peppers</button>
+        <button class="btn-add" onclick="addTopping('🥓', document.getElementById('size-text'), 1)">Bacon</button>
+        <button class="btn-add" onclick="addTopping('🧅', document.getElementById('size-text'), 1)">Onion</button>
+        <button class="btn-add" onclick="addTopping('🫒', document.getElementById('size-text'), 1)">Olive</button>
+        <button class="btn-add" onclick="addTopping('🌽', document.getElementById('size-text'), 1)">Corn</button>
+        <button class="btn-add" onclick="addTopping('🌶️', document.getElementById('size-text'), 1)">Hot Pepper</button>
       </div>
       <div class="btn-group">
         <button class="btn-remove" onclick="removeLastTopping()">⬅️ Remove Last</button>


### PR DESCRIPTION
Update the topping buttons to call the right signature of `addToppings` when WebMCP is not enabled.