### PR TITLE
Use Puppeteer instead of modelContextTesting Web API

### DIFF
--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -80,12 +80,12 @@ With Ollama:
 node dist/bin/runevals.js --model=qwen3:8b --backend=ollama --tools=examples/travel/schema.json --evals=examples/travel/evals.json
 ```
 
-| Argument     | Required | Default            | Description                                                              |
-| ------------ | -------- | ------------------ | ------------------------------------------------------------------------ |
-| `--tools`    | Yes      | —                  | Path to the tool schema JSON file                                        |
-| `--evals`    | Yes      | —                  | Path to the evals JSON file                                              |
-| `--backend`  | No       | `gemini`           | Execution backend (`gemini`, `ollama`, or `vercel`)                      |
-| `--provider` | No       | `google`           | Model provider (e.g., `openai`, `anthropic`, `google`) if using `vercel` |
+| Argument     | Required | Default                  | Description                                                              |
+| ------------ | -------- | ------------------------ | ------------------------------------------------------------------------ |
+| `--tools`    | Yes      | —                        | Path to the tool schema JSON file                                        |
+| `--evals`    | Yes      | —                        | Path to the evals JSON file                                              |
+| `--backend`  | No       | `gemini`                 | Execution backend (`gemini`, `ollama`, or `vercel`)                      |
+| `--provider` | No       | `google`                 | Model provider (e.g., `openai`, `anthropic`, `google`) if using `vercel` |
 | `--model`    | No       | `gemini-3-flash-preview` | Model name                                                               |
 
 ### `webmcpevals` — live tool schemas via WebMCP

--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -33,7 +33,7 @@ The project is structured as follows:
 
 - Node.js (v18+ recommended)
 - Appropriate API Keys (Google GenAI, OpenAI, or Anthropic, depending on the backend used)
-- Chrome 150+ with the `#enable-webmcp-testing` flag enabled (for `webmcpevals` only)
+- Chrome Canary 150+ with the `#enable-webmcp-testing` flag enabled (for `webmcpevals` only)
 
 ## Setup
 
@@ -90,7 +90,7 @@ node dist/bin/runevals.js --model=qwen3:8b --backend=ollama --tools=examples/tra
 
 ### `webmcpevals` — live tool schemas via WebMCP
 
-Launches Chrome, navigates to the given URL, and retrieves tool schemas live from the page via Puppeteer. Requires Chrome 150+.
+Launches Chrome Canary, navigates to the given URL, and retrieves tool schemas live from the page via Puppeteer. Requires Chrome Canary 150+ with the `chrome://flags/#enable-webmcp-testing` flag enabled.
 
 ```bash
 node dist/bin/webmcpevals.js --url=https://example.com/my-webmcp-app --evals=examples/travel/evals.json

--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -33,7 +33,7 @@ The project is structured as follows:
 
 - Node.js (v18+ recommended)
 - Appropriate API Keys (Google GenAI, OpenAI, or Anthropic, depending on the backend used)
-- Chrome 149+ with the `#enable-webmcp-testing` flag enabled (for `webmcpevals` only)
+- Chrome 150+ with the `#enable-webmcp-testing` flag enabled (for `webmcpevals` only)
 
 ## Setup
 
@@ -90,7 +90,7 @@ node dist/bin/runevals.js --model=qwen3:8b --backend=ollama --tools=examples/tra
 
 ### `webmcpevals` — live tool schemas via WebMCP
 
-Launches Chrome, navigates to the given URL, and retrieves tool schemas live from the page via Puppeteer. Requires Chrome 149+.
+Launches Chrome, navigates to the given URL, and retrieves tool schemas live from the page via Puppeteer. Requires Chrome 150+.
 
 ```bash
 node dist/bin/webmcpevals.js --url=https://example.com/my-webmcp-app --evals=examples/travel/evals.json

--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -33,7 +33,7 @@ The project is structured as follows:
 
 - Node.js (v18+ recommended)
 - Appropriate API Keys (Google GenAI, OpenAI, or Anthropic, depending on the backend used)
-- Chrome Canary 146+ with the `#enable-webmcp-testing` flag enabled (for `webmcpevals` only)
+- Chrome 149+ with the `#enable-webmcp-testing` flag enabled (for `webmcpevals` only)
 
 ## Setup
 
