### PR TITLE
fix(demos/analytics-dashboard): resolve query tool only after React rendering commits

### DIFF
--- a/demos/analytics-dashboard/src/App.jsx
+++ b/demos/analytics-dashboard/src/App.jsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { flushSync } from "react-dom";
 import {
   VALID_STATUSES,
   VALID_METHODS,
@@ -27,6 +26,7 @@ import useWebMCPQueryTool from "./hooks/useWebMCPQueryTool.js";
  */
 export default function WebMCPDashboard() {
   const [query, setQuery] = useState(DEFAULT_QUERY);
+  const pendingResolversRef = useRef([]);
   const {
     statusFilter,
     methodFilter,
@@ -75,7 +75,7 @@ export default function WebMCPDashboard() {
   const maxValue = Math.max(...aggregatedData.map((d) => d.value), 1);
 
   const executeQuery = useCallback(
-    async (params) => {
+    (params) => {
       const {
         status,
         method,
@@ -153,17 +153,15 @@ export default function WebMCPDashboard() {
           ],
         };
 
-      flushSync(() => {
-        setQuery({
-          statusFilter: status || "All",
-          methodFilter: method || "All",
-          pathSearch: ps || "",
-          dateFrom: df || "",
-          dateTo: dt || "",
-          groupBy: gb,
-          measure: ms,
-          chartType: ct,
-        });
+      setQuery({
+        statusFilter: status || "All",
+        methodFilter: method || "All",
+        pathSearch: ps || "",
+        dateFrom: df || "",
+        dateTo: dt || "",
+        groupBy: gb,
+        measure: ms,
+        chartType: ct,
       });
 
       const filters = [
@@ -178,11 +176,14 @@ export default function WebMCPDashboard() {
         : "";
       const vizDesc = ct === "table" ? "table" : `${ms} by ${gb} as ${ct}`;
 
-      return {
-        content: [
-          { type: "text", text: `Query applied: ${vizDesc}${filterDesc}.` },
-        ],
-      };
+      return new Promise((resolve) => {
+        const response = {
+          content: [
+            { type: "text", text: `Query applied: ${vizDesc}${filterDesc}.` },
+          ],
+        };
+        pendingResolversRef.current.push(() => resolve(response));
+      });
     },
     [setQuery],
   );
@@ -194,6 +195,14 @@ export default function WebMCPDashboard() {
   }, [executeQuery]);
 
   useWebMCPQueryTool(executeQueryRef);
+
+  useEffect(() => {
+    const resolvers = pendingResolversRef.current;
+    if (resolvers.length > 0) {
+      pendingResolversRef.current = [];
+      resolvers.forEach((resolve) => resolve());
+    }
+  });
 
   const PAGE_SIZE = 50;
   const [tablePage, setTablePage] = useState(0);

--- a/demos/analytics-dashboard/src/hooks/useWebMCPQueryTool.js
+++ b/demos/analytics-dashboard/src/hooks/useWebMCPQueryTool.js
@@ -6,7 +6,7 @@ import { useEffect } from "react";
 
 /**
  * Registers the WebMCP query tool for server logs filtering and visualisation.
- * @param {React.MutableRefObject<function>} executeQueryRef - A mutable ref object holding the latest executeQuery callback.
+ * @param {React.RefObject<function>} executeQueryRef - A ref object holding the latest executeQuery callback.
  */
 export default function useWebMCPQueryTool(executeQueryRef) {
   useEffect(() => {
@@ -17,9 +17,10 @@ export default function useWebMCPQueryTool(executeQueryRef) {
 
     const controller = new AbortController();
 
-    navigator.modelContext.registerTool({
-      name: "query",
-      description: `Query the server logs. Sets all filters and visualization in one atomic call — every parameter is always applied together, so no stale state can carry over from a previous query.
+    navigator.modelContext.registerTool(
+      {
+        name: "query",
+        description: `Query the server logs. Sets all filters and visualization in one atomic call — every parameter is always applied together, so no stale state can carry over from a previous query.
 
 FILTERS (all optional — omit or pass null to leave unfiltered):
   status     — HTTP status code: '200' | '201' | '301' | '304' | '401' | '403' | '404' | '500'
@@ -34,49 +35,60 @@ AGGREGATION (required):
 
 CHART (required):
   chartType — 'line' (trends over time, best with groupBy=date) | 'bar_vertical' | 'bar_horizontal' | 'table' (raw rows, groupBy/measure ignored)`,
-      inputSchema: {
-        type: "object",
-        properties: {
-          status: {
-            type: "string",
-            description: "HTTP status filter. Omit for no filter.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            status: {
+              type: "string",
+              description: "HTTP status filter. Omit for no filter.",
+            },
+            method: {
+              type: "string",
+              description: "HTTP method filter. Omit for no filter.",
+            },
+            pathSearch: {
+              type: "string",
+              description: "URL path substring filter. Omit for no filter.",
+            },
+            dateFrom: {
+              type: "string",
+              description: "Start date YYYY-MM-DD. Omit for no lower bound.",
+            },
+            dateTo: {
+              type: "string",
+              description: "End date YYYY-MM-DD. Omit for no upper bound.",
+            },
+            groupBy: {
+              type: "string",
+              enum: [
+                "date",
+                "status",
+                "method",
+                "path",
+                "country",
+                "user_agent",
+              ],
+              description: "Dimension to group results by.",
+            },
+            measure: {
+              type: "string",
+              enum: ["count", "bytes", "unique_ips"],
+              description:
+                "Metric to compute: count (requests), bytes (bandwidth), or unique_ips.",
+            },
+            chartType: {
+              type: "string",
+              enum: ["line", "bar_vertical", "bar_horizontal", "table"],
+              description:
+                "Chart type. Use line for trends over time (best with groupBy=date). Use table for raw rows (groupBy/measure ignored).",
+            },
           },
-          method: {
-            type: "string",
-            description: "HTTP method filter. Omit for no filter.",
-          },
-          pathSearch: {
-            type: "string",
-            description: "URL path substring filter. Omit for no filter.",
-          },
-          dateFrom: {
-            type: "string",
-            description: "Start date YYYY-MM-DD. Omit for no lower bound.",
-          },
-          dateTo: {
-            type: "string",
-            description: "End date YYYY-MM-DD. Omit for no upper bound.",
-          },
-          groupBy: {
-            type: "string",
-            enum: ["date", "status", "method", "path", "country", "user_agent"],
-            description: "Dimension to group results by.",
-          },
-          measure: {
-            type: "string",
-            enum: ["count", "bytes", "unique_ips"],
-            description: "Metric to compute: count (requests), bytes (bandwidth), or unique_ips.",
-          },
-          chartType: {
-            type: "string",
-            enum: ["line", "bar_vertical", "bar_horizontal", "table"],
-            description: "Chart type. Use line for trends over time (best with groupBy=date). Use table for raw rows (groupBy/measure ignored).",
-          },
+          required: ["groupBy", "measure", "chartType"],
         },
-        required: ["groupBy", "measure", "chartType"],
+        execute: (params) => executeQueryRef.current(params),
       },
-      execute: (params) => executeQueryRef.current(params),
-    }, { signal: controller.signal });
+      { signal: controller.signal },
+    );
 
     return () => {
       navigator.modelContext.unregisterTool?.("query");


### PR DESCRIPTION
Addresses the race condition in the WebMCP analytics-dashboard query tool. The issue happened because `flushSync` forced the DOM to update, but didn't wait for the browser to re-render.

By using a deferred promise queue that resolves inside a React on-commit `useEffect` hook, we guarantee the tool only completes execution after the browser has successfully performed layout/paint cycles on the updated DOM, avoiding stale visual screenshots for AI agents.

This also removes usage of `flushSync`, which the [React documentation marks as uncommon and that it's usage may hurt performance](https://react.dev/reference/react-dom/flushSync).