### PR TITLE
Fixing hotel search logic

### DIFF
--- a/demos/hotel-chain/src/pages/Booking.tsx
+++ b/demos/hotel-chain/src/pages/Booking.tsx
@@ -14,7 +14,7 @@ export default function Booking() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
 
-  const hotel = hotels.find(h => h.id === id) || hotels[0];
+  const hotel = hotels.find(h => h.id === id || h.id.toLowerCase() === id?.toLowerCase() || h.name.toLowerCase() === id?.toLowerCase()) || hotels[0];
   const [success, setSuccess] = useState(false);
   const [formData, setFormData] = useState({
     firstName: 'Jane',

--- a/demos/hotel-chain/src/pages/HotelDetails.tsx
+++ b/demos/hotel-chain/src/pages/HotelDetails.tsx
@@ -16,7 +16,7 @@ export default function HotelDetails() {
   const location = useLocation();
   const { id } = useParams<{ id: string }>();
 
-  const hotel = hotels.find(h => h.id === id) || hotels[0];
+  const hotel = hotels.find(h => h.id === id || h.id.toLowerCase() === id?.toLowerCase() || h.name.toLowerCase() === id?.toLowerCase()) || hotels[0];
 
   const policiesRef = useRef<HTMLDivElement>(null);
   const [isHighlighted, setIsHighlighted] = useState(false);


### PR DESCRIPTION
fixed the bug where query parameters or route parameters using the full hotel name or a capitalized format (e.g. Montmartre Suites vs montmartre) would fail to match the hotel, falling back to The Aurelian Shibuya (the first item).