### PR TITLE
Use document.modelContext when available

### DIFF
--- a/demos/analytics-dashboard/src/hooks/useWebMCPQueryTool.js
+++ b/demos/analytics-dashboard/src/hooks/useWebMCPQueryTool.js
@@ -10,14 +10,15 @@ import { useEffect } from "react";
  */
 export default function useWebMCPQueryTool(executeQueryRef) {
   useEffect(() => {
-    if (!window.navigator.modelContext) {
+    const modelContext = document.modelContext || navigator.modelContext;
+    if (!modelContext) {
       console.warn("WebMCP not detected in this browser.");
       return;
     }
 
     const controller = new AbortController();
 
-    navigator.modelContext.registerTool(
+    modelContext.registerTool(
       {
         name: "query",
         description: `Query the server logs. Sets all filters and visualization in one atomic call — every parameter is always applied together, so no stale state can carry over from a previous query.
@@ -91,7 +92,7 @@ CHART (required):
     );
 
     return () => {
-      navigator.modelContext.unregisterTool?.("query");
+      modelContext.unregisterTool?.("query");
       controller.abort();
     };
   }, [executeQueryRef]);

--- a/demos/coffee-shop/classic_dark_roast_coffee_beans.html
+++ b/demos/coffee-shop/classic_dark_roast_coffee_beans.html
@@ -302,8 +302,8 @@
 
   refreshCartUI();
 
-  if ("modelContext" in navigator) {
-    const modelContext = navigator.modelContext;
+  const modelContext = document.modelContext || navigator.modelContext;
+  if (modelContext) {
 
     modelContext.registerTool({
       name: "search_catalog",

--- a/demos/coffee-shop/index.html
+++ b/demos/coffee-shop/index.html
@@ -279,8 +279,8 @@
   
   refreshCartUI();
 
-  if ("modelContext" in navigator) {
-    const modelContext = navigator.modelContext;
+  const modelContext = document.modelContext || navigator.modelContext;
+  if (modelContext) {
 
     modelContext.registerTool({
       name: "search_catalog",

--- a/demos/coffee-shop/order_history.html
+++ b/demos/coffee-shop/order_history.html
@@ -237,8 +237,8 @@
     alert('Classic Dark Roast added to your ritual!');
     });
 
-    if ("modelContext" in navigator) {
-    const modelContext = navigator.modelContext;
+    const modelContext = document.modelContext || navigator.modelContext;
+    if (modelContext) {
 
     modelContext.registerTool({
         name: "search_catalog",

--- a/demos/coffee-shop/precision_burr.html
+++ b/demos/coffee-shop/precision_burr.html
@@ -281,8 +281,8 @@ section class="relative min-height-[819px] flex flex-col md:flex-row items-cente
 
   refreshCartUI();
 
-  if ("modelContext" in navigator) {
-    const modelContext = navigator.modelContext;
+  const modelContext = document.modelContext || navigator.modelContext;
+  if (modelContext) {
 
     modelContext.registerTool({
       name: "search_catalog",

--- a/demos/coffee-shop/the_alchemist.html
+++ b/demos/coffee-shop/the_alchemist.html
@@ -205,8 +205,8 @@
 
     refreshCartUI();
 
-    if ("modelContext" in navigator) {
-    const modelContext = navigator.modelContext;
+    const modelContext = document.modelContext || navigator.modelContext;
+    if (modelContext) {
 
     modelContext.registerTool({
         name: "get_machine_specifications",

--- a/demos/doors/forest.html
+++ b/demos/doors/forest.html
@@ -62,7 +62,8 @@
             speech.innerText = "Ask me anything else...";
         }
 
-        navigator.modelContext.registerTool({
+        const modelContext = document.modelContext || navigator.modelContext;
+        modelContext.registerTool({
             name: 'talk',
             description: 'Talk with the animal. You can ask "What are you?" or say "Give me a gift"',
             inputSchema: {

--- a/demos/doors/magic.html
+++ b/demos/doors/magic.html
@@ -45,7 +45,8 @@
             document.querySelector('form button').removeAttribute('disabled');
         }
 
-        navigator.modelContext.registerTool({
+        const modelContext = document.modelContext || navigator.modelContext;
+        modelContext.registerTool({
             name: 'castLight',
             description: 'Cast light',
             execute: async () => {

--- a/demos/doors/ocean.html
+++ b/demos/doors/ocean.html
@@ -60,7 +60,8 @@
             return document.getElementById('speech').innerText;
         }
 
-        navigator.modelContext.registerTool({
+        const modelContext = document.modelContext || navigator.modelContext;
+        modelContext.registerTool({
             name: 'dance',
             description: 'Dance with him',
             execute: () => {
@@ -68,7 +69,7 @@
             },
         });
 
-        navigator.modelContext.registerTool({
+        modelContext.registerTool({
             name: 'hide',
             description: 'Play Hide & Seek',
             execute: () => {

--- a/demos/hotel-chain/src/hooks/useWebMCP.ts
+++ b/demos/hotel-chain/src/hooks/useWebMCP.ts
@@ -20,11 +20,11 @@ export function useWebMCP(tools: WebMCPTool[]) {
   const registeredTools = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !window.navigator.modelContext) {
+    const modelContext = document.modelContext || navigator.modelContext;
+    if (!modelContext) {
       return;
     }
 
-    const modelContext = window.navigator.modelContext;
     const controller = new AbortController();
 
     tools.forEach(tool => {

--- a/demos/pizza-maker/script.js
+++ b/demos/pizza-maker/script.js
@@ -179,13 +179,14 @@ function loadPizzaStateFromURL() {
 // Load state on startup
 loadPizzaStateFromURL();
 
-if (window.navigator.modelContext) {
+const modelContext = document.modelContext || navigator.modelContext;
+if (modelContext) {
   const urlParams = new URLSearchParams(window.location.search);
   if (!urlParams.has('showButtons')) {
     document.body.classList.add('webmcp-supported');
   }
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'set_pizza_size',
     description: 'Set the pizza size directly or infer it based on the number of people.',
     inputSchema: {
@@ -222,7 +223,7 @@ if (window.navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'set_pizza_style',
     description: 'Set the style of the pizza (colors/theme)',
     inputSchema: {
@@ -241,7 +242,7 @@ if (window.navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'toggle_layer',
     description: 'Control pizza layers (sauce, cheese). Use "add", "remove", or "toggle".',
     inputSchema: {
@@ -258,7 +259,7 @@ if (window.navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'add_topping',
     description: 'Add one or more toppings to the pizza',
     inputSchema: {
@@ -283,7 +284,7 @@ if (window.navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'remove_topping',
     description: 'Remove a specific topping from the pizza',
     inputSchema: {
@@ -309,7 +310,7 @@ if (window.navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'manage_pizza',
     description: 'Manage pizza state',
     inputSchema: {
@@ -331,7 +332,7 @@ if (window.navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'share_pizza',
     description: 'Get a shareable URL for the current pizza creation',
     inputSchema: {

--- a/demos/react-flightsearch/src/webmcp.ts
+++ b/demos/react-flightsearch/src/webmcp.ts
@@ -308,7 +308,7 @@ export const searchFlightsTool = {
 };
 
 export function registerFlightSearchTools() {
-  const modelContext = window.navigator.modelContext;
+  const modelContext = document.modelContext || navigator.modelContext;
   if (modelContext) {
     if (!registeredTools.searchTools) {
       registeredTools.searchTools = new AbortController();
@@ -325,7 +325,7 @@ export function unregisterFlightSearchTools() {
 }
 
 export function registerFlightResultsTools() {
-  const modelContext = window.navigator.modelContext;
+  const modelContext = document.modelContext || navigator.modelContext;
 
   if (modelContext) {
     if (!registeredTools.resultsTools) {

--- a/demos/real-estate-map/mcp.js
+++ b/demos/real-estate-map/mcp.js
@@ -4,7 +4,7 @@
  */
 
 // Register WebMCP Tools natively
-const modelContext = navigator.modelContext;
+const modelContext = document.modelContext || navigator.modelContext;
 if (modelContext) {
   modelContext.registerTool({
     name: "apply_smart_filters",

--- a/demos/shared/types/webmcp.d.ts
+++ b/demos/shared/types/webmcp.d.ts
@@ -5,7 +5,7 @@
 
 /**
  * Type declarations for the WebMCP browser API.
- * Extends the Navigator interface with `modelContext`.
+ * Extends the Document interface with `modelContext`.
  * @see https://webmachinelearning.github.io/webmcp/
  */
 
@@ -59,13 +59,21 @@ declare global {
     };
   }
 
-  /** The model context API exposed on `navigator.modelContext`. */
+  /** The model context API exposed on `document.modelContext`. */
   interface ModelContext {
     /** Adds a single tool to the current context. */
     registerTool(tool: ModelContextTool, options?: { signal?: AbortSignal }): void;
   }
 
   interface Navigator {
+    /**
+     * WebMCP model context API. May be undefined if the browser doesn't support it.
+     * @deprecated Use `document.modelContext` instead.
+     */
+    modelContext?: ModelContext;
+  }
+
+  interface Document {
     /** WebMCP model context API. May be undefined if the browser doesn't support it. */
     modelContext?: ModelContext;
   }

--- a/demos/smart-home/src/context/DashboardContext.jsx
+++ b/demos/smart-home/src/context/DashboardContext.jsx
@@ -17,8 +17,9 @@ export function DashboardProvider({ children }) {
   useEffect(() => {
     const controller = new AbortController();
 
+    const modelContext = document.modelContext || navigator.modelContext;
     try {
-      navigator.modelContext.registerTool({
+      modelContext.registerTool({
         name: "rearrangeDOMComponents",
         title: "Rearrange Dashboard",
         description: "Rearranges the user's home dashboard by adding, removing, or reordering smart home control components based on the user's intent.",
@@ -42,7 +43,7 @@ export function DashboardProvider({ children }) {
         }
       }, { signal: controller.signal });
 
-      console.log("WebMCP tool registered via navigator.modelContext");
+      console.log("WebMCP tool registered via modelContext");
     } catch (e) {
       console.error(e);
     }

--- a/demos/sport-shop-angular/src/app/components/cart-modal/cart-modal.component.ts
+++ b/demos/sport-shop-angular/src/app/components/cart-modal/cart-modal.component.ts
@@ -40,7 +40,7 @@ export class CartModalComponent implements OnInit, OnDestroy {
   private cartToolController: AbortController | null = null;
 
   private registerCartTools() {
-    const modelContext = navigator.modelContext;
+    const modelContext = document.modelContext || navigator.modelContext;
     if (modelContext) {
       this.cartToolController = new AbortController();
       const signal = this.cartToolController.signal;

--- a/demos/sport-shop-angular/src/app/pages/search/search.component.ts
+++ b/demos/sport-shop-angular/src/app/pages/search/search.component.ts
@@ -66,7 +66,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   private searchToolController: AbortController | null = null;
 
   private registerSearchTools() {
-    const modelContext = navigator.modelContext;
+    const modelContext = document.modelContext || navigator.modelContext;
     if (modelContext) {
       this.searchToolController = new AbortController();
       const signal = this.searchToolController.signal;

--- a/demos/sport-shop-angular/src/app/services/webmcp.service.ts
+++ b/demos/sport-shop-angular/src/app/services/webmcp.service.ts
@@ -25,13 +25,13 @@ export class WebmcpService {
   }
 
   private get modelContext(): ModelContext | undefined {
-    return navigator.modelContext;
+    return document.modelContext || navigator.modelContext;
   }
 
   private registerTools() {
     const modelContext = this.modelContext;
     if (!modelContext) {
-      console.warn('modelContext is not defined on navigator. WebMCP tools will not be registered.');
+      console.warn('modelContext is not defined. WebMCP tools will not be registered.');
       return;
     }
 

--- a/demos/ticket-booking/script.js
+++ b/demos/ticket-booking/script.js
@@ -278,8 +278,9 @@ window.addEventListener('hashchange', updateStateFromUrl);
 updateStateFromUrl();
 
 // WebMCP Implementation
-if (navigator.modelContext) {
-  navigator.modelContext.registerTool({
+const modelContext = document.modelContext || navigator.modelContext;
+if (modelContext) {
+  modelContext.registerTool({
     name: 'update_location',
     description: "Updates the user's location.",
     inputSchema: {
@@ -301,7 +302,7 @@ if (navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'query_content',
     description: 'Filters the movie catalog by a specific genre.',
     inputSchema: {
@@ -325,7 +326,7 @@ if (navigator.modelContext) {
     },
   });
 
-  navigator.modelContext.registerTool({
+  modelContext.registerTool({
     name: 'select_showtime',
     description: 'Selects a movie and a specific showtime to initiate the checkout process.',
     inputSchema: {

--- a/demos/webmcp-maze/src/webmcp/ToolRegistry.ts
+++ b/demos/webmcp-maze/src/webmcp/ToolRegistry.ts
@@ -13,7 +13,7 @@ import { createStartGameTool } from "./tools/StartGameTool.ts";
 import { createEvalTool } from "./tools/EvalTool.ts";
 
 /**
- * Manages the lifecycle of WebMCP tools registered with `navigator.modelContext`.
+ * Manages the lifecycle of WebMCP tools registered with `document.modelContext`.
  *
  * Different sets of tools are registered depending on the current game state:
  * - **Intro / GameOver**: only `start_game`
@@ -44,11 +44,11 @@ export class ToolRegistry {
   constructor(game: Game) {
     this.game = game;
     this.supported =
-      typeof navigator !== "undefined" && !!navigator.modelContext;
+      !!document.modelContext || !!navigator.modelContext;
 
     if (!this.supported) {
       console.warn(
-        "WebMCP (navigator.modelContext) is not available in this browser.",
+        "WebMCP (modelContext) is not available in this browser.",
       );
       return;
     }
@@ -101,7 +101,7 @@ export class ToolRegistry {
    */
   private provideTools(tools: ModelContextTool[]): void {
     if (this.supported) {
-      const ctx = navigator.modelContext!;
+      const ctx = document.modelContext || navigator.modelContext!;
       this.toolController?.abort();
       this.toolController = new AbortController();
       for (const tool of tools) {


### PR DESCRIPTION
Following https://github.com/webmachinelearning/webmcp/pull/184/ and https://chromium-review.googlesource.com/c/chromium/src/+/7867800, this PR uses `document.modelContext` instead of the deprecated `navigator.modelContext` when available.