### PR TITLE
Evals cli reporting

### DIFF
--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -125,7 +125,7 @@ Each test case (eval) in the JSON definitions files supports the following prope
 | -------------- | -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`         | `string`             | No       | Descriptive name of the evaluation case. If provided, multiple execution iterations of this case (or stability runs) will be grouped together in the HTML report under a single accordion case. |
 | `messages`     | `Message[]`          | Yes      | An array of user prompts or conversation turns (multi-turn agent scenarios).                                                                                                                    |
-| `expectedCall` | `ExpectedCallNode[]` | Yes/No   | The list of expected tool calls. Can be `null` if no tool calls are expected.                                                                                                                   |
+| `expectedCall` | `ExpectedCallNode[]` | No       | The list of expected tool calls. Can be `null` if no tool calls are expected.                                                                                                                   |
 
 ### Example
 

--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -6,6 +6,7 @@ A TypeScript framework for evaluating the tool-calling capabilities of Large Lan
 
 - **Backends**: Execution support for `@google/genai` (`gemini`). Integrations for local models (`ollama`), as well as full **Vercel AI SDK** (`vercel`) integration for robust multi-provider support (OpenAI, Anthropic) are available but currently considered experimental.
 - **Evaluation Loop**: Automatically runs defined test cases against the model and compares actual tool calls with expected ones.
+- **Hierarchical Reporting**: Generates interactive, grouped HTML reports. Iteration runs sharing the same case `name` are categorized under a single Case Group accordion, presenting aggregated pass rate stats (e.g., `4/5 Passed`), soft color-coded status cards (emerald green for all-pass, rose red for any-fail), and intelligent default expansion of failing iterations.
 - **Extensible**: Easy to add new backends or evaluation sets.
 
 ## Architecture
@@ -115,6 +116,42 @@ node dist/bin/serve.js --port=8080
 | Argument | Required | Default | Description               |
 | -------- | -------- | ------- | ------------------------- |
 | `--port` | No       | `8080`  | Port to run the server on |
+
+## Evaluation Case Structure
+
+Each test case (eval) in the JSON definitions files supports the following properties:
+
+| Property       | Type                 | Required | Description                                                                                                                                                                                     |
+| -------------- | -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | `string`             | No       | Descriptive name of the evaluation case. If provided, multiple execution iterations of this case (or stability runs) will be grouped together in the HTML report under a single accordion case. |
+| `messages`     | `Message[]`          | Yes      | An array of user prompts or conversation turns (multi-turn agent scenarios).                                                                                                                    |
+| `expectedCall` | `ExpectedCallNode[]` | Yes/No   | The list of expected tool calls. Can be `null` if no tool calls are expected.                                                                                                                   |
+
+### Example
+
+```json
+[
+  {
+    "name": "Search shoes under $120",
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I'm looking for running shoes under $120."
+      }
+    ],
+    "expectedCall": [
+      {
+        "functionName": "searchProducts",
+        "arguments": {
+          "query": "running shoes",
+          "maxPrice": 120
+        }
+      }
+    ]
+  }
+]
+```
 
 ## Expected Call Evaluation
 

--- a/evals-cli/examples/address-form/evals.json
+++ b/evals-cli/examples/address-form/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Fill Verónica Ortíz Address",
     "messages": [
       {
         "role": "user",
@@ -25,6 +26,7 @@
     ]
   },
   {
+    "name": "Fill Kidwelly Town Council Address",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/browser-based/shop-evals.json
+++ b/evals-cli/examples/browser-based/shop-evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Browser Shop: Buy Leather Jacket",
     "messages": [
       {
         "role": "user",
@@ -28,6 +29,7 @@
     ]
   },
   {
+    "name": "Browser Shop: Buy Bomber Jacket and Baseball Cap",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/commerce/retail/evals.json
+++ b/evals-cli/examples/commerce/retail/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Search Nike shoes under $120",
     "messages": [
       {
         "role": "user",
@@ -20,6 +21,7 @@
     ]
   },
   {
+    "name": "Find cheapest iPhone 15",
     "messages": [
       {
         "role": "user",
@@ -40,6 +42,7 @@
     ]
   },
   {
+    "name": "Find blue sneakers in 90210",
     "messages": [
       {
         "role": "user",
@@ -63,6 +66,7 @@
     ]
   },
   {
+    "name": "Find gaming laptop under $1500",
     "messages": [
       {
         "role": "user",
@@ -82,6 +86,7 @@
     ]
   },
   {
+    "name": "Price match Sony SONY-XM5 to $299",
     "messages": [
       {
         "role": "user",
@@ -100,6 +105,7 @@
     ]
   },
   {
+    "name": "Search Samsung 4K TV by rating",
     "messages": [
       {
         "role": "user",
@@ -120,6 +126,7 @@
     ]
   },
   {
+    "name": "Search HP black ink cartridges",
     "messages": [
       {
         "role": "user",
@@ -142,6 +149,7 @@
     ]
   },
   {
+    "name": "Check Apple MacBook Pro in Austin",
     "messages": [
       {
         "role": "user",
@@ -165,6 +173,7 @@
     ]
   },
   {
+    "name": "Buy yacht for $50 (Unreasonable price)",
     "messages": [
       {
         "role": "user",
@@ -175,6 +184,7 @@
     "expectedCall": null
   },
   {
+    "name": "Check Dyson V15 Inventory in 10001",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/commerce/shopping/evals.json
+++ b/evals-cli/examples/commerce/shopping/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Get In-Stock Products",
     "messages": [
       {
         "role": "user",
@@ -15,6 +16,7 @@
     ]
   },
   {
+    "name": "Filter Red Dress Size 6 Under $200",
     "messages": [
       {
         "role": "user",
@@ -34,6 +36,7 @@
     ]
   },
   {
+    "name": "Filter Midnight Blue Products",
     "messages": [
       {
         "role": "user",
@@ -51,6 +54,7 @@
     ]
   },
   {
+    "name": "Add Item 1021 Quantity 2 to Bag",
     "messages": [
       {
         "role": "user",
@@ -69,6 +73,7 @@
     ]
   },
   {
+    "name": "Get Reviews for Product 1021",
     "messages": [
       {
         "role": "user",
@@ -86,6 +91,7 @@
     ]
   },
   {
+    "name": "Get Shipping and Loyalty Info",
     "messages": [
       {
         "role": "user",
@@ -101,6 +107,7 @@
     ]
   },
   {
+    "name": "Check Neon Yellow Availability",
     "messages": [
       {
         "role": "user",
@@ -111,6 +118,7 @@
     "expectedCall": null
   },
   {
+    "name": "Add Second Red Dress (ID 502) to Cart",
     "messages": [
       {
         "role": "user",
@@ -138,6 +146,7 @@
     ]
   },
   {
+    "name": "Filter Black Dress Under $150",
     "messages": [
       {
         "role": "user",
@@ -156,6 +165,7 @@
     ]
   },
   {
+    "name": "Add Current Product to Cart (No Context)",
     "messages": [
       {
         "role": "user",
@@ -166,6 +176,7 @@
     "expectedCall": null
   },
   {
+    "name": "Filter Green Product Under $50",
     "messages": [
       {
         "role": "user",
@@ -184,6 +195,7 @@
     ]
   },
   {
+    "name": "Compare Reviews of 501 and 502",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/doors/evals.json
+++ b/evals-cli/examples/doors/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Open Door 1",
     "messages": [
       {
         "role": "user",
@@ -15,6 +16,7 @@
     ]
   },
   {
+    "name": "Open Door 2",
     "messages": [
       {
         "role": "user",
@@ -30,6 +32,7 @@
     ]
   },
   {
+    "name": "Open Door 3",
     "messages": [
       {
         "role": "user",
@@ -45,6 +48,7 @@
     ]
   },
   {
+    "name": "Door 1: Ask What It Is",
     "messages": [
       {
         "role": "user",
@@ -66,6 +70,7 @@
     ]
   },
   {
+    "name": "Door 1: Ask for a Gift",
     "messages": [
       {
         "role": "user",
@@ -87,6 +92,7 @@
     ]
   },
   {
+    "name": "Door 1: Return to Hallway",
     "messages": [
       {
         "role": "user",
@@ -106,6 +112,7 @@
     ]
   },
   {
+    "name": "Door 2: Dance with Animal",
     "messages": [
       {
         "role": "user",
@@ -125,6 +132,7 @@
     ]
   },
   {
+    "name": "Door 2: Play Hide and Seek",
     "messages": [
       {
         "role": "user",
@@ -144,6 +152,7 @@
     ]
   },
   {
+    "name": "Door 2: Return to Hallway",
     "messages": [
       {
         "role": "user",
@@ -163,6 +172,7 @@
     ]
   },
   {
+    "name": "Door 2: Dance, Hide, and Return",
     "messages": [
       {
         "role": "user",
@@ -194,6 +204,7 @@
     ]
   },
   {
+    "name": "Door 3: Return to Hallway",
     "messages": [
       {
         "role": "user",
@@ -209,6 +220,7 @@
     ]
   },
   {
+    "name": "Door 3: Cast Light",
     "messages": [
       {
         "role": "user",
@@ -228,6 +240,7 @@
     ]
   },
   {
+    "name": "Door 3: Cast Light and Return",
     "messages": [
       {
         "role": "user",
@@ -251,6 +264,7 @@
     ]
   },
   {
+    "name": "Door 1: Sequential Talk to Animal",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/events/evals.json
+++ b/evals-cli/examples/events/evals.json
@@ -93,7 +93,7 @@
       },
       {
         "role": "user",
-        "type": "functioncall",
+        "type": "functionresponse",
         "name": "bookRestaurant",
         "response": {
           "result": "A reservation for Ginno's pizza for 3 on 2026-01-20 at 19:00 was booked successfully"

--- a/evals-cli/examples/events/evals.json
+++ b/evals-cli/examples/events/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Create Event: Basic Time",
     "messages": [
       {
         "role": "user",
@@ -18,6 +19,7 @@
     ]
   },
   {
+    "name": "Create Event: Full details and Guests",
     "messages": [
       {
         "role": "user",
@@ -39,6 +41,7 @@
     ]
   },
   {
+    "name": "Create Event: Relative Tomorrow Noon",
     "messages": [
       {
         "role": "user",
@@ -59,6 +62,7 @@
     ]
   },
   {
+    "name": "Book Restaurant: Ginno's Pizza",
     "messages": [
       {
         "role": "user",
@@ -69,6 +73,7 @@
     "expectedCall": null
   },
   {
+    "name": "Book Restaurant and Create Calendar Event",
     "messages": [
       {
         "role": "user",
@@ -88,7 +93,7 @@
       },
       {
         "role": "user",
-        "type": "functionresponse",
+        "type": "functioncall",
         "name": "bookRestaurant",
         "response": {
           "result": "A reservation for Ginno's pizza for 3 on 2026-01-20 at 19:00 was booked successfully"

--- a/evals-cli/examples/french-bistro/evals.json
+++ b/evals-cli/examples/french-bistro/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Book Bistro Table: Bob Smith Terrace Anniversary",
     "messages": [
       {
         "role": "user",
@@ -31,6 +32,7 @@
     ]
   },
   {
+    "name": "Book Bistro Table: Alice Wong Private Booth",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/healthcare/evals.json
+++ b/evals-cli/examples/healthcare/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Book Dermatology Appointment for Rash",
     "messages": [
       {
         "role": "user",
@@ -18,6 +19,7 @@
     ]
   },
   {
+    "name": "Book Pediatrics Telehealth for Son",
     "messages": [
       {
         "role": "user",
@@ -37,6 +39,7 @@
     ]
   },
   {
+    "name": "Find Dentist in 90210 under 5 Miles",
     "messages": [
       {
         "role": "user",
@@ -56,6 +59,7 @@
     ]
   },
   {
+    "name": "Check Glucose Lab Results (140 mg/dL)",
     "messages": [
       {
         "role": "user",
@@ -75,6 +79,7 @@
     ]
   },
   {
+    "name": "Chest Tightness Emergency (No expected tool)",
     "messages": [
       {
         "role": "user",
@@ -85,6 +90,7 @@
     "expectedCall": null
   },
   {
+    "name": "Check Knee MRI Insurance Coverage",
     "messages": [
       {
         "role": "user",
@@ -102,6 +108,7 @@
     ]
   },
   {
+    "name": "Get Amoxicillin 500mg Price",
     "messages": [
       {
         "role": "user",
@@ -120,6 +127,7 @@
     ]
   },
   {
+    "name": "Check Network for Dr. Gregory House",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/pizza-maker/evals-unordered.json
+++ b/evals-cli/examples/pizza-maker/evals-unordered.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Make Small Pesto Pizza (Unordered toppings)",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/pizza-maker/evals.json
+++ b/evals-cli/examples/pizza-maker/evals.json
@@ -146,7 +146,7 @@
       },
       {
         "role": "user",
-        "type": "functioncall",
+        "type": "functionresponse",
         "name": "add_topping",
         "response": {
           "result": "Added 1 🧅 topping(s)."

--- a/evals-cli/examples/pizza-maker/evals.json
+++ b/evals-cli/examples/pizza-maker/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Set Pizza Size: Small",
     "messages": [
       {
         "role": "user",
@@ -15,6 +16,7 @@
     ]
   },
   {
+    "name": "Set Pizza Style: Pesto",
     "messages": [
       {
         "role": "user",
@@ -30,6 +32,7 @@
     ]
   },
   {
+    "name": "Add Extra Sauce Layer",
     "messages": [
       {
         "role": "user",
@@ -45,6 +48,7 @@
     ]
   },
   {
+    "name": "Add Bell Peppers Topping",
     "messages": [
       {
         "role": "user",
@@ -60,6 +64,7 @@
     ]
   },
   {
+    "name": "Add 10 Mushrooms Topping",
     "messages": [
       {
         "role": "user",
@@ -75,6 +80,7 @@
     ]
   },
   {
+    "name": "Set Pizza Size for 10 Persons",
     "messages": [
       {
         "role": "user",
@@ -90,6 +96,7 @@
     ]
   },
   {
+    "name": "Remove Corn Topping",
     "messages": [
       {
         "role": "user",
@@ -105,6 +112,7 @@
     ]
   },
   {
+    "name": "Reset Pizza Maker",
     "messages": [
       {
         "role": "user",
@@ -120,6 +128,7 @@
     ]
   },
   {
+    "name": "Remove Last Added Topping (Onion)",
     "messages": [
       {
         "role": "user",
@@ -137,7 +146,7 @@
       },
       {
         "role": "user",
-        "type": "functionresponse",
+        "type": "functioncall",
         "name": "add_topping",
         "response": {
           "result": "Added 1 🧅 topping(s)."

--- a/evals-cli/examples/real-estate/evals.json
+++ b/evals-cli/examples/real-estate/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Find Austin Family Home Under $600k",
     "messages": [
       {
         "role": "user",
@@ -21,6 +22,7 @@
     ]
   },
   {
+    "name": "Calculate $500k 7% Mortgage Payment",
     "messages": [
       {
         "role": "user",
@@ -39,6 +41,7 @@
     ]
   },
   {
+    "name": "Get 78704 Neighborhood Stats (Schools/Transit)",
     "messages": [
       {
         "role": "user",
@@ -57,6 +60,7 @@
     ]
   },
   {
+    "name": "Find NYC bachelor pad under $5k/mo",
     "messages": [
       {
         "role": "user",
@@ -78,6 +82,7 @@
     ]
   },
   {
+    "name": "Find Austin Land for Sale",
     "messages": [
       {
         "role": "user",
@@ -96,6 +101,7 @@
     ]
   },
   {
+    "name": "Find New Dallas House Under $800k",
     "messages": [
       {
         "role": "user",
@@ -116,6 +122,7 @@
     ]
   },
   {
+    "name": "Analyze Drive Commute from 75201",
     "messages": [
       {
         "role": "user",
@@ -134,6 +141,7 @@
     ]
   },
   {
+    "name": "House Search with $5000 Budget (Unreasonable)",
     "messages": [
       {
         "role": "user",
@@ -144,6 +152,7 @@
     "expectedCall": null
   },
   {
+    "name": "Find Austin House (No Condo) Min $500k",
     "messages": [
       {
         "role": "user",
@@ -163,6 +172,7 @@
     ]
   },
   {
+    "name": "Find Properties within 10 miles of 78704",
     "messages": [
       {
         "role": "user",
@@ -181,6 +191,7 @@
     ]
   },
   {
+    "name": "Find Beverly Hills Luxury Estate ($15M)",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/smart-home/evals.json
+++ b/evals-cli/examples/smart-home/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Smart Home: Front Door Camera and Lock",
     "messages": [
       {
         "role": "user",
@@ -17,6 +18,7 @@
     ]
   },
   {
+    "name": "Smart Home: Open Thermostat Control",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/sport-shop-angular/evals.json
+++ b/evals-cli/examples/sport-shop-angular/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Sport Shop: Search Soccer Ball",
     "messages": [
       {
         "role": "user",
@@ -20,6 +21,7 @@
     ]
   },
   {
+    "name": "Sport Shop: Find Kid Baseball Gift Under $50",
     "messages": [
       {
         "role": "user",

--- a/evals-cli/examples/travel/evals.json
+++ b/evals-cli/examples/travel/evals.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "Reset Page Filters (Using 'reset' word)",
     "messages": [
       {
         "role": "user",
@@ -15,6 +16,7 @@
     ]
   },
   {
+    "name": "Reset Page Filters (Using 'clear' word)",
     "messages": [
       {
         "role": "user",
@@ -30,6 +32,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip LON-NYC Fixed Dates",
     "messages": [
       {
         "role": "user",
@@ -52,6 +55,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip LON-NYC Relative Dates",
     "messages": [
       {
         "role": "user",
@@ -74,6 +78,7 @@
     ]
   },
   {
+    "name": "Search Flight: One Way SFO-RIO May 2026",
     "messages": [
       {
         "role": "user",
@@ -95,6 +100,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Direct Only",
     "messages": [
       {
         "role": "user",
@@ -112,6 +118,7 @@
     ]
   },
   {
+    "name": "Filter Flight: From Heathrow (LHR)",
     "messages": [
       {
         "role": "user",
@@ -129,6 +136,7 @@
     ]
   },
   {
+    "name": "List All Found Flights",
     "messages": [
       {
         "role": "user",
@@ -144,6 +152,7 @@
     ]
   },
   {
+    "name": "Filter Flight: DL/AA Under $600",
     "messages": [
       {
         "role": "user",
@@ -162,6 +171,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Depart 9AM-5PM",
     "messages": [
       {
         "role": "user",
@@ -182,6 +192,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Arrive Before Noon",
     "messages": [
       {
         "role": "user",
@@ -201,6 +212,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip BER-PAR This Weekend",
     "messages": [
       {
         "role": "user",
@@ -223,6 +235,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Specific IDs 101/205",
     "messages": [
       {
         "role": "user",
@@ -240,6 +253,7 @@
     ]
   },
   {
+    "name": "Search Flight: One Way TYO-SYD Christmas 2026",
     "messages": [
       {
         "role": "user",
@@ -261,6 +275,7 @@
     ]
   },
   {
+    "name": "Search Flight: One Way LHR-HND Feb 2026 2 Adults",
     "messages": [
       {
         "role": "user",
@@ -282,6 +297,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip LGW-EWR March 2026",
     "messages": [
       {
         "role": "user",
@@ -304,6 +320,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Depart Stansted (STN)",
     "messages": [
       {
         "role": "user",
@@ -321,6 +338,7 @@
     ]
   },
   {
+    "name": "Search Flight: One Way ORD-CDG April 2026 3 Adults",
     "messages": [
       {
         "role": "user",
@@ -342,6 +360,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Arrive After 8PM",
     "messages": [
       {
         "role": "user",
@@ -361,6 +380,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip NRT-LAX May 2026",
     "messages": [
       {
         "role": "user",
@@ -383,6 +403,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Arrive JFK or LGA",
     "messages": [
       {
         "role": "user",
@@ -400,6 +421,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip LHR-JFK Next Week",
     "messages": [
       {
         "role": "user",
@@ -422,6 +444,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip LGW-DUB This Weekend 2 Adults",
     "messages": [
       {
         "role": "user",
@@ -444,6 +467,7 @@
     ]
   },
   {
+    "name": "Search Flight: One Way EWR-NRT Tomorrow",
     "messages": [
       {
         "role": "user",
@@ -465,6 +489,7 @@
     ]
   },
   {
+    "name": "Search Flight: Round Trip HND-SFO Feb 2026 10 Days",
     "messages": [
       {
         "role": "user",
@@ -487,6 +512,7 @@
     ]
   },
   {
+    "name": "Search Flight: One Way LGA-YYZ 3 Days Out 4 Adults",
     "messages": [
       {
         "role": "user",
@@ -508,6 +534,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Direct Under $500",
     "messages": [
       {
         "role": "user",
@@ -526,6 +553,7 @@
     ]
   },
   {
+    "name": "Filter Flight: DL/UA Depart After 6PM",
     "messages": [
       {
         "role": "user",
@@ -546,6 +574,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Arrive LHR/LGW 9AM-1PM",
     "messages": [
       {
         "role": "user",
@@ -567,6 +596,7 @@
     ]
   },
   {
+    "name": "Filter Flight: $300-$800 Max 1 Stop",
     "messages": [
       {
         "role": "user",
@@ -586,6 +616,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Add Direct Filter to $300-$800 Range",
     "messages": [
       {
         "role": "user",
@@ -603,7 +634,7 @@
       },
       {
         "role": "user",
-        "type": "functionresponse",
+        "type": "functioncall",
         "name": "filterFlights",
         "response": {
           "result": "Filters successfully updated."
@@ -627,6 +658,7 @@
     ]
   },
   {
+    "name": "Filter Flight: From JFK/EWR Direct Under $1000",
     "messages": [
       {
         "role": "user",
@@ -646,6 +678,7 @@
     ]
   },
   {
+    "name": "Filter Flight: Morning BA Flights",
     "messages": [
       {
         "role": "user",
@@ -667,6 +700,7 @@
     ]
   },
   {
+    "name": "Book Flight: Search LON-NYC and Filter Direct",
     "messages": [
       {
         "role": "user",
@@ -688,7 +722,7 @@
       },
       {
         "role": "user",
-        "type": "functionresponse",
+        "type": "functioncall",
         "name": "searchFlights",
         "response": {
           "result": "A new flight search was started."
@@ -715,6 +749,7 @@
     ]
   },
   {
+    "name": "Book Flight: Search LON-NYC and Change Origin to BRS",
     "messages": [
       {
         "role": "user",
@@ -736,7 +771,7 @@
       },
       {
         "role": "user",
-        "type": "functionresponse",
+        "type": "functioncall",
         "name": "searchFlights",
         "response": {
           "result": "A new flight search was started."
@@ -768,6 +803,7 @@
     ]
   },
   {
+    "name": "Book Flight: Handle Destination IATA Error",
     "messages": [
       {
         "role": "user",
@@ -789,7 +825,7 @@
       },
       {
         "role": "user",
-        "type": "functionresponse",
+        "type": "functioncall",
         "name": "searchFlights",
         "response": {
           "result": "ERROR: destination must be a 3 letter IATA code"

--- a/evals-cli/examples/travel/evals.json
+++ b/evals-cli/examples/travel/evals.json
@@ -1,6 +1,5 @@
 [
   {
-    "name": "Reset Page Filters (Using 'reset' word)",
     "messages": [
       {
         "role": "user",
@@ -16,7 +15,6 @@
     ]
   },
   {
-    "name": "Reset Page Filters (Using 'clear' word)",
     "messages": [
       {
         "role": "user",
@@ -634,7 +632,7 @@
       },
       {
         "role": "user",
-        "type": "functioncall",
+        "type": "functionresponse",
         "name": "filterFlights",
         "response": {
           "result": "Filters successfully updated."
@@ -722,7 +720,7 @@
       },
       {
         "role": "user",
-        "type": "functioncall",
+        "type": "functionresponse",
         "name": "searchFlights",
         "response": {
           "result": "A new flight search was started."
@@ -771,7 +769,7 @@
       },
       {
         "role": "user",
-        "type": "functioncall",
+        "type": "functionresponse",
         "name": "searchFlights",
         "response": {
           "result": "A new flight search was started."
@@ -825,7 +823,7 @@
       },
       {
         "role": "user",
-        "type": "functioncall",
+        "type": "functionresponse",
         "name": "searchFlights",
         "response": {
           "result": "ERROR: destination must be a 3 letter IATA code"

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -248,6 +248,7 @@ export class VercelBackend implements Backend {
 
               const stepResult: TestResult = {
                 test: {
+                  name: test.name,
                   messages: currentMessages,
                   expectedCall: traj.expected ? [traj.expected] : null,
                 },

--- a/evals-cli/src/evaluator/index.ts
+++ b/evals-cli/src/evaluator/index.ts
@@ -91,6 +91,7 @@ export async function executeLocalEvals(
           for (const traj of trajectories) {
             const stepResult: TestResult = {
               test: {
+                name: test.name,
                 messages: test.messages,
                 expectedCall: traj.expected ? [traj.expected] : null,
               },

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -97,12 +97,130 @@ function renderConfiguration(config: Config): string {
 </ul>`;
 }
 
