### PR TITLE
Remove unregisterTool calls

### DIFF
--- a/demos/doors/magic.html
+++ b/demos/doors/magic.html
@@ -36,7 +36,6 @@
             document.body.style.background = "#fff";
             document.getElementById('status').innerText = "The owl blinks at the sudden light!";
 
-            navigator.modelContext.unregisterTool?.('castLight');
             controller.abort();
             document.querySelector('button').setAttribute('disabled', '');
 

--- a/demos/hotel-chain/src/hooks/useWebMCP.ts
+++ b/demos/hotel-chain/src/hooks/useWebMCP.ts
@@ -37,14 +37,7 @@ export function useWebMCP(tools: WebMCPTool[]) {
     });
 
     return () => {
-      registeredTools.current.forEach(name => {
-        try {
-          modelContext.unregisterTool?.(name);
-          controller.abort();
-        } catch (error) {
-          console.error(`Failed to unregister WebMCP tool "${name}":`, error);
-        }
-      });
+      controller.abort();
       registeredTools.current.clear();
     };
   }, [tools]);

--- a/demos/react-flightsearch/src/webmcp.ts
+++ b/demos/react-flightsearch/src/webmcp.ts
@@ -318,13 +318,9 @@ export function registerFlightSearchTools() {
 }
 
 export function unregisterFlightSearchTools() {
-  const modelContext = window.navigator.modelContext;
-  if (modelContext) {
-    modelContext.unregisterTool?.(searchFlightsTool.name);
-    if (registeredTools.searchTools) {
-      registeredTools.searchTools.abort();
-      registeredTools.searchTools = null;
-    }
+  if (registeredTools.searchTools) {
+    registeredTools.searchTools.abort();
+    registeredTools.searchTools = null;
   }
 }
 
@@ -344,16 +340,8 @@ export function registerFlightResultsTools() {
 }
 
 export function unregisterFlightResultsTools() {
-  const modelContext = window.navigator.modelContext;
-  if (modelContext) {
-    modelContext.unregisterTool?.(listFlightsTool.name);
-    modelContext.unregisterTool?.(setFiltersTool.name);
-    modelContext.unregisterTool?.(resetFiltersTool.name);
-    modelContext.unregisterTool?.(searchFlightsTool.name);
-
-    if (registeredTools.resultsTools) {
-      registeredTools.resultsTools.abort();
-      registeredTools.resultsTools = null;
-    }
+  if (registeredTools.resultsTools) {
+    registeredTools.resultsTools.abort();
+    registeredTools.resultsTools = null;
   }
 }

--- a/demos/shared/types/webmcp.d.ts
+++ b/demos/shared/types/webmcp.d.ts
@@ -54,9 +54,6 @@ declare global {
   interface ModelContext {
     /** Adds a single tool to the current context. */
     registerTool(tool: ModelContextTool, options?: { signal?: AbortSignal }): void;
-
-    /** Removes a tool by name. (Deprecated) */
-    unregisterTool?(name: string): void;
   }
 
   interface Navigator {

--- a/demos/sport-shop-angular/src/app/components/cart-modal/cart-modal.component.ts
+++ b/demos/sport-shop-angular/src/app/components/cart-modal/cart-modal.component.ts
@@ -106,13 +106,7 @@ export class CartModalComponent implements OnInit, OnDestroy {
   }
 
   private unregisterCartTools() {
-    const modelContext = navigator.modelContext;
-    if (modelContext) {
-      modelContext.unregisterTool?.("remove_from_cart");
-      modelContext.unregisterTool?.("start_checkout");
-      modelContext.unregisterTool?.("confirm_order");
-      this.cartToolController?.abort();
-    }
+    this.cartToolController?.abort();
   }
 
   onClose() {

--- a/demos/sport-shop-angular/src/app/pages/search/search.component.ts
+++ b/demos/sport-shop-angular/src/app/pages/search/search.component.ts
@@ -132,12 +132,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   }
 
   private unregisterSearchTools() {
-    const modelContext = navigator.modelContext;
-    if (modelContext) {
-      modelContext.unregisterTool?.("refine_search");
-      modelContext.unregisterTool?.("add_search_result_to_cart");
-      this.searchToolController?.abort();
-    }
+    this.searchToolController?.abort();
   }
 
 

--- a/demos/webmcp-maze/src/webmcp/ToolRegistry.ts
+++ b/demos/webmcp-maze/src/webmcp/ToolRegistry.ts
@@ -102,9 +102,6 @@ export class ToolRegistry {
   private provideTools(tools: ModelContextTool[]): void {
     if (this.supported) {
       const ctx = navigator.modelContext!;
-      for (const name of this.toolMap.keys()) {
-        ctx.unregisterTool?.(name);
-      }
       this.toolController?.abort();
       this.toolController = new AbortController();
       for (const tool of tools) {


### PR DESCRIPTION
Now that AbortSignal has reached Chrome Stable channel, we can remove unregisterTool calls.

See https://chromiumdash.appspot.com/commit/71866d873bb9e87303f9009a188d429027fdd7a2