@@ -86,11 +86,11 @@ node dist/bin/runevals.js --model=qwen3:8b --backend=ollama --tools=examples/tra
 | `--evals`    | Yes      | —                  | Path to the evals JSON file                                              |
 | `--backend`  | No       | `gemini`           | Execution backend (`gemini`, `ollama`, or `vercel`)                      |
 | `--provider` | No       | `google`           | Model provider (e.g., `openai`, `anthropic`, `google`) if using `vercel` |
-| `--model`    | No       | `gemini-2.5-flash` | Model name                                                               |
+| `--model`    | No       | `gemini-3-flash-preview` | Model name                                                               |
 
 ### `webmcpevals` — live tool schemas via WebMCP
 
-Launches Chrome Canary, navigates to the given URL, and retrieves tool schemas live from the page via `navigator.modelContextTesting.listTools()`. Requires Chrome Canary 146+ with the `chrome://flags/#enable-webmcp-testing` flag enabled.
+Launches Chrome, navigates to the given URL, and retrieves tool schemas live from the page via Puppeteer. Requires Chrome 149+.
 
 ```bash
 node dist/bin/webmcpevals.js --url=https://example.com/my-webmcp-app --evals=examples/travel/evals.json
@@ -102,7 +102,7 @@ node dist/bin/webmcpevals.js --url=https://example.com/my-webmcp-app --evals=exa
 | `--evals`    | Yes      | —                  | Path to the evals JSON file                                         |
 | `--backend`  | No       | `vercel`           | Must be `vercel` (live browser evaluation requires `ToolLoopAgent`) |
 | `--provider` | No       | `gemini`           | Model provider to use with Vercel (e.g., `openai`, `anthropic`)     |
-| `--model`    | No       | `gemini-2.5-flash` | Model name                                                          |
+| `--model`    | No       | `gemini-3-flash-preview` | Model name                                                          |
 
 ### `serve` — WebMCP Evals UI sidecar
 

--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -96,12 +96,12 @@ Launches Chrome Canary, navigates to the given URL, and retrieves tool schemas l
 node dist/bin/webmcpevals.js --url=https://example.com/my-webmcp-app --evals=examples/travel/evals.json
 ```
 
-| Argument     | Required | Default            | Description                                                         |
-| ------------ | -------- | ------------------ | ------------------------------------------------------------------- |
-| `--url`      | Yes      | —                  | URL of the page exposing WebMCP tools                               |
-| `--evals`    | Yes      | —                  | Path to the evals JSON file                                         |
-| `--backend`  | No       | `vercel`           | Must be `vercel` (live browser evaluation requires `ToolLoopAgent`) |
-| `--provider` | No       | `gemini`           | Model provider to use with Vercel (e.g., `openai`, `anthropic`)     |
+| Argument     | Required | Default                  | Description                                                         |
+| ------------ | -------- | ------------------------ | ------------------------------------------------------------------- |
+| `--url`      | Yes      | —                        | URL of the page exposing WebMCP tools                               |
+| `--evals`    | Yes      | —                        | Path to the evals JSON file                                         |
+| `--backend`  | No       | `vercel`                 | Must be `vercel` (live browser evaluation requires `ToolLoopAgent`) |
+| `--provider` | No       | `gemini`                 | Model provider to use with Vercel (e.g., `openai`, `anthropic`)     |
 | `--model`    | No       | `gemini-3-flash-preview` | Model name                                                          |
 
 ### `serve` — WebMCP Evals UI sidecar

