### PR TITLE
Add shared worker support to french-bistro demo

### DIFF
--- a/demos/french-bistro/README.md
+++ b/demos/french-bistro/README.md
@@ -27,6 +27,8 @@ When visiting `index.html?crossdocument`, the form submission triggers a navigat
 
 With `index.html?toolautosubmit` (or `index.html?crossdocument&toolautosubmit`), the `toolautosubmit` attribute is set on the form, which lets the agent submit the form on the user's behalf after filling it out, without requiring the user to check it manually before submitting. Otherwise when the agent finishes filling out the form, the browser brings the submit button into focus, and the agent should then tell the user to check the form contents, and submit it manually.
 
+With `index.html?sharedworker`, the demo uses a `SharedWorker` to manage the AI agent's state and message history. This is particularly useful for maintaining continuity across page navigations (e.g., when combined with `?crossdocument`). It is possible thanks to [`extendedLifetime: true`](https://developer.mozilla.org/docs/Web/API/SharedWorker/SharedWorker#extendedlifetime).
+
 Testing WebMCP audit failures can be streamlined by using specific URL parameters to simulate common tool configuration issues:
 - `index.html?notoolname` removes `toolname` form attribute
 - `index.html?notooldescription` removes `tooldescription` form attribute.

--- a/demos/french-bistro/agent-worker.js
+++ b/demos/french-bistro/agent-worker.js
@@ -18,6 +18,11 @@ self.onconnect = (e) => {
     const { type, payload, id } = event.data;
 
     switch (type) {
+      case 'CLOSE_CONNECTION':
+        ports = ports.filter(p => p !== port);
+        port.close();
+        break;
+
       case 'GET_STATUS':
         port.postMessage({ type: 'STATUS_RESPONSE', payload: { initialized: !!ai, messages } });
         break;

--- a/demos/french-bistro/agent-worker.js
+++ b/demos/french-bistro/agent-worker.js
@@ -10,11 +10,7 @@ let apiKey = null;
 let ports = [];
 let messages = []; // Persistent message history
 
-self._ai = ai;
-self._messages = messages;
-
 self.onconnect = (e) => {
-  console.log(e);
   const port = e.ports[0];
   ports.push(port);
 

--- a/demos/french-bistro/agent-worker.js
+++ b/demos/french-bistro/agent-worker.js
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GoogleGenAI } from 'https://esm.sh/@google/genai';
+
+let ai, chat;
+let apiKey = null;
+let ports = [];
+let messages = []; // Persistent message history
+
+self._ai = ai;
+self._messages = messages;
+
+self.onconnect = (e) => {
+  console.log(e);
+  const port = e.ports[0];
+  ports.push(port);
+
+  port.onmessage = async (event) => {
+    const { type, payload, id } = event.data;
+
+    switch (type) {
+      case 'GET_STATUS':
+        port.postMessage({ type: 'STATUS_RESPONSE', payload: { initialized: !!ai, messages } });
+        break;
+
+      case 'INIT':
+        apiKey = payload.apiKey;
+        ai = new GoogleGenAI({ apiKey });
+        broadcast({ type: 'INITIALIZED' });
+        break;
+
+      case 'SEND_MESSAGE':
+        await handleUserSubmit(payload.text, port, id);
+        break;
+
+      case 'LOGOUT':
+        ai = null;
+        chat = null;
+        apiKey = null;
+        messages = [];
+        broadcast({ type: 'LOGGED_OUT' });
+        break;
+      
+      case 'TOOL_RESPONSE':
+        // This will be handled inside the handleUserSubmit loop via a promise resolver
+        if (toolRequestResolvers.has(id)) {
+          toolRequestResolvers.get(id)(payload);
+          toolRequestResolvers.delete(id);
+        }
+        break;
+    }
+  };
+
+  port.start();
+};
+
+function broadcast(msg) {
+  ports.forEach(p => p.postMessage(msg));
+}
+
+function appendMessage(sender, text, className) {
+  const message = { sender, text, className };
+  messages.push(message);
+  broadcast({ type: 'APPEND_MESSAGE', payload: message });
+}
+
+const toolRequestResolvers = new Map();
+
+async function requestToolExecution(port, tool, args) {
+  const id = Math.random().toString(36).substring(7);
+  return new Promise((resolve) => {
+    toolRequestResolvers.set(id, resolve);
+    port.postMessage({ type: 'EXECUTE_TOOL', payload: { tool, args }, id });
+  });
+}
+
+async function requestTools(port) {
+  const id = Math.random().toString(36).substring(7);
+  return new Promise((resolve) => {
+    toolRequestResolvers.set(id, resolve);
+    port.postMessage({ type: 'GET_TOOLS', id });
+  });
+}
+
+async function handleUserSubmit(text, port, requestId) {
+  try {
+    if (!ai) return;
+
+    appendMessage('You', text, 'user');
+
+    chat ??= ai.chats.create({ model: 'gemini-3.5-flash' });
+
+    let finalResponseGiven = false;
+
+    // Helper to get config (including tools) from the page
+    const getConfig = async () => {
+      const systemInstruction = [
+        'You are an assistant for "Le Petit Bistro" restaurant.',
+        'Help the user make a reservation using the available tools.',
+        'CRITICAL RULE: Do not try to use other tools than the available ones.',
+      ];
+      const tools = await requestTools(port);
+      const functionDeclarations = tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        parametersJsonSchema: tool.inputSchema
+          ? JSON.parse(tool.inputSchema)
+          : { type: 'object', properties: {} },
+      }));
+      return { systemInstruction, tools: [{ functionDeclarations }] };
+    };
+
+    let config = await getConfig();
+    let currentResult = await chat.sendMessage({ message: text, config });
+
+    while (!finalResponseGiven) {
+      const response = currentResult;
+      const functionCalls = response.functionCalls || [];
+
+      if (functionCalls.length === 0) {
+        appendMessage('Agent', response.text, 'agent');
+        finalResponseGiven = true;
+      } else {
+        const toolResponses = [];
+        for (const { name, args } of functionCalls) {
+          try {
+            appendMessage('System', `⚙️ Executing tool: ${name}...`, 'system');
+            const tools = await requestTools(port);
+            const tool = tools.find((t) => t.name == name);
+            if (!tool) throw new Error(`Tool ${name} not found`);
+            
+            const result = await requestToolExecution(port, tool, JSON.stringify(args));
+            toolResponses.push({ functionResponse: { name, response: { result } } });
+          } catch (error) {
+            appendMessage('System', `Error: ${error.message}`, 'system');
+            toolResponses.push({
+              functionResponse: { name, response: { error: error.message } },
+            });
+          }
+        }
+        config = await getConfig();
+        currentResult = await chat.sendMessage({ message: toolResponses, config });
+      }
+    }
+  } catch (error) {
+    appendMessage('System', `Error: ${error.message}`, 'system');
+  } finally {
+    port.postMessage({ type: 'SUBMIT_FINISHED', id: requestId });
+  }
+}

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GoogleGenAI } from 'https://esm.sh/@google/genai';
-
 const agentToggle = document.getElementById('agent-toggle');
 const agentChat = document.getElementById('agent-chat');
 const agentChatWindow = document.getElementById('agent-chat-window');
