### PR TITLE
Add missing origin trial tokens to demos

### DIFF
--- a/demos/analytics-dashboard/index.html
+++ b/demos/analytics-dashboard/index.html
@@ -8,6 +8,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="origin-trial" content="AkSy8NN0hHVbV1Tcto9+K2cDotMP5NcgNobK+M8bhWqrxefn6KOq0cpv/Glx1A+/1EmTU4KmfdLhdcrIA7L8EwwAAABaeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZWNocm9tZWxhYnMuZ2l0aHViLmlvOjQ0MyIsImZlYXR1cmUiOiJXZWJNQ1AiLCJleHBpcnkiOjE3OTQ4NzM2MDB9">
     <title>webmcp-analytics-dashboard</title>
   </head>
   <body>

--- a/demos/explainer/index.html
+++ b/demos/explainer/index.html
@@ -8,6 +8,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="origin-trial" content="AkSy8NN0hHVbV1Tcto9+K2cDotMP5NcgNobK+M8bhWqrxefn6KOq0cpv/Glx1A+/1EmTU4KmfdLhdcrIA7L8EwwAAABaeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZWNocm9tZWxhYnMuZ2l0aHViLmlvOjQ0MyIsImZlYXR1cmUiOiJXZWJNQ1AiLCJleHBpcnkiOjE3OTQ4NzM2MDB9">
   <title>WebMCP — Give agents tools, not DOM</title>
   <meta name="description" content="A side-by-side demo of how AI agents interact with web pages today versus a future where pages expose structured tools via WebMCP." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
This PR adds OT tokens to `webmcp-analytics-dashboard` and `explainers` demos