### PR TITLE
evals-cli: add multi-step trajectory support to executeLocalEvals

### DIFF
--- a/evals-cli/src/backends/index.ts
+++ b/evals-cli/src/backends/index.ts
@@ -5,10 +5,24 @@
 
 import { WebmcpConfig } from "../types/config.js";
 import { Eval, TestResult, TestResults } from "../types/evals.js";
-import { Tool } from "../types/tools.js";
+import { Tool, ToolCall } from "../types/tools.js";
+
+/**
+ * Result of running a single test through the local (non-browser) path.
+ *
+ * `toolCalls` is the full trajectory of tool invocations the model made
+ * across all agent-loop steps — in order — not just the first one. An
+ * empty array means the model responded with text and no tool calls.
+ *
+ * `text` is the model's final natural-language response, if any.
+ */
+export type LocalEvalResult = {
+  toolCalls: ToolCall[];
+  text?: string;
+};
 
 export interface Backend {
-  executeLocalEvals(test: Eval): Promise<any>;
+  executeLocalEvals(test: Eval): Promise<LocalEvalResult>;
 
   executeInBrowserEvals(
     tests: Array<Eval>,

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { generateText, ToolLoopAgent } from "ai";
+import { generateText, stepCountIs, ToolLoopAgent } from "ai";
 import puppeteer, { Browser, Page } from "puppeteer-core";
 import { Config, WebmcpConfig } from "../types/config.js";
 import { Eval, TestResult, TestResults } from "../types/evals.js";
 import { Tool, ToolCall } from "../types/tools.js";
 import { countExpectedCalls, evaluateExecutionTrajectory, findChromePath } from "../utils.js";
 
-import { Backend, RunEvent } from "../backends/index.js";
+import { Backend, LocalEvalResult, RunEvent } from "../backends/index.js";
 import { createBrowserTool } from "../evaluator/browser.js";
 import {
   mapJsonSchemaToVercelTools,
@@ -18,12 +18,19 @@ import {
   mapRawBrowserToolsToConfig,
 } from "../evaluator/mappers.js";
 import { getModel } from "../evaluator/models.js";
+import { MockResolver } from "../evaluator/mockResolver.js";
 import { SYSTEM_PROMPT } from "../evaluator/prompts.js";
+
+// Default upper bound on the local agent loop's step count. Large enough for
+// any reasonable trajectory in evals.json; small enough that a stuck model
+// terminates without burning tokens. Overridable via `--max-steps=N`.
+const DEFAULT_MAX_STEPS = 6;
 
 export class VercelBackend implements Backend {
   private aiModel: any;
   private modelName: string;
   private debug: boolean;
+  private maxSteps: number;
 
   constructor(
     config: Config | WebmcpConfig,
@@ -32,17 +39,27 @@ export class VercelBackend implements Backend {
     this.modelName = config.model || "gemini-3-flash-preview";
     this.aiModel = getModel(config);
     this.debug = !!config.debug;
+    this.maxSteps = config.maxSteps ?? DEFAULT_MAX_STEPS;
   }
 
-  async executeLocalEvals(test: Eval): Promise<any> {
+  async executeLocalEvals(test: Eval): Promise<LocalEvalResult> {
     const aiMessages = mapMessages(test.messages);
-    let aiResult;
 
-    aiResult = await generateText({
+    // Fresh resolver per test — cursor state must not leak across cases.
+    const resolver = new MockResolver(test.expectedCall);
+    const executableTools = mapJsonSchemaToVercelTools(this.tools, (fnName, args) =>
+      resolver.resolve(fnName, args),
+    );
+
+    const aiResult = await generateText({
       model: this.aiModel,
       system: SYSTEM_PROMPT,
       messages: aiMessages,
-      tools: mapJsonSchemaToVercelTools(this.tools),
+      tools: executableTools,
+      // Enables multi-step trajectories. Tools have execute functions now,
+      // so without a stopWhen the loop would run until the model itself
+      // stops calling tools — which can be never. Cap it explicitly.
+      stopWhen: stepCountIs(this.maxSteps),
       experimental_onToolCallStart: this.debug
         ? (event) => {
             console.log(`\n[DEBUG] Tool "${event.toolCall.toolName}" starting...`);
@@ -73,15 +90,20 @@ export class VercelBackend implements Backend {
         : undefined,
     });
 
-    if (aiResult.toolCalls && aiResult.toolCalls.length > 0) {
-      const call: any = aiResult.toolCalls[0];
-      return {
-        functionName: call.toolName,
-        args: call.input || call.args || call.arguments || {},
-      };
-    } else {
-      return { text: aiResult.text };
+    // Gather every tool call from every step in trajectory order. Previously
+    // only aiResult.toolCalls[0] was surfaced, which both dropped subsequent
+    // steps and dropped parallel calls within a single step.
+    const toolCalls: ToolCall[] = [];
+    for (const step of aiResult.steps ?? []) {
+      for (const call of (step.toolCalls ?? []) as any[]) {
+        toolCalls.push({
+          functionName: call.toolName,
+          args: call.input || call.args || call.arguments || {},
+        });
+      }
     }
+
+    return { toolCalls, text: aiResult.text };
   }
 
   async executeInBrowserEvals(

--- a/evals-cli/src/bin/runevals.ts
+++ b/evals-cli/src/bin/runevals.ts
@@ -40,6 +40,7 @@ const config: Config = {
   provider: args.provider,
   model: args.model || "gemini-3-flash-preview",
   runs: args.runs ? parseInt(args.runs, 10) : 1,
+  maxSteps: args["max-steps"] ? parseInt(args["max-steps"], 10) : undefined,
 };
 
 const toolsSchema: ToolsSchema = JSON.parse(

--- a/evals-cli/src/evaluator/index.ts
+++ b/evals-cli/src/evaluator/index.ts
@@ -69,11 +69,7 @@ export async function executeLocalEvals(
       testCount++;
       try {
         const response = await backendImpl.executeLocalEvals(test);
-
-        let executedCalls: ToolCall[] = [];
-        if (response && response.functionName) {
-          executedCalls = [response as ToolCall];
-        }
+        const executedCalls: ToolCall[] = response.toolCalls;
 
         const trajectories = test.expectedCall
           ? evaluateExecutionTrajectory(test.expectedCall, executedCalls)
@@ -110,7 +106,18 @@ export async function executeLocalEvals(
             }
           }
         }
-      } catch {
+      } catch (e) {
+        // Surface the underlying error even without --debug. Previously this
+        // catch swallowed everything, so backend/SDK/regex/etc. failures
+        // showed up as an opaque case-level ERROR with no way to diagnose
+        // without editing the CLI. Debug mode keeps the full stack.
+        const message = e instanceof Error ? e.message : String(e);
+        if (config.debug) {
+          console.error(`\n[eval error] ${test.name ?? "(unnamed)"}:`, e);
+        } else {
+          console.error(`\n[eval error] ${test.name ?? "(unnamed)"}: ${message}`);
+        }
+
         errorCount++;
         const result: TestResult = {
           test,

--- a/evals-cli/src/evaluator/mappers.ts
+++ b/evals-cli/src/evaluator/mappers.ts
@@ -85,9 +85,7 @@ export function mapJsonSchemaToVercelTools(
       description: toolDef.description,
       parameters: jsonSchema(parameters),
       inputSchema: jsonSchema(parameters),
-      ...(execute
-        ? { execute: async (args: unknown) => execute(toolDef.functionName, args) }
-        : {}),
+      ...(execute ? { execute: async (args: unknown) => execute(toolDef.functionName, args) } : {}),
     };
   });
 

--- a/evals-cli/src/evaluator/mappers.ts
+++ b/evals-cli/src/evaluator/mappers.ts
@@ -58,7 +58,23 @@ export function sanitizeSchema(obj: any): any {
   return clone;
 }
 
-export function mapJsonSchemaToVercelTools(inputTools: Tool[]): Record<string, any> {
+/**
+ * Convert WebMCP tool definitions into the Vercel AI SDK tool shape.
+ *
+ * When `execute` is provided, each generated tool gains an `execute`
+ * function that delegates to it, keyed by tool name. This turns tools
+ * from pure schemas into callables and, combined with a
+ * `stopWhen: stepCountIs(N > 1)` on `generateText`, lets the model loop
+ * across multiple tool-calling turns — which is what `executeLocalEvals`
+ * uses to drive multi-step trajectories via `MockResolver`.
+ *
+ * When `execute` is omitted, tools are returned as pure schemas and the
+ * SDK terminates after the first assistant turn — the legacy behavior.
+ */
+export function mapJsonSchemaToVercelTools(
+  inputTools: Tool[],
+  execute?: (functionName: string, args: unknown) => unknown | Promise<unknown>,
+): Record<string, any> {
   const tools: Record<string, any> = {};
   inputTools.forEach((toolDef: any) => {
     const hasParams = toolDef.parameters && Object.keys(toolDef.parameters).length > 0;
@@ -69,6 +85,9 @@ export function mapJsonSchemaToVercelTools(inputTools: Tool[]): Record<string, a
       description: toolDef.description,
       parameters: jsonSchema(parameters),
       inputSchema: jsonSchema(parameters),
+      ...(execute
+        ? { execute: async (args: unknown) => execute(toolDef.functionName, args) }
+        : {}),
     };
   });
 

--- a/evals-cli/src/evaluator/mockResolver.ts
+++ b/evals-cli/src/evaluator/mockResolver.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ExpectedCallNode, FunctionCall } from "../types/evals.js";
+import { isFunctionCall, isOrderedGroup, isUnorderedGroup } from "../utils.js";
+
+/**
+ * Resolves stub tool-result payloads for a single test case's local
+ * multi-step run.
+ *
+ * The resolver walks a flattened view of the test's `expectedCall`
+ * trajectory and, when the model invokes a tool matching an upcoming
+ * expected step, returns that step's `mockOutput` (defaulting to `{}`).
+ * Off-trajectory calls also receive `{}` — the trajectory matcher
+ * (`evaluateExecutionTrajectory`) is what scores whether the call was
+ * expected; the resolver only needs to give the model plausible-looking
+ * responses so it can decide what to do next.
+ *
+ * The matching is intentionally permissive:
+ *
+ *   1. Nodes are flattened in trajectory order across nested
+ *      `ordered:` / `unordered:` groups. Group semantics (any-order
+ *      inside an `unordered:`, strict order inside an `ordered:`) are
+ *      NOT re-enforced here — the matcher already handles that.
+ *   2. Matching is by `functionName` only. Argument constraints are for
+ *      the matcher; the resolver doesn't reject a call for having
+ *      "wrong" args (there's no such thing at this layer).
+ *   3. Each flattened node is consumed at most once. Once consumed, it
+ *      cannot resolve a later call — subsequent same-named calls fall
+ *      through to `{}`.
+ */
+export class MockResolver {
+  private readonly flat: FunctionCall[];
+  private readonly consumed: boolean[];
+
+  constructor(expected: ExpectedCallNode[] | null) {
+    this.flat = expected ? flattenTrajectory(expected) : [];
+    this.consumed = new Array(this.flat.length).fill(false);
+  }
+
+  resolve(functionName: string, _args: unknown): unknown {
+    for (let i = 0; i < this.flat.length; i++) {
+      if (this.consumed[i]) continue;
+      if (this.flat[i].functionName !== functionName) continue;
+
+      this.consumed[i] = true;
+      // Only `undefined` (field omitted from evals.json) defaults to `{}`.
+      // An explicit `null` is a valid mockOutput and is passed through.
+      const { mockOutput } = this.flat[i];
+      return mockOutput === undefined ? {} : mockOutput;
+    }
+    return {};
+  }
+}
+
+/**
+ * Recursively flattens an `ExpectedCallNode[]` trajectory into a flat
+ * ordered list of `FunctionCall` leaves. Order is preserved for
+ * `ordered:` groups; `unordered:` groups keep their authored order too,
+ * since the resolver's permissive matching (see class docs) doesn't
+ * depend on strict semantics.
+ */
+function flattenTrajectory(nodes: ExpectedCallNode[]): FunctionCall[] {
+  const out: FunctionCall[] = [];
+  for (const node of nodes) {
+    if (isFunctionCall(node)) {
+      out.push(node);
+    } else if (isOrderedGroup(node)) {
+      out.push(...flattenTrajectory(node.ordered));
+    } else if (isUnorderedGroup(node)) {
+      out.push(...flattenTrajectory(node.unordered));
+    }
+  }
+  return out;
+}

--- a/evals-cli/src/test/mockResolver.test.ts
+++ b/evals-cli/src/test/mockResolver.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import * as assert from "node:assert";
+import { MockResolver } from "../evaluator/mockResolver.js";
+import { ExpectedCallNode } from "../types/evals.js";
+
+describe("MockResolver", () => {
+  it("returns {} when there are no expected calls", () => {
+    const resolver = new MockResolver(null);
+    assert.deepStrictEqual(resolver.resolve("anything", {}), {});
+    assert.deepStrictEqual(resolver.resolve("anything", { x: 1 }), {});
+  });
+
+  it("returns {} for an empty expected array", () => {
+    const resolver = new MockResolver([]);
+    assert.deepStrictEqual(resolver.resolve("foo", {}), {});
+  });
+
+  it("returns a matching step's mockOutput on first invocation", () => {
+    const expected: ExpectedCallNode[] = [
+      {
+        functionName: "search_catalog",
+        mockOutput: { products: [{ id: "p1" }] },
+      },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("search_catalog", {}), {
+      products: [{ id: "p1" }],
+    });
+  });
+
+  it("returns {} when a matching step has no mockOutput", () => {
+    const expected: ExpectedCallNode[] = [{ functionName: "get_cart" }];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("get_cart", {}), {});
+  });
+
+  it("returns {} for off-trajectory tool calls", () => {
+    const expected: ExpectedCallNode[] = [
+      { functionName: "search_catalog", mockOutput: { products: [] } },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("update_cart", {}), {});
+  });
+
+  it("advances through a trajectory in order, one match per node", () => {
+    const expected: ExpectedCallNode[] = [
+      { functionName: "search_catalog", mockOutput: { step: 1 } },
+      { functionName: "get_product", mockOutput: { step: 2 } },
+      { functionName: "update_cart", mockOutput: { step: 3 } },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("search_catalog", {}), { step: 1 });
+    assert.deepStrictEqual(resolver.resolve("get_product", {}), { step: 2 });
+    assert.deepStrictEqual(resolver.resolve("update_cart", {}), { step: 3 });
+  });
+
+  it("does not resolve the same step twice", () => {
+    const expected: ExpectedCallNode[] = [
+      { functionName: "get_cart", mockOutput: { first: true } },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("get_cart", {}), { first: true });
+    // Second call to same function falls through to `{}` — the expected node
+    // was already consumed.
+    assert.deepStrictEqual(resolver.resolve("get_cart", {}), {});
+  });
+
+  it("flattens ordered groups into a linear sequence", () => {
+    const expected: ExpectedCallNode[] = [
+      {
+        ordered: [
+          { functionName: "search_catalog", mockOutput: { search: true } },
+          { functionName: "get_product", mockOutput: { product: true } },
+        ],
+      },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("search_catalog", {}), { search: true });
+    assert.deepStrictEqual(resolver.resolve("get_product", {}), { product: true });
+  });
+
+  it("flattens unordered groups and matches by function name regardless of authored order", () => {
+    // Authored order inside `unordered:` is get_product first, update_cart
+    // second, but the model may call them in either order. The resolver
+    // matches on function name and consumes each node once.
+    const expected: ExpectedCallNode[] = [
+      {
+        unordered: [
+          { functionName: "get_product", mockOutput: { got: "product" } },
+          { functionName: "update_cart", mockOutput: { got: "cart" } },
+        ],
+      },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("update_cart", {}), { got: "cart" });
+    assert.deepStrictEqual(resolver.resolve("get_product", {}), { got: "product" });
+  });
+
+  it("flattens nested ordered + unordered groups", () => {
+    const expected: ExpectedCallNode[] = [
+      {
+        ordered: [
+          { functionName: "search_catalog", mockOutput: { s: 1 } },
+          {
+            unordered: [
+              { functionName: "get_product", mockOutput: { s: 2 } },
+              { functionName: "update_cart", mockOutput: { s: 3 } },
+            ],
+          },
+        ],
+      },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("search_catalog", {}), { s: 1 });
+    assert.deepStrictEqual(resolver.resolve("get_product", {}), { s: 2 });
+    assert.deepStrictEqual(resolver.resolve("update_cart", {}), { s: 3 });
+  });
+
+  it("matches on function name only — args are not consulted", () => {
+    // The matcher (evaluateExecutionTrajectory) is what scores arguments.
+    // The resolver's job is just to hand the model a plausible response so
+    // it can decide what to do next, even if the model got the args wrong.
+    const expected: ExpectedCallNode[] = [
+      {
+        functionName: "search_catalog",
+        arguments: { catalog: { query: "shoe" } },
+        mockOutput: { products: [{ id: "wanted" }] },
+      },
+    ];
+    const resolver = new MockResolver(expected);
+    // Model called with "pizza" instead of "shoe" — resolver still returns
+    // the mockOutput; the matcher will flag the arguments mismatch.
+    assert.deepStrictEqual(resolver.resolve("search_catalog", { catalog: { query: "pizza" } }), {
+      products: [{ id: "wanted" }],
+    });
+  });
+
+  it("keeps state per resolver instance (fresh cursor each test case)", () => {
+    const expected: ExpectedCallNode[] = [
+      { functionName: "get_cart", mockOutput: { fresh: true } },
+    ];
+    const a = new MockResolver(expected);
+    const b = new MockResolver(expected);
+    assert.deepStrictEqual(a.resolve("get_cart", {}), { fresh: true });
+    // Second instance still has its own unconsumed node.
+    assert.deepStrictEqual(b.resolve("get_cart", {}), { fresh: true });
+  });
+
+  it("allows mockOutput to be an arbitrary JSON value, not just an object", () => {
+    // The API surfaces `unknown` — arrays, strings, numbers, null are all valid.
+    const expected: ExpectedCallNode[] = [
+      { functionName: "list_ids", mockOutput: ["a", "b", "c"] },
+      { functionName: "count_items", mockOutput: 42 },
+      { functionName: "was_found", mockOutput: false },
+      { functionName: "get_note", mockOutput: null },
+    ];
+    const resolver = new MockResolver(expected);
+    assert.deepStrictEqual(resolver.resolve("list_ids", {}), ["a", "b", "c"]);
+    assert.strictEqual(resolver.resolve("count_items", {}), 42);
+    assert.strictEqual(resolver.resolve("was_found", {}), false);
+    assert.strictEqual(resolver.resolve("get_note", {}), null);
+  });
+});

--- a/evals-cli/src/types/config.ts
+++ b/evals-cli/src/types/config.ts
@@ -11,6 +11,11 @@ export type Config = {
   model: string;
   debug?: boolean;
   runs?: number;
+  // Upper bound on the local agent loop's step count. Fed to
+  // `stopWhen: stepCountIs(maxSteps)` in `executeLocalEvals`. Larger values
+  // let longer trajectories complete; smaller values cap runaway loops.
+  // Ignored by `executeInBrowserEvals`.
+  maxSteps?: number;
 };
 
 export type WebmcpConfig = {
@@ -21,4 +26,5 @@ export type WebmcpConfig = {
   model: string;
   debug?: boolean;
   runs?: number;
+  maxSteps?: number;
 };

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -43,6 +43,11 @@ export type FunctionCall = {
   // Optional: when omitted (or explicitly null), the eval imposes no
   // constraint on the tool call's arguments — any actual args are accepted.
   arguments?: object | null;
+  // Optional: mock output returned to the model when it invokes this tool
+  // during a local (non-browser) multi-step trajectory. When omitted, an
+  // empty object `{}` is returned. Only consulted by `executeLocalEvals` —
+  // browser evals always use real tool results.
+  mockOutput?: unknown;
 };
 
 export type TestResult = {


### PR DESCRIPTION
*_AI generated - Claude Opus 4.7_*

Fixes https://github.com/GoogleChromeLabs/webmcp-tools/issues/264

Changes:
```

 ┌───────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ File                          │ Change                                                                                                                                                                           │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/types/evals.ts            │ FunctionCall.mockOutput?: unknown                                                                                                                                                │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/types/config.ts           │ Config.maxSteps?: number (both variants)                                                                                                                                         │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/evaluator/mockResolver.ts │ NEW — trajectory-flattening cursor-based resolver, ~80 lines                                                                                                                     │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/evaluator/mappers.ts      │ mapJsonSchemaToVercelTools takes optional execute callback (backward-compatible)                                                                                                 │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/backends/index.ts         │ New LocalEvalResult = { toolCalls[], text? } return type on the Backend interface                                                                                                │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/backends/vercel.ts        │ executeLocalEvals builds a MockResolver, wraps tools with execute, adds stopWhen: stepCountIs(6), gathers all steps[*].toolCalls (fixes the [0] truncation as a natural side     │
 │                               │ effect)                                                                                                                                                                          │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/evaluator/index.ts        │ Adapt caller for array return; catch now surfaces e.message (or full e under --debug) instead of silently registering ERROR                                                      │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/bin/runevals.ts           │ --max-steps=N flag plumbed through Config                                                                                                                                        │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ src/test/mockResolver.test.ts │ NEW — 13 tests covering resolver behavior                                                                                                                                        │
 └───────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```