### PR TITLE
Add in-page agent to french-bistro

### DIFF
--- a/demos/french-bistro/agent.css
+++ b/demos/french-bistro/agent.css
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#agent-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+#agent-toggle {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background-color: var(--black);
+  color: var(--gold);
+  border: 2px solid var(--gold);
+  font-size: 24px;
+  cursor: pointer;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+#agent-toggle:hover {
+  transform: scale(1.1);
+}
+
+#agent-chat {
+  position: absolute;
+  bottom: 80px;
+  right: 0;
+  width: 350px;
+  height: 500px;
+  background-color: var(--cream);
+  border: 2px solid var(--gold);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+#agent-chat.hidden {
+  display: none;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+#agent-header {
+  background-color: var(--black);
+  color: var(--gold);
+  padding: 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#agent-header h3 {
+  margin: 0;
+  font-size: 1.1em;
+  font-family: 'Playfair Display', serif;
+}
+
+#agent-logout {
+  background: none;
+  border: 1px solid var(--gold);
+  color: var(--gold);
+  font-size: 0.7em;
+  padding: 2px 8px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+#agent-chat-window {
+  flex: 1;
+  overflow-y: auto;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background-color: #fffaf0;
+}
+
+.agent-message {
+  padding: 10px 14px;
+  border-radius: 8px;
+  max-width: 85%;
+  font-size: 0.9em;
+  line-height: 1.4;
+  word-wrap: break-word;
+}
+
+.agent-message.user {
+  background-color: var(--black);
+  color: var(--gold);
+  align-self: flex-end;
+  border-bottom-right-radius: 0;
+}
+
+.agent-message.agent {
+  background-color: #eee;
+  color: #333;
+  align-self: flex-start;
+  border-bottom-left-radius: 0;
+  border: 1px solid #ddd;
+}
+
+.agent-message.system {
+  background-color: #fef9e7;
+  color: #856404;
+  font-size: 0.8em;
+  align-self: center;
+  text-align: center;
+  border: 1px solid #ffeeba;
+  width: 90%;
+}
+
+#agent-input-area {
+  padding: 15px;
+  border-top: 1px solid #eee;
+  display: flex;
+  gap: 10px;
+}
+
+#agent-user-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+#agent-send-btn {
+  padding: 8px 15px;
+  background-color: var(--black);
+  color: var(--gold);
+  border: 1px solid var(--gold);
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+#agent-setup {
+  padding: 30px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  height: 100%;
+  justify-content: center;
+}
+
+#agent-api-key-input {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+}
+
+#agent-save-key-btn {
+  padding: 10px;
+  background-color: var(--black);
+  color: var(--gold);
+  border: 1px solid var(--gold);
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.hidden {
+  display: none !important;
+}

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GoogleGenAI } from 'https://esm.sh/@google/genai';
+
+const agentToggle = document.getElementById('agent-toggle');
+const agentChat = document.getElementById('agent-chat');
+const agentChatWindow = document.getElementById('agent-chat-window');
+const agentUserInput = document.getElementById('agent-user-input');
+const agentSendBtn = document.getElementById('agent-send-btn');
+const agentSetup = document.getElementById('agent-setup');
+const agentChatContainer = document.getElementById('agent-chat-container');
+const agentApiKeyInput = document.getElementById('agent-api-key-input');
+const agentSaveKeyBtn = document.getElementById('agent-save-key-btn');
+const agentLogoutBtn = document.getElementById('agent-logout');
+
+let ai, chat;
+
+async function getTools() {
+  if (!window.document.modelContext) {
+    return [];
+  }
+  return await document.modelContext.getTools();
+}
+
+async function getConfig() {
+  const systemInstruction = [
+    'You are an assistant for "Le Petit Bistro" restaurant.',
+    'Help the user make a reservation using the available tools.',
+    'CRITICAL RULE: Do not try to use other tools than the available ones.',
+  ];
+
+  const tools = await getTools();
+  const functionDeclarations = tools.map((tool) => {
+    return {
+      name: tool.name,
+      description: tool.description,
+      parametersJsonSchema: tool.inputSchema
+        ? JSON.parse(tool.inputSchema)
+        : { type: 'object', properties: {} },
+    };
+  });
+
+  return { systemInstruction, tools: [{ functionDeclarations }] };
+}
+
+const storedKey = localStorage.getItem('gemini_api_key');
+if (storedKey) {
+  initChat(storedKey);
+} else {
+  agentSetup.classList.remove('hidden');
+  agentChatContainer.classList.add('hidden');
+}
+
+agentToggle.addEventListener('click', () => {
+  agentChat.classList.toggle('hidden');
+  if (!agentChat.classList.contains('hidden')) {
+    agentUserInput.focus();
+  }
+});
+
+agentSaveKeyBtn.addEventListener('click', () => {
+  const key = agentApiKeyInput.value.trim();
+  if (key) {
+    localStorage.setItem('gemini_api_key', key);
+    initChat(key);
+  }
+});
+
+function initChat(apiKey) {
+  ai = new GoogleGenAI({ apiKey: apiKey });
+  agentSetup.classList.add('hidden');
+  agentChatContainer.classList.remove('hidden');
+  appendMessage('System', 'Welcome to Le Petit Bistro! How can I help you today?', 'system');
+}
+
+agentLogoutBtn.addEventListener('click', () => {
+  localStorage.removeItem('gemini_api_key');
+  ai = null;
+  chat = null;
+  agentChatWindow.innerHTML = '';
+  agentSetup.classList.remove('hidden');
+  agentChatContainer.classList.add('hidden');
+});
+
+agentSendBtn.addEventListener('click', handleUserSubmit);
+agentUserInput.addEventListener('keypress', (e) => {
+  if (e.key === 'Enter' && !agentUserInput.disabled) handleUserSubmit();
+});
+
+async function handleUserSubmit() {
+  try {
+    const text = agentUserInput.value.trim();
+    if (!text || !ai) return;
+
+    agentUserInput.value = '';
+    agentUserInput.disabled = true;
+    agentSendBtn.disabled = true;
+
+    appendMessage('You', text, 'user');
+
+    chat ??= ai.chats.create({ model: 'gemini-3.5-flash' });
+
+    const config = await getConfig();
+    const sendMessageParams = { message: text, config };
+    console.log(sendMessageParams);
+    let currentResult = await chat.sendMessage(sendMessageParams);
+    let finalResponseGiven = false;
+
+    while (!finalResponseGiven) {
+      const response = currentResult;
+      const functionCalls = response.functionCalls || [];
+
+      if (functionCalls.length === 0) {
+        appendMessage('Agent', response.text, 'agent');
+        finalResponseGiven = true;
+      } else {
+        const toolResponses = [];
+        for (const { name, args } of functionCalls) {
+          try {
+            appendMessage('System', `⚙️ Executing tool: ${name}...`, 'system');
+            const tools = await getTools();
+            const tool = tools.find((t) => t.name == name);
+            if (!tool) throw new Error(`Tool ${name} not found`);
+            
+            const result = await document.modelContext.executeTool(tool, JSON.stringify(args));
+            toolResponses.push({ functionResponse: { name, response: { result } } });
+          } catch (error) {
+            appendMessage('System', `Error: ${error.message}`, 'system');
+            toolResponses.push({
+              functionResponse: { name, response: { error: error.message } },
+            });
+          }
+        }
+        const sendMessageParams = { message: toolResponses, config: await getConfig() };
+        currentResult = await chat.sendMessage(sendMessageParams);
+      }
+    }
+
+    agentUserInput.disabled = false;
+    agentSendBtn.disabled = false;
+    agentUserInput.focus();
+  } catch (error) {
+    console.log(error);
+    appendMessage('System', `Error: ${error.message}`, 'system');
+    agentUserInput.disabled = false;
+    agentSendBtn.disabled = false;
+  }
+}
+
+function appendMessage(sender, text, className) {
+  const msgDiv = document.createElement('div');
+  msgDiv.className = `agent-message ${className}`;
+  msgDiv.innerHTML = text.replace(/\n/g, '<br>');
+  agentChatWindow.appendChild(msgDiv);
+  agentChatWindow.scrollTop = agentChatWindow.scrollHeight;
+}
+
+// Check if WebMCP is supported
+if (!window.document.modelContext) {
+  setTimeout(() => {
+    appendMessage('System', '⚠️ WebMCP API not detected. Make sure you are using a compatible browser with the experiment enabled.', 'system');
+  }, 1000);
+}

