### PR TITLE
Add webmcp.cool to AWESOME_WEBMCP.md

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -57,6 +57,8 @@ A curated list of awesome WebMCP demos.
   - **Example Prompt:** "Find a handmade leather bag, check if they have a 30-day return policy, and if yes, add the brown one to my cart"
 - [WebMCP Smart Home](https://googlechromelabs.github.io/webmcp-tools/demos/smart-home) - A sleek, interactive dashboard where an AI agent can dynamically reconfigure home control components (e.g., front door cameras, thermostats, smart lights, energy distribution) based on user intents.
   - **Example Prompt:** "Someone is at the door. Show me."
+- [webmcp.cool](https://webmcp.cool/) - A live, curated directory of WebMCP-enabled websites. Each entry surfaces the site's real `navigator.modelContext` tools (name, kind, impl, description, JSON schema) exactly as an agent would see them, with a public agent-facing JSON API at [`/api/v1/sites`](https://webmcp.cool/api-docs) for programmatic discovery. The directory itself also exposes WebMCP tools (`about`, `request_listing`, `surprise_me`, `share_on_x`, `share_on_linkedin`) so an agent can list a new site or learn about the registry through tool calls.
+  - **Example Prompt:** "List my site `https://example.com` in the WebMCP directory using my email `me@example.com`."
 
 ## Contributing
 


### PR DESCRIPTION
## What

Adds a single entry for [webmcp.cool](https://webmcp.cool/) to `AWESOME_WEBMCP.md`.

## Why

webmcp.cool is a live, curated directory of websites that ship WebMCP tools via `navigator.modelContext`. For each listed site, it surfaces the real tool definitions (name, kind, impl, description, JSON schema) exactly as an agent would see them — useful as a reference for spec-compliant `registerTool` usage in the wild, and as a discovery surface for the ecosystem this list catalogs.

In addition to being a directory, it exposes its own small set of WebMCP tools on the homepage so agents can interact with the registry itself:

- `about` — get a description of the directory
- `request_listing` — submit a new site for inclusion
- `surprise_me` — generate a pixel-art "fossil" (whimsy)
- `share_on_x`, `share_on_linkedin` — open a pre-filled share composer

There is also a public, agent-facing JSON API at `/api/v1/sites`, `/api/v1/sites/{host}`, `/api/v1/tools`, `/api/v1/stats`, etc., advertised on the home page via `<link rel="alternate" type="application/json">`. Full docs: <https://webmcp.cool/api-docs>. OpenAPI 3.1 spec: <https://webmcp.cool/api/openapi.json>.

## Entry placement

Appended at the end of the `Demos` section (just before `## Contributing`), matching the conventions used by recent additions like `WebMCP Bridge` and `AI Audit` — sites that themselves expose WebMCP tools and serve a broader ecosystem purpose.

## Verification

- Site live, returns HTTP 200, ships a valid CSP and HSTS.
- `GET /api/v1/stats` returns `{ ok: true, sites: 31, tools: 143, ... }` at the time of writing.
- `GET /api/v1/sites/webmcp.cool/tools` confirms the 5 self-registered tools listed in the entry, each with a `description` and `inputSchema`.

## Note on CLA

Per `CONTRIBUTING.md`, this contribution needs to be covered by the Google CLA. I (the contributor, idan@nekuda.ai) will sign when the bot prompts.