### PR TITLE
Use document.referrer instead of history.back

### DIFF
--- a/demos/french-bistro/result.html
+++ b/demos/french-bistro/result.html
@@ -51,7 +51,7 @@
     }
 
     document.getElementById('closeDialogBtn').addEventListener('click', () => {
-      history.back();
+      location = document.referrer;
     });
   </script>
 </body>


### PR DESCRIPTION
Using `location = document.referrer` instead of `history.back()` loads the previous page instead of showing the page from the cache which would contain previous form data.