@@ -16,7 +14,7 @@ const agentApiKeyInput = document.getElementById('agent-api-key-input');
 const agentSaveKeyBtn = document.getElementById('agent-save-key-btn');
 const agentLogoutBtn = document.getElementById('agent-logout');
 
-let ai, chat;
+let ai, chat, worker;
 
 async function getTools() {
   if (!window.document.modelContext) {
@@ -47,11 +45,91 @@ async function getConfig() {
 }
 
 const storedKey = localStorage.getItem('gemini_api_key');
-if (storedKey) {
-  initChat(storedKey);
+
+const params = new URLSearchParams(window.location.search);
+if (params.has('sharedworker')) {
+  initSharedWorker(storedKey);
 } else {
-  agentSetup.classList.remove('hidden');
-  agentChatContainer.classList.add('hidden');
+  if (storedKey) {
+    initChat(storedKey);
+  } else {
+    agentSetup.classList.remove('hidden');
+    agentChatContainer.classList.add('hidden');
+  }
+}
+
+function initSharedWorker(apiKey) {
+  worker = new SharedWorker('agent-worker.js', { type: 'module', extendedLifetime: true });
+  worker.port.onmessage = async (event) => {
+    const { type, payload, id } = event.data;
+
+    switch (type) {
+      case 'STATUS_RESPONSE':
+        if (payload.initialized) {
+          agentSetup.classList.add('hidden');
+          agentChatContainer.classList.remove('hidden');
+          agentChatWindow.innerHTML = '';
+          payload.messages.forEach((m) => appendMessage(m.sender, m.text, m.className));
+        } else if (apiKey) {
+          worker.port.postMessage({ type: 'INIT', payload: { apiKey } });
+        } else {
+          agentSetup.classList.remove('hidden');
+          agentChatContainer.classList.add('hidden');
+        }
+        break;
+
+      case 'INITIALIZED':
+        agentSetup.classList.add('hidden');
+        agentChatContainer.classList.remove('hidden');
+        if (agentChatWindow.innerHTML === '') {
+          appendMessage(
+            'System',
+            'Welcome to Le Petit Bistro! How can I help you today?',
+            'system',
+          );
+        }
+        break;
+
+      case 'APPEND_MESSAGE':
+        appendMessage(payload.sender, payload.text, payload.className);
+        break;
+
+      case 'LOGGED_OUT':
+        agentChatWindow.innerHTML = '';
+        agentSetup.classList.remove('hidden');
+        agentChatContainer.classList.add('hidden');
+        break;
+
+      case 'GET_TOOLS':
+        const tools = await getTools();
+        // FIXME: tool.window needs to be removed because it's not serializable.
+        tools.map((tool) => {
+          delete tool.window;
+          return tool;
+        });
+        worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: tools, id });
+        break;
+
+      case 'EXECUTE_TOOL':
+        try {
+          // FIXME: Find a way to get tools with `window` parameter.
+          payload.tool.window = window;
+          const result = await document.modelContext.executeTool(payload.tool, payload.args);
+          worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: result, id });
+        } catch (error) {
+          worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: { error: error.message }, id });
+        }
+        break;
+
+      case 'SUBMIT_FINISHED':
+        agentUserInput.disabled = false;
+        agentSendBtn.disabled = false;
+        agentUserInput.focus();
+        break;
+    }
+  };
+  worker.port.start();
+  worker.port.postMessage({ type: 'GET_STATUS' });
 }
 
 agentToggle.addEventListener('click', () => {
@@ -63,14 +141,18 @@ agentToggle.addEventListener('click', () => {
 
 agentSaveKeyBtn.addEventListener('click', () => {
   const key = agentApiKeyInput.value.trim();
-  if (key) {
-    localStorage.setItem('gemini_api_key', key);
-    initChat(key);
+  if (!key) return;
+  localStorage.setItem('gemini_api_key', key);
+  if (worker) {
+    worker.port.postMessage({ type: 'INIT', payload: { apiKey: key } });
+    return;
   }
+  initChat(key);
 });
 
-function initChat(apiKey) {
-  ai = new GoogleGenAI({ apiKey: apiKey });
+async function initChat(apiKey) {
+  const { GoogleGenAI } = await import("https://esm.sh/@google/genai");
+  ai = new GoogleGenAI({ apiKey });
   agentSetup.classList.add('hidden');
   agentChatContainer.classList.remove('hidden');
   appendMessage('System', 'Welcome to Le Petit Bistro! How can I help you today?', 'system');
@@ -78,6 +160,10 @@ function initChat(apiKey) {
 
 agentLogoutBtn.addEventListener('click', () => {
   localStorage.removeItem('gemini_api_key');
+  if (worker) {
+    worker.port.postMessage({ type: 'LOGOUT' });
+    return;
+  }
   ai = null;
   chat = null;
   agentChatWindow.innerHTML = '';
@@ -91,13 +177,20 @@ agentUserInput.addEventListener('keypress', (e) => {
 });
 
 async function handleUserSubmit() {
-  try {
-    const text = agentUserInput.value.trim();
-    if (!text || !ai) return;
+  const text = agentUserInput.value.trim();
+  if (!text) return;
 
-    agentUserInput.value = '';
-    agentUserInput.disabled = true;
-    agentSendBtn.disabled = true;
+  agentUserInput.value = '';
+  agentUserInput.disabled = true;
+  agentSendBtn.disabled = true;
+
+  if (worker) {
+    worker.port.postMessage({ type: 'SEND_MESSAGE', payload: { text } });
+    return;
+  }
+
+  try {
+    if (!ai) return;
 
     appendMessage('You', text, 'user');
 
@@ -105,7 +198,6 @@ async function handleUserSubmit() {
 
     const config = await getConfig();
     const sendMessageParams = { message: text, config };
-    console.log(sendMessageParams);
     let currentResult = await chat.sendMessage(sendMessageParams);
     let finalResponseGiven = false;
 
@@ -124,7 +216,7 @@ async function handleUserSubmit() {
             const tools = await getTools();
             const tool = tools.find((t) => t.name == name);
             if (!tool) throw new Error(`Tool ${name} not found`);
-            
+
             const result = await document.modelContext.executeTool(tool, JSON.stringify(args));
             toolResponses.push({ functionResponse: { name, response: { result } } });
           } catch (error) {
@@ -161,6 +253,10 @@ function appendMessage(sender, text, className) {
 // Check if WebMCP is supported
 if (!window.document.modelContext) {
   setTimeout(() => {
-    appendMessage('System', '⚠️ WebMCP API not detected. Make sure you are using a compatible browser with the experiment enabled.', 'system');
+    appendMessage(
+      'System',
+      '⚠️ WebMCP API not detected. Make sure you are using a compatible browser with the experiment enabled.',
+      'system',
+    );
   }, 1000);
 }

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -127,6 +127,9 @@ function initSharedWorker(apiKey) {
   };
   worker.port.start();
   worker.port.postMessage({ type: 'GET_STATUS' });
+  window.addEventListener('pagehide', () => {
+    worker.port.postMessage({ type: 'CLOSE_CONNECTION' });
+  });
 }
 
 agentToggle.addEventListener('click', () => {

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -103,11 +103,8 @@ function initSharedWorker(apiKey) {
       case 'GET_TOOLS':
         const tools = await getTools();
         // FIXME: tool.window needs to be removed because it's not serializable.
-        tools.map((tool) => {
-          delete tool.window;
-          return tool;
-        });
-        worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: tools, id });
+        const serializableTools = tools.map(({ window, ...toolWithoutWindow }) => toolWithoutWindow);
+        worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: serializableTools, id });
         break;
 
       case 'EXECUTE_TOOL':


### PR DESCRIPTION
With `index.html?sharedworker`, the demo now uses a `SharedWorker` to manage the AI agent's state and message history. This is particularly useful for maintaining continuity across page navigations (e.g., when combined with `?crossdocument`). It is possible thanks to [`extendedLifetime: true`](https://developer.mozilla.org/docs/Web/API/SharedWorker/SharedWorker#extendedlifetime).