### PR TITLE
Handle registerTool promise rejections

### DIFF
--- a/demos/explainer/app.js
+++ b/demos/explainer/app.js
@@ -344,7 +344,7 @@
   // Internal mirror, used by the on-page tools panel UI.
   const localRegistry = [];
 
-  function registerTool(spec) {
+  async function registerTool(spec) {
     // Wrap execute so EVERY invocation — whether from the in-page sim or a
     // real WebMCP agent — flashes the matching tool card and shows the call
     // in the "Last call" panel. Tools no longer need to call flashTool() themselves.
@@ -358,7 +358,7 @@
 
     if (HAS_WEBMCP) {
       try {
-        document.modelContext.registerTool({
+        await document.modelContext.registerTool({
           name: spec.name,
           title: spec.title,
           description: spec.description,

--- a/demos/explainer/index.html
+++ b/demos/explainer/index.html
@@ -164,7 +164,7 @@
             On any page, declare the actions an agent can take. Each tool has a name,
             description, and JSON schema — the same shape as a server-side MCP tool.
           </p>
-<pre class="code"><code><span class="c-key">document</span>.<span class="c-fn">modelContext</span>.<span class="c-fn">registerTool</span>({
+<pre class="code"><code><span class="c-key">await</span> <span class="c-key">document</span>.<span class="c-fn">modelContext</span>.<span class="c-fn">registerTool</span>({
   name: <span class="c-str">"bookSlot"</span>,
   title: <span class="c-str">"Book a consultation slot"</span>,
   description: <span class="c-str">"Reserve a 30-minute consultation."</span>,
@@ -239,7 +239,7 @@
           </div>
           <h3>Imperative API</h3>
           <p>Define different types of tools with standard JavaScript — form input, navigation, state management, or any other function on your page. The booking widget above uses this approach. Here's its <code>getAvailability</code> tool — the same one you'd see if you opened the WebMCP inspector on this page:</p>
-<pre class="code"><code><span class="c-key">document</span>.<span class="c-fn">modelContext</span>.<span class="c-fn">registerTool</span>({
+<pre class="code"><code><span class="c-key">await</span> <span class="c-key">document</span>.<span class="c-fn">modelContext</span>.<span class="c-fn">registerTool</span>({
   name: <span class="c-str">"getAvailability"</span>,
   title: <span class="c-str">"Get booking availability"</span>,
   description: <span class="c-str">"List bookable consultation times within a date range."</span>,

--- a/demos/hotel-chain/src/hooks/useWebMCP.ts
+++ b/demos/hotel-chain/src/hooks/useWebMCP.ts
@@ -27,9 +27,9 @@ export function useWebMCP(tools: WebMCPTool[]) {
 
     const controller = new AbortController();
 
-    tools.forEach(tool => {
+    tools.forEach(async tool => {
       try {
-        modelContext.registerTool(tool, { signal: controller.signal });
+        await modelContext.registerTool(tool, { signal: controller.signal });
         registeredTools.current.add(tool.name);
       } catch (error) {
         console.error(`Failed to register WebMCP tool "${tool.name}":`, error);

--- a/demos/shared/types/webmcp.d.ts
+++ b/demos/shared/types/webmcp.d.ts
@@ -62,7 +62,7 @@ declare global {
   /** The model context API exposed on `document.modelContext`. */
   interface ModelContext {
     /** Adds a single tool to the current context. */
-    registerTool(tool: ModelContextTool, options?: { signal?: AbortSignal }): void;
+    registerTool(tool: ModelContextTool, options?: { signal?: AbortSignal }): Promise<void>;
   }
 
   interface Navigator {

--- a/demos/smart-home/src/context/DashboardContext.jsx
+++ b/demos/smart-home/src/context/DashboardContext.jsx
@@ -18,35 +18,38 @@ export function DashboardProvider({ children }) {
     const controller = new AbortController();
 
     const modelContext = document.modelContext || navigator.modelContext;
-    try {
-      modelContext.registerTool({
-        name: "rearrangeDOMComponents",
-        title: "Rearrange Dashboard",
-        description: "Rearranges the user's home dashboard by adding, removing, or reordering smart home control components based on the user's intent.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            componentIds: {
-              type: "array",
-              items: { type: "string" },
-              description: "Array of component IDs to display on the dashboard. Examples: 'thermostat_control', 'camera_front_door', 'lock_front_door', 'smart_lights_living_room', 'energy_summary', 'weather_widget', 'media_player_living_room', 'alarm_panel', 'air_quality_sensor', 'robot_vacuum', 'solar_grid'"
-            }
-          },
-          required: ["componentIds"]
-        },
-        execute: async (input) => {
-          setIsAgentActive(true);
-          setDashboardComponents(input.componentIds);
-          
-          setTimeout(() => setIsAgentActive(false), 2000);
-          return "Dashboard successfully updated with requested components.";
-        }
-      }, { signal: controller.signal });
 
-      console.log("WebMCP tool registered via modelContext");
-    } catch (e) {
-      console.error(e);
-    }
+    (async() => {
+      try {
+        await modelContext.registerTool({
+          name: "rearrangeDOMComponents",
+          title: "Rearrange Dashboard",
+          description: "Rearranges the user's home dashboard by adding, removing, or reordering smart home control components based on the user's intent.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              componentIds: {
+                type: "array",
+                items: { type: "string" },
+                description: "Array of component IDs to display on the dashboard. Examples: 'thermostat_control', 'camera_front_door', 'lock_front_door', 'smart_lights_living_room', 'energy_summary', 'weather_widget', 'media_player_living_room', 'alarm_panel', 'air_quality_sensor', 'robot_vacuum', 'solar_grid'"
+              }
+            },
+            required: ["componentIds"]
+          },
+          execute: async (input) => {
+            setIsAgentActive(true);
+            setDashboardComponents(input.componentIds);
+
+            setTimeout(() => setIsAgentActive(false), 2000);
+            return "Dashboard successfully updated with requested components.";
+          }
+        }, { signal: controller.signal });
+
+        console.log("WebMCP tool registered via modelContext");
+      } catch (e) {
+        console.error(e);
+      }
+    })();
 
     return () => {
       controller.abort();


### PR DESCRIPTION
This PR updates demos to handle the new promise rejection behavior of `registerTool()`, following spec changes in webmachinelearning/webmcp#175. This specifically updates the demos that explicitly catch tool registration failures.