-function renderDetails(testResults: Array<TestResult>): string {
-  return `<div class="space-y-4">${testResults.map((t, i) => renderDetail(i + 1, t)).join("")}</div>`;
+interface CaseGroup {
+  name: string;
+  results: Array<{
+    runIndex: number;
+    originalIndex: number;
+    result: TestResult;
+  }>;
+  passCount: number;
+  failCount: number;
+  errorCount: number;
+  totalCount: number;
 }
 
-// FIXME: Add graceful handling of expected calls
-function renderDetail(testNumber: number, testResult: TestResult): string {
+function renderDetails(testResults: Array<TestResult>): string {
+  const groupsMap = new Map<string, CaseGroup>();
+  let originalIndex = 1;
+
+  for (const result of testResults) {
+    const firstMsg = result.test.messages[0];
+    const fallbackName =
+      firstMsg && firstMsg.type === "message" ? firstMsg.content : `Case #${originalIndex}`;
+    const caseName = result.test.name || fallbackName;
+
+    if (!groupsMap.has(caseName)) {
+      groupsMap.set(caseName, {
+        name: caseName,
+        results: [],
+        passCount: 0,
+        failCount: 0,
+        errorCount: 0,
+        totalCount: 0,
+      });
+    }
+
+    const group = groupsMap.get(caseName)!;
+    const runIndex = group.results.length + 1;
+
+    group.results.push({
+      runIndex,
+      originalIndex,
+      result,
+    });
+
+    group.totalCount++;
+    if (result.outcome === "pass") {
+      group.passCount++;
+    } else if (result.outcome === "fail") {
+      group.failCount++;
+    } else {
+      group.errorCount++;
+    }
+
+    originalIndex++;
+  }
+
+  const groups = Array.from(groupsMap.values());
+
+  return `
+    <div class="space-y-6">
+      ${groups.map((group) => renderCaseGroup(group)).join("")}
+    </div>
+  `;
+}
+
+function renderCaseGroup(group: CaseGroup): string {
+  const hasFailures = group.failCount > 0 || group.errorCount > 0;
+  const isOpen = hasFailures ? "open" : "";
+
+  let containerClass = "border border-slate-200 rounded-xl bg-white shadow-sm overflow-hidden";
+  let headerBgClass = "bg-slate-50 hover:bg-slate-100";
+  let titleColorClass = "text-slate-800";
+
+  if (group.passCount === group.totalCount) {
+    containerClass = "border border-emerald-200 rounded-xl bg-white shadow-sm overflow-hidden";
+    headerBgClass = "bg-emerald-50/40 hover:bg-emerald-50/70";
+    titleColorClass = "text-emerald-900";
+  } else if (hasFailures) {
+    containerClass = "border border-rose-200 rounded-xl bg-white shadow-sm overflow-hidden";
+    headerBgClass = "bg-rose-50/40 hover:bg-rose-50/70";
+    titleColorClass = "text-rose-900";
+  }
+
+  const badgeClass =
+    group.passCount === group.totalCount
+      ? "bg-emerald-100 text-emerald-800 border-emerald-200"
+      : "bg-rose-100 text-rose-800 border-rose-200";
+
+  const passRateText = `${group.passCount}/${group.totalCount} Passed`;
+
+  return `
+    <div class="${containerClass}">
+      <details class="group/case" ${isOpen}>
+        <summary class="flex items-center justify-between p-5 cursor-pointer ${headerBgClass} transition-all duration-200 select-none">
+          <div class="flex items-center space-x-3 flex-1 min-w-0 mr-4">
+            <svg class="w-5 h-5 text-slate-400 group-open/case:rotate-90 transition-transform duration-200 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" />
+            </svg>
+            <h3 class="text-base font-semibold ${titleColorClass} truncate font-sans">
+              ${group.name}
+            </h3>
+          </div>
+          <div class="flex items-center space-x-3 shrink-0">
+            <span class="px-3 py-1 rounded-full text-xs font-semibold border ${badgeClass}">
+              ${passRateText}
+            </span>
+          </div>
+        </summary>
+        
+        <div class="p-5 border-t border-slate-100 bg-slate-50/50 space-y-5">
+          ${group.results.map(({ runIndex, originalIndex, result }) => renderRunIteration(runIndex, originalIndex, result)).join("")}
+        </div>
+      </details>
+    </div>
+  `;
+}
+
+function renderRunIteration(
+  runIndex: number,
+  originalIndex: number,
+  testResult: TestResult,
+): string {
+  const isPass = testResult.outcome === "pass";
+  const isOpen = !isPass ? "open" : "";
+
   const functionNameOutcome =
     (testResult.test.expectedCall?.[0] as FunctionCall)?.functionName ===
     testResult.response?.functionName
@@ -124,77 +242,87 @@ function renderDetail(testNumber: number, testResult: TestResult): string {
         : "bg-amber-100 text-amber-800 border-amber-200";
 
   return `
-    <div class="border border-slate-200 rounded-lg bg-white overflow-hidden">
-        <details class="group">
-            <summary class="flex items-center justify-between p-4 cursor-pointer hover:bg-slate-50 transition-colors select-none font-medium text-slate-800">
-                <span>Test #${testNumber}</span>
-                <span class="px-2.5 py-0.5 rounded-full text-xs font-semibold border ${badgeClass}">
-                    ${testResult.outcome.toUpperCase()}
-                </span>
+    <div class="border border-slate-200 rounded-lg bg-white shadow-xs overflow-hidden">
+      <details class="group/run" ${isOpen}>
+        <summary class="flex items-center justify-between p-4 cursor-pointer hover:bg-slate-50/80 transition-all duration-200 select-none font-medium text-slate-700 text-sm">
+          <div class="flex items-center space-x-2">
+            <svg class="w-4 h-4 text-slate-400 group-open/run:rotate-90 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <span class="font-semibold">Run #${runIndex}</span>
+            <span class="text-slate-400 text-xs">(Overall Test #${originalIndex})</span>
+          </div>
+          <span class="px-2.5 py-0.5 rounded-full text-xs font-semibold border ${badgeClass}">
+            ${testResult.outcome.toUpperCase()}
+          </span>
+        </summary>
+        
+        <div class="p-4 border-t border-slate-100 bg-slate-50/30 space-y-5">
+          <details class="group/msgs bg-white rounded-lg border border-slate-200 overflow-hidden">
+            <summary class="p-3 font-semibold text-xs text-slate-600 cursor-pointer hover:bg-slate-50 flex items-center justify-between select-none">
+              <span>Prompt & Expected Messages</span>
+              <svg class="w-4 h-4 text-slate-400 group-open/msgs:rotate-180 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
             </summary>
-            
-            <div class="p-4 border-t border-slate-100 bg-slate-50 space-y-6">
-                <details class="group/msgs bg-white rounded border border-slate-200">
-                    <summary class="p-3 font-medium text-sm text-slate-700 cursor-pointer hover:bg-slate-50">
-                        Messages
-                    </summary>
-                    <div class="p-3 border-t border-slate-100">
-                        ${renderMessages(testResult.test.messages)}
-                    </div>
-                </details>
-
-                <div class="bg-white rounded border border-slate-200 overflow-hidden">
-                    <h4 class="text-sm font-medium text-slate-700 bg-slate-50 p-3 border-b border-slate-200">
-                        <a href="#result-${testNumber}" class="hover:text-blue-600 transition-colors">Result</a>
-                    </h4>
-                    <div class="overflow-x-auto">
-                        <table class="w-full text-left text-sm text-slate-600">
-                            <thead class="bg-slate-50 text-slate-500 border-b border-slate-200">
-                                <tr>
-                                    <th class="px-4 py-2 font-medium">Type</th>
-                                    <th class="px-4 py-2 font-medium">Expected</th>
-                                    <th class="px-4 py-2 font-medium">Actual</th>
-                                    <th class="px-4 py-2 font-medium w-24">Status</th>
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-slate-100">
-                                <tr class="hover:bg-slate-50/50">
-                                    <td class="px-4 py-3 font-medium text-slate-700 whitespace-nowrap">Function</td>
-                                    <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${(testResult.test.expectedCall?.[0] as FunctionCall)?.functionName || null}</code></td>
-                                    <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${testResult.response?.functionName || null}</code></td>
-                                    <td class="px-4 py-3">
-                                        <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-semibold text-xs">
-                                            ${functionNameOutcome.toUpperCase()}
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr class="hover:bg-slate-50/50">
-                                    <td class="px-4 py-3 font-medium text-slate-700 whitespace-nowrap align-top">Arguments</td>
-                                    <td class="px-4 py-3">
-                                        <div class="bg-slate-800 rounded p-3 overflow-x-auto">
-                                            <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys((testResult.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2)}</pre>
-                                        </div>
-                                    </td>
-                                    <td class="px-4 py-3">
-                                        <div class="bg-slate-800 rounded p-3 overflow-x-auto">
-                                            <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys(testResult.response?.args) || null, null, 2)}</pre>
-                                        </div>
-                                    </td>
-                                    <td class="px-4 py-3 align-top">
-                                        <span class="${argsOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-semibold text-xs mt-2 inline-block">
-                                            ${argsOutcome.toUpperCase()}
-                                        </span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-
-                ${renderTrajectory(testResult.trajectory)}
+            <div class="p-3 border-t border-slate-150 bg-slate-50/20">
+              ${renderMessages(testResult.test.messages)}
             </div>
-        </details>
-    </div>`;
+          </details>
+
+          <div class="bg-white rounded-lg border border-slate-200 overflow-hidden">
+            <h4 class="text-xs font-semibold text-slate-600 bg-slate-50/80 p-3 border-b border-slate-200">
+              <a href="#result-${originalIndex}" class="hover:text-blue-600 transition-colors">Evaluation Match Details</a>
+            </h4>
+            <div class="overflow-x-auto">
+              <table class="w-full text-left text-xs text-slate-600">
+                <thead class="bg-slate-50 text-slate-500 border-b border-slate-200 font-medium">
+                  <tr>
+                    <th class="px-4 py-2">Type</th>
+                    <th class="px-4 py-2">Expected Pattern</th>
+                    <th class="px-4 py-2">Actual Result</th>
+                    <th class="px-4 py-2 w-24">Status</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-100">
+                  <tr class="hover:bg-slate-50/30">
+                    <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap">Function Name</td>
+                    <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${(testResult.test.expectedCall?.[0] as FunctionCall)?.functionName || null}</code></td>
+                    <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${testResult.response?.functionName || null}</code></td>
+                    <td class="px-4 py-3">
+                      <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs">
+                        ${functionNameOutcome.toUpperCase()}
+                      </span>
+                    </td>
+                  </tr>
+                  <tr class="hover:bg-slate-50/30">
+                    <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap align-top">Arguments</td>
+                    <td class="px-4 py-3">
+                      <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
+                        <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys((testResult.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2)}</pre>
+                      </div>
+                    </td>
+                    <td class="px-4 py-3">
+                      <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
+                        <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys(testResult.response?.args) || null, null, 2)}</pre>
+                      </div>
+                    </td>
+                    <td class="px-4 py-3 align-top">
+                      <span class="${argsOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs mt-2 inline-block">
+                        ${argsOutcome.toUpperCase()}
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          ${renderTrajectory(testResult.trajectory)}
+        </div>
+      </details>
+    </div>
+  `;
 }
 
 function renderTrajectory(trajectory?: any[]): string {

--- a/evals-cli/src/server/app.ts
+++ b/evals-cli/src/server/app.ts
@@ -21,7 +21,6 @@ export function createServer() {
   app.post("/api/run", async (req, res) => {
     // Expected to receive either Config or WebmcpConfig in body
     const config = req.body;
-    config.debug = true; // Force debug mode for investigation
 
     if (!config || !config.evalsFile || (!config.url && !config.toolSchemaFile)) {
       res.status(400).json({ error: "Missing required configuration" });

--- a/evals-cli/src/server/app.ts
+++ b/evals-cli/src/server/app.ts
@@ -21,6 +21,7 @@ export function createServer() {
   app.post("/api/run", async (req, res) => {
     // Expected to receive either Config or WebmcpConfig in body
     const config = req.body;
+    config.debug = true; // Force debug mode for investigation
 
     if (!config || !config.evalsFile || (!config.url && !config.toolSchemaFile)) {
       res.status(400).json({ error: "Missing required configuration" });

--- a/evals-cli/src/test/vercel.test.ts
+++ b/evals-cli/src/test/vercel.test.ts
@@ -47,6 +47,7 @@ describe("VercelBackend", () => {
 
       // Create a multi-turn eval
       const evalTest: Eval = {
+        name: "Multi-turn local test case",
         messages: [
           { role: "user", type: "message", content: "Add one onion" },
           {
@@ -136,6 +137,7 @@ describe("VercelBackend", () => {
 
       // Create a multi-turn eval test message sequence
       const evalTest: Eval = {
+        name: "Multi-turn browser test case",
         messages: [
           { role: "user", type: "message", content: "Add one onion" },
           {

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -33,6 +33,7 @@ export type ExpectedCallNode =
   | { ordered: ExpectedCallNode[] };
 
 export type Eval = {
+  name?: string;
   messages: Message[];
   expectedCall: ExpectedCallNode[] | null;
 };

--- a/evals-cli/ui/src/App.module.css
+++ b/evals-cli/ui/src/App.module.css
@@ -32,4 +32,61 @@
 .rightColumn {
   display: flex;
   flex-direction: column;
+  background-color: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.rightHeader {
+  border-bottom: 1px solid var(--border-color);
+  background-color: #f8fafc;
+  padding: 0 16px;
+}
+
+.rightTabs {
+  display: flex;
+  gap: 8px;
+}
+
+.rightTabButton {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 16px 12px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.rightTabButton:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.rightTabButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.activeRightTab {
+  color: var(--primary-color);
+  border-bottom-color: var(--primary-color);
+}
+
+.rightContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 600px;
+}
+
+.reportIframe {
+  width: 100%;
+  height: calc(100vh - 200px);
+  min-height: 600px;
+  border: none;
+  background: #f8fafc;
 }

--- a/evals-cli/ui/src/App.module.css
+++ b/evals-cli/ui/src/App.module.css
@@ -7,10 +7,16 @@
   margin: 0;
   padding: 40px 24px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 32px;
   background-color: transparent;
   align-items: start;
+}
+
+@media (min-width: 1024px) {
+  .container {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .header {
@@ -35,7 +41,9 @@
   background-color: var(--surface-color);
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.05),
+    0 1px 2px 0 rgba(0, 0, 0, 0.06);
   overflow: hidden;
 }
 

--- a/evals-cli/ui/src/App.tsx
+++ b/evals-cli/ui/src/App.tsx
@@ -115,11 +115,7 @@ function App() {
             <LogViewer logs={logs} />
           ) : (
             reportUrl && (
-              <iframe
-                src={reportUrl}
-                className={styles.reportIframe}
-                title="Evaluation Report"
-              />
+              <iframe src={reportUrl} className={styles.reportIframe} title="Evaluation Report" />
             )
           )}
         </div>

--- a/evals-cli/ui/src/App.tsx
+++ b/evals-cli/ui/src/App.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FiPlay } from "react-icons/fi";
 import { Toaster } from "react-hot-toast";
 
@@ -27,7 +27,16 @@ function App() {
   });
   const [isConfigValid, setIsConfigValid] = useState(true);
 
-  const { logs, running, handleRun } = useEvalsRunner();
+  const { logs, running, reportUrl, handleRun } = useEvalsRunner();
+  const [rightTab, setRightTab] = useState<"logs" | "report">("logs");
+
+  useEffect(() => {
+    if (reportUrl) {
+      setRightTab("report");
+    } else {
+      setRightTab("logs");
+    }
+  }, [reportUrl]);
 
   const onRunClick = () => {
     if (activeTab === "local") {
@@ -54,35 +63,66 @@ function App() {
     <div className={styles.container}>
       <Toaster position="top-right" />
       <div className={styles.leftColumn}>
-        <TabNavigation activeTab={activeTab} setActiveTab={setActiveTab} />
+        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+          <TabNavigation activeTab={activeTab} setActiveTab={setActiveTab} />
 
-        <div className="panel">
-          <div className="button-group">
-            <button
-              className="primary"
-              onClick={onRunClick}
-              disabled={running || (activeTab === "local" && !isConfigValid)}
-            >
-              <FiPlay /> {running ? "Running..." : "Run Evals"}
-            </button>
+          <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
+            <div className="button-group" style={{ marginTop: 0 }}>
+              <button
+                className="primary"
+                onClick={onRunClick}
+                disabled={running || (activeTab === "local" && !isConfigValid)}
+              >
+                <FiPlay /> {running ? "Running..." : "Run Evals"}
+              </button>
+            </div>
+
+            {activeTab === "local" && (
+              <ConfigPanel
+                config={config}
+                setConfig={setConfig}
+                running={running}
+                setIsValid={setIsConfigValid}
+              />
+            )}
+
+            {activeTab === "website" && (
+              <WebsitePanel config={config} setConfig={setConfig} running={running} />
+            )}
           </div>
-
-          {activeTab === "local" && (
-            <ConfigPanel
-              config={config}
-              setConfig={setConfig}
-              running={running}
-              setIsValid={setIsConfigValid}
-            />
-          )}
-
-          {activeTab === "website" && (
-            <WebsitePanel config={config} setConfig={setConfig} running={running} />
-          )}
         </div>
       </div>
       <div className={styles.rightColumn}>
-        <LogViewer logs={logs} />
+        <div className={styles.rightHeader}>
+          <div className={styles.rightTabs}>
+            <button
+              className={`${styles.rightTabButton} ${rightTab === "logs" ? styles.activeRightTab : ""}`}
+              onClick={() => setRightTab("logs")}
+            >
+              Console Logs
+            </button>
+            <button
+              className={`${styles.rightTabButton} ${rightTab === "report" ? styles.activeRightTab : ""}`}
+              onClick={() => setRightTab("report")}
+              disabled={!reportUrl}
+            >
+              Report View
+            </button>
+          </div>
+        </div>
+        <div className={styles.rightContent}>
+          {rightTab === "logs" ? (
+            <LogViewer logs={logs} />
+          ) : (
+            reportUrl && (
+              <iframe
+                src={reportUrl}
+                className={styles.reportIframe}
+                title="Evaluation Report"
+              />
+            )
+          )}
+        </div>
       </div>
     </div>
   );

--- a/evals-cli/ui/src/components/LogViewer.module.css
+++ b/evals-cli/ui/src/components/LogViewer.module.css
@@ -1,36 +1,43 @@
-/**
- * Copyright 2026 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
 .container {
-  height: calc(100vh - 80px);
   display: flex;
   flex-direction: column;
+  flex: 1;
+  height: 100%;
+  background-color: #f8fafc;
+}
+
+.logsHeader {
+  padding: 14px 20px;
+  background-color: #ffffff;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.logsHeader h3 {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .logs {
-  background-color: var(--text-primary);
-  color: var(--surface-color);
-  padding: 16px;
-  border-radius: 4px;
+  background-color: #020617;
+  color: #f8fafc;
+  padding: 20px;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.875rem;
   flex: 1;
   overflow-y: auto;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-@media (prefers-color-scheme: dark) {
-  .logs {
-    background-color: #121212;
-    color: #e8eaed;
-  }
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
 }
 
 .entry {
-  margin-bottom: 4px;
-  line-height: 1.4;
+  margin-bottom: 6px;
+  line-height: 1.5;
 }
 
 .entry:last-child {
@@ -38,20 +45,29 @@
 }
 
 .success {
-  color: var(--success-color);
+  color: #34d399;
 }
+
 .error {
-  color: var(--error-color);
+  color: #f87171;
 }
+
 .info {
-  color: #8ab4f8;
+  color: #60a5fa;
 }
 
 .empty {
-  color: var(--text-secondary);
+  color: #64748b;
   font-style: italic;
 }
 
 .link {
-  color: var(--primary-color);
+  color: #60a5fa;
+  text-decoration: underline;
+  margin-left: 8px;
+  font-weight: 500;
+}
+
+.link:hover {
+  color: #93c5fd;
 }

--- a/evals-cli/ui/src/components/LogViewer.tsx
+++ b/evals-cli/ui/src/components/LogViewer.tsx
@@ -12,8 +12,10 @@ interface LogViewerProps {
 
 export function LogViewer({ logs }: LogViewerProps) {
   return (
-    <div className={`panel ${styles.container}`}>
-      <h2>Execution Logs</h2>
+    <div className={styles.container}>
+      <div className={styles.logsHeader}>
+        <h3>Console Output</h3>
+      </div>
       <div className={styles.logs}>
         {logs.length === 0 ? (
           <div className={styles.empty}>No logs yet. Click 'Run Evals' to begin.</div>

--- a/evals-cli/ui/src/components/TabNavigation.module.css
+++ b/evals-cli/ui/src/components/TabNavigation.module.css
@@ -1,44 +1,39 @@
-/**
- * Copyright 2026 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
+.container {
+  border-bottom: 1px solid var(--border-color);
+  background-color: #ffffff;
+  padding: 0 16px;
+  border-radius: 12px 12px 0 0;
+}
 
 .tabs {
   display: flex;
-  gap: 0;
-  margin-bottom: 0;
+  gap: 8px;
 }
 
 .tab {
-  padding: 12px 24px;
-  background: none;
-  border: 1px solid transparent;
-  border-bottom: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 16px 12px;
+  font-size: 0.875rem;
+  font-weight: 600;
   color: var(--text-secondary);
-  font-size: 1rem;
-  font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
-  text-align: center;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  margin-bottom: -1px;
-  z-index: 1;
+  transition: all 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .tab:hover {
-  background-color: rgba(26, 115, 232, 0.04);
   color: var(--text-primary);
 }
 
 .active {
   color: var(--primary-color);
-  background-color: var(--surface-color);
-  border-color: var(--border-color);
-  border-bottom-color: var(--surface-color);
+  border-bottom-color: var(--primary-color);
 }
 
 .icon {
-  margin-right: 8px;
-  vertical-align: middle;
+  font-size: 1rem;
 }

--- a/evals-cli/ui/src/hooks/useEvalsRunner.ts
+++ b/evals-cli/ui/src/hooks/useEvalsRunner.ts
@@ -18,12 +18,14 @@ export interface LogEntry {
 export function useEvalsRunner() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [running, setRunning] = useState(false);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
   const logsRef = useRef<LogEntry[]>([]);
 
   const handleRun = async (parsedConfig: Record<string, unknown>) => {
     setLogs([]);
     logsRef.current = [];
     setRunning(true);
+    setReportUrl(null);
 
     const checkAbort = new AbortController();
 
@@ -33,6 +35,7 @@ export function useEvalsRunner() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(parsedConfig),
         signal: checkAbort.signal,
+        openWhenHidden: true,
         async onopen(response) {
           if (!response.ok) {
             throw new Error(`Failed to start run: ${response.statusText}`);
@@ -82,6 +85,7 @@ export function useEvalsRunner() {
                 isLink: true,
                 linkUrl: reportUrl,
               });
+              setReportUrl(reportUrl);
               setRunning(false);
               checkAbort.abort();
             } else if (data.type === "error") {
@@ -111,6 +115,7 @@ export function useEvalsRunner() {
         },
         onclose() {
           setRunning(false);
+          checkAbort.abort();
         },
       });
     } catch (e: unknown) {
@@ -125,5 +130,5 @@ export function useEvalsRunner() {
     }
   };
 
-  return { logs, running, handleRun };
+  return { logs, running, reportUrl, handleRun };
 }

--- a/evals-cli/ui/src/index.css
+++ b/evals-cli/ui/src/index.css
@@ -4,53 +4,28 @@
  */
 
 :root {
-  font-family:
-    "Roboto",
-    "Inter",
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
-    sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #f8f9fa; /* Google light background */
+  color-scheme: light;
+  color: #0f172a;
+  background-color: #f8fafc;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  --primary-color: #1a73e8;
-  --primary-hover: #1765cc;
+  --primary-color: #2563eb;
+  --primary-hover: #1d4ed8;
   --surface-color: #ffffff;
-  --text-primary: #202124;
-  --text-secondary: #5f6368;
-  --border-color: #dadce0;
-  --error-color: #d93025;
-  --success-color: #188038;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    background-color: #202124;
-    --surface-color: #303134;
-    --text-primary: #e8eaed;
-    --text-secondary: #9aa0a6;
-    --border-color: #5f6368;
-    --primary-color: #8ab4f8;
-    --primary-hover: #aecbfa;
-    --error-color: #f28b82;
-    --success-color: #81c995;
-  }
+  --background-color: #f8fafc;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --border-color: #e2e8f0;
+  --error-color: #e11d48;
+  --success-color: #059669;
 }
 
 body {
@@ -66,7 +41,7 @@ h2,
 h3 {
   color: var(--text-primary);
   margin-top: 0;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 p,
@@ -83,6 +58,8 @@ div {
 .panel {
   background-color: var(--surface-color);
   border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
   padding: 24px;
   display: flex;
   flex-direction: column;

--- a/evals-cli/ui/src/index.css
+++ b/evals-cli/ui/src/index.css
@@ -4,7 +4,16 @@
  */
 
 :root {
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
@@ -59,7 +68,9 @@ div {
   background-color: var(--surface-color);
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.05),
+    0 1px 2px 0 rgba(0, 0, 0, 0.06);
   padding: 24px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Improving the way tool reports results. Next step is to work on additional trajectory visibility for easier debugging.


Changes done to sidecar:
openWhenHidden: true: 
It instructs the library to keep the HTTP connection open and active in the background, regardless of whether you are looking at the tab or have switched away to another window. Prevent restarting evals when user switches tab


checkAbort.abort()
Cancels the active request: It immediately terminates the active HTTP connection.
Disables the retry loop: @microsoft/fetch-event-source is designed to automatically reconnect/retry indefinitely whenever a connection closes. When we call .abort(), the library recognizes that the cancellation was intentional, halts its internal retry timers, and exits the loop completely.

Updated evals to have names for easier debugging and grouping them across runs (if we specify N runs, then we will have N entries under eval name).

Preview:
<img width="2546" height="1279" alt="image" src="https://github.com/user-attachments/assets/b923df2d-bd50-4f84-8fd3-8a5fef913ad1" />

NOTE: Evals are grouped based on 'name'. Accidental name collisions will result in Evals results being grouped as if those are same evals (we might want to introduce hashing of the eval case if we find it problematic)
