### PR TITLE
`s/enable-features=WebMCPTesting/enable-features=WebMCP/g`

### DIFF
--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -99,7 +99,7 @@ export class VercelBackend implements Backend {
       browser = await puppeteer.launch({
         executablePath,
         headless: true,
-        args: ["--enable-features=WebMCPTesting", "--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--enable-features=WebMCP", "--no-sandbox", "--disable-setuid-sandbox"],
       });
 
       console.log("Browser initialized for actual evals");

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -101,7 +101,7 @@ export async function listToolsFromPage(url: string): Promise<Tool[]> {
     browser = await puppeteer.launch({
       executablePath,
       headless: true,
-      args: ["--enable-features=WebMCPTesting", "--no-sandbox", "--disable-setuid-sandbox"],
+      args: ["--enable-features=WebMCP", "--no-sandbox", "--disable-setuid-sandbox"],
     });
 
     const page = await browser.newPage();


### PR DESCRIPTION
This PR makes the evals-cli tool use the blink feature WebMCP instead of WebMCPTesting which is removed in https://chromium-review.googlesource.com/c/chromium/src/+/7921035/comment/1f0982d8_fb3efb91/