--- a/evals-cli/package-lock.json
+++ b/evals-cli/package-lock.json
@@ -27,7 +27,7 @@
         "ollama": "^0.6.3",
         "open": "^11.0.0",
         "ora": "^9.3.0",
-        "puppeteer-core": "^24.37.5",
+        "puppeteer-core": "^25.0.4",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -1058,36 +1058,36 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
-      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.3.tgz",
+      "integrity": "sha512-v3YaiGpzUTgOZkHBFR0iZg58Vto25SqBQxfLUXDiofJccwVl6Mlr7BdLCS1NZgxikdeIHf936cxYWL9IZp3tow==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
         "semver": "^7.7.4",
         "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
-        "browsers": "lib/cjs/main-cli.js"
+        "browsers": "lib/main-cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        }
       }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
@@ -1242,16 +1242,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
@@ -1356,22 +1346,25 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.0.1"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -1394,9 +1387,9 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -1408,9 +1401,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
-      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -1432,9 +1425,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.1.tgz",
-      "integrity": "sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -1450,19 +1443,23 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
-      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "streamx": "^2.21.0",
+        "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
@@ -1472,9 +1469,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -1499,15 +1496,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -1554,15 +1542,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1637,13 +1616,16 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
-      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -1735,21 +1717,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -1760,23 +1727,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -1944,20 +1894,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1968,9 +1904,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1566079",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
-      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/dotenv": {
@@ -2097,27 +2033,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
     "node_modules/eslint": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
@@ -2241,19 +2156,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -2286,7 +2188,9 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2295,7 +2199,9 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2376,26 +2282,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2425,15 +2311,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -2659,44 +2536,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2793,19 +2632,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -2862,15 +2688,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3138,15 +2955,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3267,15 +3075,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-domexception": {
@@ -3591,38 +3390,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3663,12 +3430,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
     },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
