### PR TITLE
Add Page Agent demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,7 @@ jobs:
           cp -r demos/coffee-shop deployment-root/demos/coffee-shop
           cp -r demos/leather-bag/dist/leather-bag/browser deployment-root/demos/leather-bag
           cp -r demos/smart-home/dist deployment-root/demos/smart-home
+          cp -r demos/page-agent deployment-root/demos/page-agent
 
 
       - name: Setup Pages

--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -59,6 +59,8 @@ A curated list of awesome WebMCP demos.
   - **Example Prompt:** "Someone is at the door. Show me."
 - [webmcp.cool](https://webmcp.cool/) - A live, curated directory of WebMCP-enabled websites with a JSON API for agent-side discovery. Also registers its own WebMCP tools so agents can interact with the registry directly.
   - **Example Prompt:** "List my site `https://example.com` in the WebMCP directory."
+- [WebMCP Page Agent](https://googlechromelabs.github.io/webmcp-tools/demos/page-agent) - A Gemini-powered meta-demo that lets you control any WebMCP-enabled website using simple natural language commands.
+  - **Example Prompt:** "Make me a large BBQ pizza with sauce, pineapple and extra bacon."
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository contains a suite of developer utilities and demos designed to su
 - [**UrbanEstates (Imperative)**](demos/real-estate-map/): A real-estate map application that demonstrates imperative tool registration, allowing an AI agent to interact with property filters and map views.
 - [**Luxe Leather (Declarative)**](demos/leather-bag/): A premium e-commerce site for hand-crafted leather bags built with Angular and WebMCP. This demo showcases how an AI agent can interact with a web application to search products, check policies, and manage a shopping cart using declarative tools.
 - [**WebMCP Smart Home (Imperative)**](demos/smart-home/): A sleek, interactive dashboard where an AI agent can dynamically reconfigure home control components (e.g., front door cameras, thermostats, smart lights, energy distribution) based on user intents.
+- [**WebMCP Page Agent (Imperative)**](demos/page-agent/): A Gemini-powered meta-demo that lets you control any WebMCP-enabled website using simple natural language commands.
 
 Check out our curated list of WebMCP demos in the [Awesome WebMCP List](AWESOME_WEBMCP.md).
 

--- a/demos/page-agent/README.md
+++ b/demos/page-agent/README.md
@@ -1,0 +1,46 @@
+# WebMCP Page Agent | WebMCP Imperative Demo
+
+🚀 Live Demo: https://googlechromelabs.github.io/webmcp-tools/demos/page-agent
+🪞 Mirror: https://chrome.dev/web-ai-demos/webmcp/page-agent/
+
+The **WebMCP Page Agent** is a "meta-demo" that demonstrates how to get tools from an iframe (cross-origin or not) and execute them in a chat session powered by Gemini. It allows users to control any WebMCP-enabled website by typing natural language commands.
+
+## 🛠️ How It Works
+
+This demo uses the `document.modelContext` API to discover and execute tools provided by the site loaded in the iframe.
+
+### 1. Discovering Tools
+
+The agent uses `getTools` to find all tools registered by the guest page within the iframe.
+
+```javascript
+async function getTools() {
+  const iframeOrigin = new URL(iframe.src).origin;
+  const tools = await document.modelContext.getTools({ fromOrigins: [iframeOrigin] });
+  return tools;
+}
+```
+
+For cross-origin iframes, tools must be registered with the `exposedTo` property correctly configured. For details, check out https://developer.chrome.com/docs/ai/webmcp/imperative-api#origin-exposure.
+
+### 2. Executing Tools
+
+When the Gemini model decides to call a tool, the agent uses `executeTool` to perform the action within the guest page.
+
+```javascript
+const result = await document.modelContext.executeTool(tool, inputArgs);
+```
+
+## ✨ Features
+
+- **Dynamic Tool Discovery**: Automatically detects tools from any WebMCP-compatible URL entered in the address bar.
+- **Gemini Integration**: Uses the Gemini 3.5 Flash model to interpret user intent and map it to available tools.
+- **Cross-Origin Support**: Safely interacts with tools across different origins via the WebMCP protocol.
+- **Real-time Feedback**: Shows system messages when tools are being executed.
+
+## 🚀 Getting Started
+
+1. Open the [Live Demo](https://googlechromelabs.github.io/webmcp-tools/demos/page-agent).
+2. Enter your **Gemini API Key**.
+3. Load a WebMCP-enabled demo (e.g., the default [Pizza Maker](https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/)).
+4. Start chatting! Try commands like "Add a large BBQ pizza with mushrooms and onions".

--- a/demos/page-agent/index.html
+++ b/demos/page-agent/index.html
@@ -1,0 +1,59 @@
+<!--
+ Copyright 2026 Google LLC
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebMCP Page Agent</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💬</text></svg>"
+    />
+    <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+    <div id="app-container">
+        <div id="browser-container">
+            <div id="address-bar">
+                <input type="text" id="url-input"
+                    value="https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/" />
+            </div>
+            <iframe id="iframe" allow="tools *"></iframe>
+        </div>
+
+        <div id="chat-wrapper">
+            <div id="setup-container" class="hidden">
+                <h2>WebMCP Page Agent</h2>
+                <p>
+                    Using Gemini 3.5 Flash. Try executing tools exposed by this iframe.
+                </p>
+                <input type="password" id="api-key-input" placeholder="Enter Gemini API Key (AIzaSy...)" />
+                <br />
+                <button id="save-key-btn">Save Key & Start Chatting</button>
+            </div>
+
+            <div id="chat-container" class="hidden">
+                <div class="header">
+                    <h2 style="margin: 0">Interact with WebMCP tools</h2>
+                    <button class="btn-clear" id="logout-btn">Log Out</button>
+                </div>
+
+                <div id="chat-window"></div>
+
+                <div class="input-area">
+                    <input type="text" id="user-input" placeholder="Type a message..." />
+                    <button id="send-btn">Send</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GoogleGenAI } from 'https://esm.sh/@google/genai';
+
+const setupContainer = document.getElementById('setup-container');
+const chatContainer = document.getElementById('chat-container');
+const apiKeyInput = document.getElementById('api-key-input');
+const chatWindow = document.getElementById('chat-window');
+const userInput = document.getElementById('user-input');
+const sendBtn = document.getElementById('send-btn');
+const saveKeyBtn = document.getElementById('save-key-btn');
+const logoutBtn = document.getElementById('logout-btn');
+const urlInput = document.getElementById('url-input');
+const iframe = document.getElementById('iframe');
+
+let ai, chat;
+
+async function getTools() {
+  const iframeOrigin = new URL(iframe.src).origin;
+  const tools = await document.modelContext.getTools({ fromOrigins: [iframeOrigin] });
+  return tools;
+}
+
+async function getConfig() {
+  const systemInstruction = [
+    'You are an assistant embedded in a web page.',
+    'CRITICAL RULE: Do not try to use other tools than the available ones.',
+  ];
+
+  const tools = await getTools();
+  const functionDeclarations = tools.map((tool) => {
+    return {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema
+        ? JSON.parse(tool.inputSchema)
+        : { type: 'object', properties: {} },
+    };
+  });
+
+  return { systemInstruction, tools: [{ functionDeclarations }] };
+}
+
+const storedKey = localStorage.getItem('gemini_api_key');
+if (storedKey) {
+  initChat(storedKey);
+} else {
+  setupContainer.classList.remove('hidden');
+}
+
+saveKeyBtn.addEventListener('click', () => {
+  const key = apiKeyInput.value.trim();
+  if (key) {
+    localStorage.setItem('gemini_api_key', key);
+    initChat(key);
+  }
+});
+
+function initChat(apiKey) {
+  ai = new GoogleGenAI({ apiKey: apiKey });
+  setupContainer.classList.add('hidden');
+  chatContainer.classList.remove('hidden');
+  userInput.focus();
+}
+
+iframe.src = urlInput.value.trim();
+
+urlInput.addEventListener('keypress', (e) => {
+  if (e.key !== 'Enter') return;
+  const url = urlInput.value.trim();
+  urlInput.value = url;
+  chatWindow.innerHTML = '';
+  chat = null;
+  iframe.src = url;
+  urlInput.blur();
+});
+
+iframe.addEventListener('load', async () => {
+  const tools = await getTools();
+  appendMessage(
+    'System',
+    `🌐 ${tools.length} tools are exposed by ${iframe.src}`,
+    'tool-indicator',
+  );
+});
+
+logoutBtn.addEventListener('click', () => {
+  localStorage.removeItem('gemini_api_key');
+  ai = null;
+  chatWindow.innerHTML = '';
+  document.body.style.backgroundColor = '';
+  setupContainer.classList.remove('hidden');
+  chatContainer.classList.add('hidden');
+});
+
+sendBtn.addEventListener('click', handleUserSubmit);
+userInput.addEventListener('keypress', (e) => {
+  if (e.key === 'Enter' && !userInput.disabled) handleUserSubmit();
+});
+
+async function handleUserSubmit() {
+  try {
+    const text = userInput.value.trim();
+    if (!text || !ai) return;
+
+    userInput.value = '';
+    userInput.disabled = true;
+    sendBtn.disabled = true;
+
+    appendMessage('You', text, 'user');
+
+    chat ??= ai.chats.create({ model: 'gemini-3.5-flash' });
+
+    const sendMessageParams = { message: text, config: await getConfig() };
+    let currentResult = await chat.sendMessage(sendMessageParams);
+    let finalResponseGiven = false;
+
+    while (!finalResponseGiven) {
+      const response = currentResult;
+      const functionCalls = response.functionCalls || [];
+
+      if (functionCalls.length === 0) {
+        appendMessage('Agent', response.text, 'agent');
+        finalResponseGiven = true;
+      } else {
+        const toolResponses = [];
+        for (const { name, args } of functionCalls) {
+          const inputArgs = JSON.stringify(args);
+          try {
+            appendMessage('System', `⚙️ Executing tool: ${name}...`, 'tool-indicator');
+            const tools = await getTools();
+            const tool = tools.find((t) => t.name == name);
+            const result = await document.modelContext.executeTool(tool, inputArgs);
+            toolResponses.push({ functionResponse: { name, response: { result } } });
+          } catch (error) {
+            appendMessage('System', `Error: ${error.message}`, 'error');
+            toolResponses.push({
+              functionResponse: { name, response: { error: error.message } },
+            });
+          }
+        }
+        const sendMessageParams = { message: toolResponses, config: await getConfig() };
+        currentResult = await chat.sendMessage(sendMessageParams);
+      }
+    }
+
+    userInput.disabled = false;
+    sendBtn.disabled = false;
+    userInput.focus();
+  } catch (error) {
+    appendMessage('System', `Error: ${error.message}`, 'error');
+  }
+}
+
+function appendMessage(sender, text, className) {
+  const msgDiv = document.createElement('div');
+  msgDiv.className = `message ${className}`;
+  msgDiv.innerHTML = text.replace(/\n/g, '<br>');
+  chatWindow.appendChild(msgDiv);
+  chatWindow.scrollTop = chatWindow.scrollHeight;
+}

--- a/demos/page-agent/styles.css
+++ b/demos/page-agent/styles.css
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+body {
+    font-family: sans-serif;
+    margin: 0;
+    padding: 1rem;
+    color: #333;
+    transition: background-color 0.5s ease;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+}
+
+#app-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+    max-width: 600px;
+    margin-top: 2rem;
+}
+
+@media (min-width: 1000px) {
+    #app-container {
+        flex-direction: row;
+        max-width: 1200px;
+        align-items: flex-start;
+    }
+
+    #browser-container,
+    #chat-wrapper {
+        flex: 1;
+        min-width: 0;
+    }
+}
+
+#browser-container {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #f1f3f4;
+}
+
+#address-bar {
+    padding: 8px;
+    display: flex;
+    gap: 8px;
+    background: #fff;
+    border-bottom: 1px solid #ccc;
+}
+
+#url-input {
+    flex: 1;
+    padding: 6px 12px;
+    border: 1px solid #dfe1e5;
+    border-radius: 20px;
+    font-size: 14px;
+    outline: none;
+    font-family: inherit;
+}
+
+#url-input:focus {
+    box-shadow: 0 1px 6px rgba(32, 33, 36, .28);
+    border-color: rgba(223, 225, 229, 0);
+}
+
+#iframe {
+    width: 100%;
+    height: 600px;
+    border: none;
+    background: white;
+}
+
+.hidden {
+    display: none !important;
+}
+
+#setup-container {
+    padding: 2rem;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    text-align: center;
+}
+
+#setup-container input {
+    width: 80%;
+    padding: 10px;
+    margin: 15px 0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: monospace;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 10px;
+    border-radius: 8px;
+}
+
+#chat-window {
+    border: 1px solid #ccc;
+    height: 492px;
+    overflow-y: auto;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    border-radius: 8px;
+    background: rgba(249, 249, 249, 0.9);
+}
+
+.message {
+    margin-bottom: 10px;
+    padding: 10px 14px;
+    border-radius: 8px;
+    width: fit-content;
+    max-width: 80%;
+    line-height: 1.4;
+    word-wrap: break-word;
+}
+
+.user {
+    background: #007bff;
+    color: white;
+    margin-left: auto;
+    border-bottom-right-radius: 0;
+}
+
+.agent {
+    background: #e9ecef;
+    color: black;
+    margin-right: auto;
+    border-bottom-left-radius: 0;
+}
+
+.tool-indicator {
+    background: #fff3cd;
+    color: #856404;
+    font-size: 0.85em;
+    font-family: monospace;
+    margin-right: auto;
+    border: 1px solid #ffeeba;
+}
+
+.error {
+    background: #f8d7da;
+    color: #721c24;
+    margin-right: auto;
+    border: 1px solid #f5c6cb;
+}
+
+.input-area {
+    display: flex;
+    gap: 10px;
+}
+
+.input-area input[type='text'] {
+    flex: 1;
+    padding: 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+button {
+    padding: 10px 20px;
+    background: #28a745;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+button:hover {
+    background: #218838;
+}
+
+button:disabled {
+    background: #6c757d;
+    cursor: not-allowed;
+}
+
+.btn-clear {
+    background: #dc3545;
+    padding: 6px 12px;
+    font-size: 0.9em;
+}


### PR DESCRIPTION
Following https://chromium-review.googlesource.com/c/chromium/src/+/7880667, this PR adds a page agent demo that shows how a webpage can get tools from a cross-origin iframe and execute them in a chat session powered by Gemini.

Here are the interesting bits:

```js
async function getTools() {
  const iframeOrigin = new URL(iframe.src).origin;
  const tools = await document.modelContext.getTools({ fromOrigins: [iframeOrigin] });
  return tools;
}
```
```js
            appendMessage('System', `⚙️ Executing tool: ${name}...`, 'tool-indicator');
            const tools = await getTools();
            const tool = tools.find((t) => t.name == name);
            const result = await document.modelContext.executeTool(tool, inputArgs);
```   
    
<img width="1644" height="1036" alt="Screenshot 2026-06-02 at 13 20 00" src="https://github.com/user-attachments/assets/1d668292-9ac9-4758-9f07-5551dc6a1a83" />