--- a/demos/french-bistro/index.html
+++ b/demos/french-bistro/index.html
@@ -15,6 +15,7 @@
     />
     <title>Le Petit Bistro | WebMCP declarative demo</title>
     <link href="style.css" rel="stylesheet" />
+    <link href="agent.css" rel="stylesheet" />
 
     <link
       rel="preload"
@@ -146,6 +147,28 @@
 
       <button class="close-modal-btn" id="closeDialogBtn">Close Window</button>
     </dialog>
+    <div id="agent-container">
+      <button id="agent-toggle" title="Chat with our AI Assistant">💬</button>
+      <div id="agent-chat" class="hidden">
+        <div id="agent-header">
+          <h3>Bistro Assistant</h3>
+          <button id="agent-logout" title="Log Out">Log Out</button>
+        </div>
+        <div id="agent-chat-window"></div>
+        <div id="agent-setup" class="hidden">
+          <p>Enter your Gemini API Key to start chatting.</p>
+          <input type="password" id="agent-api-key-input" placeholder="AIzaSy..." />
+          <button id="agent-save-key-btn">Save & Start</button>
+        </div>
+        <div id="agent-chat-container" class="hidden">
+          <div id="agent-input-area">
+            <input type="text" id="agent-user-input" placeholder="Type a message..." />
+            <button id="agent-send-btn">Send</button>
+          </div>
+        </div>
+      </div>
+    </div>
     <script type="module" src="script.js"></script>
+    <script type="module" src="agent.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds an experimental in-page agent to the french bistro demo to demonstrate current WebMCP limitations that exist with cross document navigation.

Steps to reproduce:
1. Go to https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/?crossdocument=1&toolautosubmit=1
2. Click 💬
3. Enter "Can you please book a table for 4 people at Le Petit Bistro on June 12th, 2026, at 19:30, in a private booth for my name, John Doe, reachable at 555-012-3456?"
4. Click "Send"
5. Even though the form got properly submitted, the assistant doesn't have context anymore, which could be useful for a user story that require multiple steps.

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/4c7e07c3-02a9-45b6-aa2c-e66739624137" />