### PR TITLE
evals-cli: allow overriding provider base URLs via env

### DIFF
--- a/evals-cli/README.md
+++ b/evals-cli/README.md
@@ -55,6 +55,12 @@ The project is structured as follows:
     OPENAI_API_KEY=your_openai_api_key
     ANTHROPIC_API_KEY=your_anthropic_api_key
     # OLLAMA_HOST=http://localhost:11434 (if using a remote or non-standard port Ollama)
+
+    # Optional: override the provider endpoint (useful for corporate LLM
+    # gateways or self-hosted, OpenAI-compatible services).
+    # OPENAI_BASE_URL=https://your-proxy.example.com/v1
+    # ANTHROPIC_BASE_URL=https://your-proxy.example.com/anthropic
+    # GOOGLE_GENERATIVE_AI_BASE_URL=https://your-proxy.example.com/google
     ```
 
 3.  **Build the Project**

--- a/evals-cli/src/evaluator/models.ts
+++ b/evals-cli/src/evaluator/models.ts
@@ -14,13 +14,17 @@ export function getModel(config: Config | WebmcpConfig) {
   if (config.provider === "openai" || modelId.startsWith("openai:")) {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) console.warn("Warning: OPENAI_API_KEY is missing for OpenAI provider.");
-    return createOpenAI({ apiKey })(modelId.replace("openai:", ""));
+    return createOpenAI({ apiKey, baseURL: process.env.OPENAI_BASE_URL })(
+      modelId.replace("openai:", ""),
+    );
   }
 
   if (config.provider === "anthropic" || modelId.startsWith("anthropic:")) {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) console.warn("Warning: ANTHROPIC_API_KEY is missing for Anthropic provider.");
-    return createAnthropic({ apiKey })(modelId.replace("anthropic:", ""));
+    return createAnthropic({ apiKey, baseURL: process.env.ANTHROPIC_BASE_URL })(
+      modelId.replace("anthropic:", ""),
+    );
   }
 
   if (config.provider === "ollama" || modelId.startsWith("ollama:")) {
@@ -35,6 +39,9 @@ export function getModel(config: Config | WebmcpConfig) {
   const apiKey =
     process.env.GOOGLE_AI || process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
   if (!apiKey) console.warn("Warning: Missing Google/Gemini API key");
-  const google = createGoogleGenerativeAI({ apiKey });
+  const google = createGoogleGenerativeAI({
+    apiKey,
+    baseURL: process.env.GOOGLE_GENERATIVE_AI_BASE_URL,
+  });
   return google(modelId.replace("google:", ""));
 }


### PR DESCRIPTION
*Agent-generated PR*

## What

Adds optional `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, and `GOOGLE_GENERATIVE_AI_BASE_URL` environment variables to the eval-cli. When set, they are passed through to the corresponding `@ai-sdk/*` provider as `baseURL`. When unset, behavior is unchanged — each SDK falls back to its default provider endpoint.

The env-var names match the conventions used by the Vercel AI SDK ecosystem, so users who already have them configured for other tooling get consistent behavior.

## Why

Teams behind a corporate LLM gateway, or ones self-hosting an OpenAI-compatible endpoint (Azure OpenAI, LiteLLM, vLLM, an internal proxy, etc.), currently have no way to point `evals-cli` at their gateway. The provider `baseURL` is hardcoded to each SDK’s default.

The Ollama path already uses `OLLAMA_HOST` this way; this change makes the three cloud providers symmetric.

Concrete use case: at Shopify we route all internal LLM traffic through an OpenAI-compatible gateway fronting Gemini, GPT, Claude, and other providers. With this change we can follow the [Chrome WebMCP evals guide](https://developer.chrome.com/docs/ai/webmcp/evals) and use `evals-cli` directly against the gateway.

The gateway advertises an OpenAI-compatible surface for every underlying provider, so a single env override + the OpenAI provider covers Gemini/GPT/Claude/GLM/etc.

## Scope

Just the three provider entries in `src/evaluator/models.ts`, plus a small note in `README.md` alongside the existing env-var block. No new dependencies, no new CLI flags, no behavioral change when the vars are unset.

## Testing

- `npm run build` — clean
- `npm test` — 39/39 pass
- `npm run lint` — no new warnings (one pre-existing warning in `mappers.ts` unrelated to this change)
- `oxfmt --check` — clean
- End-to-end: ran all our eval cases via a real corporate OpenAI-compatible gateway, confirmed the request lands on the override URL rather than `api.openai.com`.

---

Co-Authored-By: AI (Claude Opus 4.7 via Pi)