### PR TITLE
evals-cli: use Chat Completions API for openai/ollama providers

### DIFF
--- a/evals-cli/src/evaluator/models.ts
+++ b/evals-cli/src/evaluator/models.ts
@@ -14,7 +14,12 @@ export function getModel(config: Config | WebmcpConfig) {
   if (config.provider === "openai" || modelId.startsWith("openai:")) {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) console.warn("Warning: OPENAI_API_KEY is missing for OpenAI provider.");
-    return createOpenAI({ apiKey, baseURL: process.env.OPENAI_BASE_URL })(
+    // Use the Chat Completions API rather than the Responses API. The Responses
+    // API is OpenAI-specific; every other "OpenAI-compatible" endpoint (Ollama,
+    // vLLM, LiteLLM, corporate gateways, etc.) only implements chat completions.
+    // Chat completions works against OpenAI itself as well, so this is a safe
+    // default that keeps `baseURL` overrides usable.
+    return createOpenAI({ apiKey, baseURL: process.env.OPENAI_BASE_URL }).chat(
       modelId.replace("openai:", ""),
     );
   }
@@ -32,7 +37,9 @@ export function getModel(config: Config | WebmcpConfig) {
       baseURL: process.env.OLLAMA_HOST || "http://127.0.0.1:11434/v1",
       apiKey: "ollama", // Required by standard but ignored by Ollama locally
     });
-    return ollama(modelId.replace("ollama:", ""));
+    // Ollama's OpenAI compatibility surface implements /v1/chat/completions,
+    // not /v1/responses.
+    return ollama.chat(modelId.replace("ollama:", ""));
   }
 
   // Default to Google


### PR DESCRIPTION
**_Agent-generated PR_**

### Problem

The `openai` provider path in `evaluator/models.ts` uses `@ai-sdk/openai`'s default `provider(modelId)` shorthand, which targets OpenAI's newer **Responses API** (`POST /v1/responses`).

That endpoint is OpenAI-proprietary. Every other "OpenAI-compatible" endpoint — Ollama, vLLM, LiteLLM, corporate LLM gateways, self-hosted proxies — only implements the classic **Chat Completions** surface at `POST /v1/chat/completions`.

The `OPENAI_BASE_URL` env var added in #249 is meant to let you route eval traffic through those gateways, but with the current default any such gateway returns:

```
AI_APICallError: Not Found
statusCode: 404
url: <gateway>/v1/responses
```

on every eval, so the whole story is unusable until you also point back at `api.openai.com` itself — which defeats the purpose.

### Fix

Switch to `provider.chat(modelId)`, which explicitly picks the Chat Completions transport. This is a safe default:

- OpenAI itself still serves Chat Completions and will for the foreseeable future.
- Every other OpenAI-compatible endpoint already only ever served this shape.
- Tool calling — the only thing the evals actually need from the model — works identically over Chat Completions.

Ollama gets the same one-line treatment for the same reason (its OpenAI compat surface is chat-completions-only).

### Verification

Against a real gateway that only implements `/v1/chat/completions`:

- **Before:** 0 pass / 0 fail / 10 errors on a 10-case suite (`AI_APICallError: Not Found` on every call, silently swallowed by `catch {}` in `evaluator/index.ts:112`).
- **After:** requests hit `/v1/chat/completions`, model returns tool-calls, the eval framework produces real pass/fail signal.

`npm test` → 39/39 pass unchanged.

