### PR TITLE
Use navigator.modelContext getTools when available

### DIFF
--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -189,13 +189,12 @@ export class VercelBackend implements Backend {
               try {
                 rawTools = await page!.evaluate(async () => {
                   const nav = navigator as any;
-                  let mct = null;
-                  if (typeof nav.modelContext?.listTools === "function") {
-                    mct = nav.modelContext;
+                  if (typeof nav.modelContext?.getTools === "function") {
+                    return await nav.modelContext.getTools();
                   } else if (typeof nav.modelContextTesting?.listTools === "function") {
-                    mct = nav.modelContextTesting;
+                    return nav.modelContextTesting.listTools();
                   }
-                  return mct ? mct.listTools() : [];
+                  return [];
                 });
               } catch (err: any) {
                 console.error("[vercel.ts] Failed to fetch tools via evaluate:", err.message);

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -137,17 +137,14 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
     }
 
     const rawTools = await page.evaluate(async () => {
-      let modelContext = null;
-      if (typeof (navigator as any).modelContext?.listTools === "function") {
-        modelContext = (navigator as any).modelContext;
-      } else if (typeof (navigator as any).modelContextTesting?.listTools === "function") {
-        modelContext = (navigator as any).modelContextTesting;
+      const nav = navigator as any;
+      if (typeof nav.modelContext?.getTools === "function") {
+        return await nav.modelContext.getTools();
       }
-
-      if (!modelContext) {
-        return null;
+      if (typeof nav.modelContextTesting?.listTools === "function") {
+        return nav.modelContextTesting.listTools();
       }
-      return await modelContext.listTools();
+      return null;
     });
 
     if (rawTools === null) {


### PR DESCRIPTION
Following https://chromium-review.googlesource.com/c/chromium/src/+/7800264, this PR adds support for navigator.modelContext getTools() when available