### PR TITLE
Tighten permission policy

### DIFF
--- a/demos/page-agent/index.html
+++ b/demos/page-agent/index.html
@@ -24,7 +24,7 @@
                 <input type="text" id="url-input"
                     value="https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/" />
             </div>
-            <iframe id="iframe" allow="tools *"></iframe>
+            <iframe id="iframe"></iframe>
         </div>
 
         <div id="chat-wrapper">

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -66,17 +66,22 @@ function initChat(apiKey) {
   userInput.focus();
 }
 
-iframe.src = urlInput.value.trim();
-
 urlInput.addEventListener('keypress', (e) => {
   if (e.key !== 'Enter') return;
+  loadUrl();
+});
+
+function loadUrl() {
   const url = urlInput.value.trim();
   urlInput.value = url;
   chatWindow.innerHTML = '';
   chat = null;
+  iframe.allow = `tools ${new URL(url).origin}`;
   iframe.src = url;
   urlInput.blur();
-});
+}
+
+loadUrl();
 
 iframe.addEventListener('load', async () => {
   const tools = await getTools();


### PR DESCRIPTION
This PR tightens iframe permission policy from `allow="tools *"` to `allow="tools {iframeOrigin}"` to show best practises to web developers