@@ -3739,31 +3500,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -3786,21 +3522,21 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.37.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
-      "integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
+      "version": "25.0.4",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.4.tgz",
+      "integrity": "sha512-K1LQKDP6w1rIr1jUyN9obH16TO/DCy86k3q+FBd2prGY+TStxhFySxmaZZuRF+0D3BJXjwCYFke7tMHCH4olTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
-        "chromium-bidi": "14.0.0",
+        "@puppeteer/browsers": "3.0.3",
+        "chromium-bidi": "16.0.1",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1566079",
-        "typed-query-selector": "^2.12.0",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.19.0"
+        "ws": "^8.20.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/qs": {
@@ -3941,9 +3677,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4112,54 +3848,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4182,9 +3870,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -4243,9 +3931,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -4257,9 +3945,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -4305,12 +3993,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4340,9 +4022,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
-      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -4443,6 +4125,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4450,9 +4170,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4520,16 +4240,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/evals-cli/package.json
+++ b/evals-cli/package.json
@@ -30,7 +30,7 @@
     "ollama": "^0.6.3",
     "open": "^11.0.0",
     "ora": "^9.3.0",
-    "puppeteer-core": "^24.37.5",
+    "puppeteer-core": "^25.0.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -99,7 +99,7 @@ export class VercelBackend implements Backend {
       browser = await puppeteer.launch({
         executablePath,
         headless: true,
-        args: ["--enable-features=WebMCPTesting,DevToolsWebMCPSupport", "--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--enable-features=WebMCPTesting", "--no-sandbox", "--disable-setuid-sandbox"],
       });
 
       console.log("Browser initialized for actual evals");

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -29,7 +29,7 @@ export class VercelBackend implements Backend {
     config: Config | WebmcpConfig,
     private tools: Array<Tool>,
   ) {
-    this.modelName = config.model || "gemini-2.5-flash";
+    this.modelName = config.model || "gemini-3-flash-preview";
     this.aiModel = getModel(config);
     this.debug = !!config.debug;
   }
@@ -99,7 +99,7 @@ export class VercelBackend implements Backend {
       browser = await puppeteer.launch({
         executablePath,
         headless: true,
-        args: ["--enable-features=WebMCPTesting", "--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--enable-features=WebMCPTesting,DevToolsWebMCPSupport", "--no-sandbox", "--disable-setuid-sandbox"],
       });
 
       console.log("Browser initialized for actual evals");
@@ -183,23 +183,8 @@ export class VercelBackend implements Backend {
                   );
                 }
               : undefined,
-            prepareStep: async (_opts: any): Promise<any> => {
-              let rawTools: any = [];
-
-              try {
-                rawTools = await page!.evaluate(async () => {
-                  const nav = navigator as any;
-                  let mct = null;
-                  if (typeof nav.modelContext?.listTools === "function") {
-                    mct = nav.modelContext;
-                  } else if (typeof nav.modelContextTesting?.listTools === "function") {
-                    mct = nav.modelContextTesting;
-                  }
-                  return mct ? mct.listTools() : [];
-                });
-              } catch (err: any) {
-                console.error("[vercel.ts] Failed to fetch tools via evaluate:", err.message);
-              }
+            prepareStep: (_opts: any): any => {
+              let rawTools = page!.webmcp.tools();
 
               currentTools = mapRawBrowserToolsToConfig(rawTools, currentTools);
 

--- a/evals-cli/src/bin/runevals.ts
+++ b/evals-cli/src/bin/runevals.ts
@@ -38,7 +38,7 @@ const config: Config = {
   evalsFile: args.evals,
   backend: args.backend || "gemini",
   provider: args.provider,
-  model: args.model || "gemini-2.5-flash",
+  model: args.model || "gemini-3-flash-preview",
   runs: args.runs ? parseInt(args.runs, 10) : 1,
 };
 

--- a/evals-cli/src/bin/webmcpevals.ts
+++ b/evals-cli/src/bin/webmcpevals.ts
@@ -48,7 +48,7 @@ const config: WebmcpConfig = {
   evalsFile: args.evals,
   backend: args.backend || "vercel",
   provider: args.provider || "gemini",
-  model: args.model || "gemini-2.5-flash",
+  model: args.model || "gemini-3-flash-preview",
   debug,
   runs: args.runs ? parseInt(args.runs, 10) : 1,
 };

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -83,10 +83,11 @@ export function createBrowserTool(t: Tool, page: Page): any {
 }
 
 /**
- * Launches Chrome, navigates to the given URL, and retrieves the list
+ * Launches Chrome Canary, navigates to the given URL, and retrieves the list
  * of tools exposed by the page via Puppeteer.
  *
- * Requires Chrome 150+. The browser is always closed after the tools are retrieved,
+ * Requires Chrome Canary 150+ with the `chrome://flags/#enable-webmcp-testing`
+ * flag enabled. The browser is always closed after the tools are retrieved,
  * even if an error occurs.
  */
 export async function listToolsFromPage(url: string): Promise<Tool[]> {
@@ -94,7 +95,7 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
   let browser: Browser | null = null;
 
   try {
-    console.log(`Launching Chrome from: ${executablePath}`);
+    console.log(`Launching Chrome Canary from: ${executablePath}`);
     browser = await puppeteer.launch({
       executablePath,
       headless: true,

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -86,7 +86,7 @@ export function createBrowserTool(t: Tool, page: Page): any {
  * Launches Chrome, navigates to the given URL, and retrieves the list
  * of tools exposed by the page via Puppeteer.
  *
- * Requires Chrome 149+. The browser is always closed after the tools are retrieved,
+ * Requires Chrome 150+. The browser is always closed after the tools are retrieved,
  * even if an error occurs.
  */
 export async function listToolsFromPage(url: string): Promise<Tool[]> {
@@ -98,7 +98,7 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
     browser = await puppeteer.launch({
       executablePath,
       headless: true,
-      args: ["--enable-features=WebMCPTesting,DevToolsWebMCPSupport", "--no-sandbox", "--disable-setuid-sandbox"],
+      args: ["--enable-features=WebMCPTesting", "--no-sandbox", "--disable-setuid-sandbox"],
     });
 
     const page = await browser.newPage();

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -27,7 +27,7 @@ export function createBrowserTool(t: Tool, page: Page): any {
         return { error: "no tools were found" };
       }
 
-      const tool = tools.find(tool => tool.name === t.functionName);
+      const tool = tools.find((tool) => tool.name === t.functionName);
       if (!tool) {
         return { error: `no tool named "${t.functionName}" were found` };
       }
@@ -35,7 +35,7 @@ export function createBrowserTool(t: Tool, page: Page): any {
       try {
         const result = await tool.execute(args);
 
-        if (result.status === 'Completed') {
+        if (result.status === "Completed") {
           executionResult.result = result.output;
         } else {
           return { error: result.errorText };
@@ -45,7 +45,9 @@ export function createBrowserTool(t: Tool, page: Page): any {
         if (executionResult.result == null) {
           await page.waitForNavigation();
           executionResult = await page.evaluate(() => {
-            const result = document.querySelector('script[type="application/ld+json"]')?.textContent;
+            const result = document.querySelector(
+              'script[type="application/ld+json"]',
+            )?.textContent;
             return { result, crossDocument: true };
           });
         }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -42,8 +42,6 @@ export function createBrowserTool(t: Tool, page: Page): any {
         }
 
         // If executionResult.result is null, it is due to a navigation happening.
-        // Bug: https://issues.chromium.org/510269012
-        // Note that this doesn't work yet because of https://chromium-review.googlesource.com/c/chromium/src/+/7827877
         if (executionResult.result == null) {
           await page.waitForNavigation();
           executionResult = await page.evaluate(() => {

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -20,55 +20,35 @@ export function createBrowserTool(t: Tool, page: Page): any {
     parameters: jsonSchema(sanitizedParams) as any,
     inputSchema: jsonSchema(sanitizedParams) as any,
     execute: async (args: any) => {
-      let executionResult: any;
+      let executionResult: any = {};
+
+      const tools = page.webmcp.tools();
+      if (tools.length === 0) {
+        return { error: "no tools were found" };
+      }
+
+      const tool = tools.find(tool => tool.name === t.functionName);
+      if (!tool) {
+        return { error: `no tool named "${t.functionName}" were found` };
+      }
 
       try {
-        executionResult = await page.evaluate(
-          async (name, args) => {
-            try {
-              let mct = null;
-              if (typeof (navigator as any).modelContext?.executeTool === "function") {
-                mct = (navigator as any).modelContext;
-              } else if (
-                typeof (navigator as any).modelContextTesting?.executeTool === "function"
-              ) {
-                mct = (navigator as any).modelContextTesting;
-              }
-              if (!mct) return { error: "modelContext not found" };
-              const payload = typeof args === "string" ? args : JSON.stringify(args || {});
-              const result = await mct.executeTool(name, payload);
+        const result = await tool.execute(args);
 
-              return { result };
-            } catch (e: any) {
-              return { error: e.message || String(e) };
-            }
-          },
-          t.functionName,
-          args,
-        );
+        if (result.status === 'Completed') {
+          executionResult.result = result.output;
+        } else {
+          return { error: result.errorText };
+        }
 
-        // If executionResult.result is null, it might be due to a navigation happening,
-        // so fall back to using getCrossDocumentScriptToolResult().
-        if (!executionResult.result) {
+        // If executionResult.result is null, it is due to a navigation happening.
+        // Bug: https://issues.chromium.org/510269012
+        // Note that this doesn't work yet because of https://chromium-review.googlesource.com/c/chromium/src/+/7827877
+        if (executionResult.result == null) {
           await page.waitForNavigation();
-          executionResult = await page.evaluate(async () => {
-            try {
-              let mct = null;
-              if (typeof (navigator as any).modelContext?.executeTool === "function") {
-                mct = (navigator as any).modelContext;
-              } else if (
-                typeof (navigator as any).modelContextTesting?.executeTool === "function"
-              ) {
-                mct = (navigator as any).modelContextTesting;
-              }
-
-              if (!mct) return { error: "modelContext not found" };
-
-              const result = await mct.getCrossDocumentScriptToolResult();
-              return { result, crossDocument: true };
-            } catch (e: any) {
-              return { error: e.message || String(e) };
-            }
+          executionResult = await page.evaluate(() => {
+            const result = document.querySelector('script[type="application/ld+json"]')?.textContent;
+            return { result, crossDocument: true };
           });
         }
       } catch (e: any) {
@@ -103,11 +83,10 @@ export function createBrowserTool(t: Tool, page: Page): any {
 }
 
 /**
- * Launches Chrome Canary, navigates to the given URL, and retrieves the list
- * of tools exposed by the page via the WebMCP API.
+ * Launches Chrome, navigates to the given URL, and retrieves the list
+ * of tools exposed by the page via Puppeteer.
  *
- * Requires Chrome Canary 146+ with the `chrome://flags/#enable-webmcp-testing`
- * flag enabled. The browser is always closed after the tools are retrieved,
+ * Requires Chrome 149+. The browser is always closed after the tools are retrieved,
  * even if an error occurs.
  */
 export async function listToolsFromPage(url: string): Promise<Tool[]> {
@@ -115,11 +94,11 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
   let browser: Browser | null = null;
 
   try {
-    console.log(`Launching Chrome Canary from: ${executablePath}`);
+    console.log(`Launching Chrome from: ${executablePath}`);
     browser = await puppeteer.launch({
       executablePath,
       headless: true,
-      args: ["--enable-features=WebMCPTesting", "--no-sandbox", "--disable-setuid-sandbox"],
+      args: ["--enable-features=WebMCPTesting,DevToolsWebMCPSupport", "--no-sandbox", "--disable-setuid-sandbox"],
     });
 
     const page = await browser.newPage();
@@ -136,38 +115,9 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
       );
     }
 
-    const rawTools = await page.evaluate(async () => {
-      let modelContext = null;
-      if (typeof (navigator as any).modelContext?.listTools === "function") {
-        modelContext = (navigator as any).modelContext;
-      } else if (typeof (navigator as any).modelContextTesting?.listTools === "function") {
-        modelContext = (navigator as any).modelContextTesting;
-      }
+    const rawTools = page.webmcp.tools();
 
-      if (!modelContext) {
-        return null;
-      }
-      return await modelContext.listTools();
-    });
-
-    if (rawTools === null) {
-      throw new Error(
-        "The WebMCP API (window.navigator.modelContextTesting) is not available on this page.\n" +
-          "Please ensure:\n" +
-          "  1. You are using Chrome Canary version 146 or later.\n" +
-          "  2. The flag chrome://flags/#enable-webmcp-testing is enabled.\n" +
-          `  3. The page at ${url} implements the WebMCP API.`,
-      );
-    }
-
-    if (!Array.isArray(rawTools) || rawTools.length === 0) {
-      throw new Error(
-        `The WebMCP API returned no tools from ${url}. ` +
-          "Ensure the page exposes tools via modelContextTesting.listTools().",
-      );
-    }
-
-    console.log(`Found ${rawTools.length} tool(s) via WebMCP API.`);
+    console.log(`Found ${rawTools.length} tool(s) via Puppeteer.`);
     return mapRawBrowserToolsToConfig(rawTools, []);
   } finally {
     if (browser) {

--- a/evals-cli/src/evaluator/index.ts
+++ b/evals-cli/src/evaluator/index.ts
@@ -44,7 +44,7 @@ export async function executeLocalEvals(
     if (!apiKey) throw new Error("Missing Google API key");
     backendImpl = new GeminiBackend(
       apiKey,
-      config.model || "gemini-2.5-flash",
+      config.model || "gemini-3-flash-preview",
       SYSTEM_PROMPT,
       tools,
     );

--- a/evals-cli/src/evaluator/models.ts
+++ b/evals-cli/src/evaluator/models.ts
@@ -9,7 +9,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { Config, WebmcpConfig } from "../types/config.js";
 
 export function getModel(config: Config | WebmcpConfig) {
-  const modelId = config.model || "google:gemini-2.5-flash";
+  const modelId = config.model || "google:gemini-3-flash-preview";
 
   if (config.provider === "openai" || modelId.startsWith("openai:")) {
     const apiKey = process.env.OPENAI_API_KEY;

--- a/evals-cli/src/evaluator/prompts.ts
+++ b/evals-cli/src/evaluator/prompts.ts
@@ -6,7 +6,8 @@
 export const SYSTEM_PROMPT = `
 # INSTRUCTIONS
 You are an agent helping a user navigate a page via the tools made available to you. You must
-use the tools available to help the user.
+use the provided tools to query page content when you need it.
+CRITICAL RULE: Do not try to use other tools than the available ones.
 
 # ADDITIONAL CONTEXT
 Today's date is: ${new Date().toDateString()}.

--- a/evals-cli/src/test/vercel.test.ts
+++ b/evals-cli/src/test/vercel.test.ts
@@ -40,7 +40,7 @@ describe("VercelBackend", () => {
         }
       }
 
-      const backend = new TestableVercelBackend({ model: "gemini-2.5-flash" } as any, dummyTools);
+      const backend = new TestableVercelBackend({ model: "gemini-3-flash-preview" } as any, dummyTools);
 
       // Create a multi-turn eval
       const evalTest: Eval = {
@@ -127,7 +127,7 @@ describe("VercelBackend", () => {
       });
 
       const backend = new VercelBackend(
-        { model: "gemini-2.5-flash", url: "http://localhost:3000" } as any,
+        { model: "gemini-3-flash-preview", url: "http://localhost:3000" } as any,
         dummyTools,
       );
 

--- a/evals-cli/src/test/vercel.test.ts
+++ b/evals-cli/src/test/vercel.test.ts
@@ -40,7 +40,10 @@ describe("VercelBackend", () => {
         }
       }
 
-      const backend = new TestableVercelBackend({ model: "gemini-3-flash-preview" } as any, dummyTools);
+      const backend = new TestableVercelBackend(
+        { model: "gemini-3-flash-preview" } as any,
+        dummyTools,
+      );
 
       // Create a multi-turn eval
       const evalTest: Eval = {

--- a/evals-cli/ui/src/App.tsx
+++ b/evals-cli/ui/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
     evalsFile: "./examples/travel/evals.json",
     toolSchemaFile: "./examples/travel/schema.json",
     url: "https://example.com",
-    model: "gemini-2.5-flash",
+    model: "gemini-3-flash-preview",
     backend: "gemini",
     runs: 1,
   });


### PR DESCRIPTION
Now that https://chromiumdash.appspot.com/commit/625b9b44df117fba5a37be32dcd684ccc4a616e5 has landed into Chrome 150.0.7853.0, we can fully switch to Puppeteer instead of relying of the modelContextTesting experimental Web API which will be removed soon.

This CL does several things:
- Use `gemini-3-flash-preview` instead of deprecated `gemini-2.5-flash`
- Update system prompt to make sure model doesn't hallucinate tools
- Replace `listTools` calls with `page.webmcp.tools` from Puppeteer
- Replace `executeTool` calls with `tool.execute` from Puppeteer
- Replace `getCrossDocumentScriptToolResult` calls with manual `document.querySelector('script[type="application/ld+json"]')?.textContent` call
- Update puppeteer-core required version
- Update required Chrome version to 150+
