### PR TITLE
evals-cli: honor inline flag prefix `(?flags)` in $pattern

### DIFF
--- a/evals-cli/src/matcher.ts
+++ b/evals-cli/src/matcher.ts
@@ -40,7 +40,7 @@ function matchesConstraint(constraint: any, actual: any): boolean {
       if (typeof actual !== "string") {
         return false;
       }
-      const pattern = new RegExp(constraint[key]);
+      const pattern = buildPattern(constraint[key]);
       if (!pattern.test(actual)) {
         return false;
       }
@@ -77,6 +77,43 @@ function matchesConstraint(constraint: any, actual: any): boolean {
     // Future constraints will go here
   }
   return true;
+}
+
+/**
+ * JS regex flags accepted by `new RegExp(pattern, flags)`. `x` (extended,
+ * POSIX/Perl free-spacing) is deliberately NOT included — V8 doesn't support
+ * it and silently accepting it would give eval authors a false sense that
+ * whitespace/comments in patterns are ignored.
+ */
+const SUPPORTED_INLINE_FLAGS = new Set(["d", "g", "i", "m", "s", "u", "v", "y"]);
+
+/**
+ * Build a RegExp from a `$pattern` value.
+ *
+ * Accepts an optional leading inline-flag prefix `(?flags)` — POSIX/Python
+ * syntax that eval authors reach for reflexively when they want
+ * case-insensitive matching, e.g. `"(?i)^colou?r$"`. V8 doesn't parse the
+ * `(?flags)` form natively, so without stripping it here the RegExp
+ * constructor throws `SyntaxError: Invalid group` and the whole eval turns
+ * into an opaque case-level ERROR.
+ *
+ * Supported flag characters are the ones `new RegExp(pattern, flags)`
+ * accepts (`d g i m s u v y`). Unknown flags throw.
+ */
+function buildPattern(rawPattern: string): RegExp {
+  const match = /^\(\?([a-zA-Z]+)\)/.exec(rawPattern);
+  if (!match) return new RegExp(rawPattern);
+
+  const flags = match[1];
+  for (const flag of flags) {
+    if (!SUPPORTED_INLINE_FLAGS.has(flag)) {
+      throw new SyntaxError(
+        `Unsupported inline flag "(?${flag})" in $pattern ${JSON.stringify(rawPattern)}. ` +
+          `Supported flags: ${[...SUPPORTED_INLINE_FLAGS].join(", ")}.`,
+      );
+    }
+  }
+  return new RegExp(rawPattern.slice(match[0].length), flags);
 }
 
 /**

--- a/evals-cli/src/test/matcher.test.ts
+++ b/evals-cli/src/test/matcher.test.ts
@@ -98,7 +98,10 @@ describe("matcher", () => {
         it("does not swallow a genuine SyntaxError from a malformed pattern", () => {
           // Malformed regexes still throw — the shim only handles the inline
           // flag prefix, not general error recovery.
-          assert.throws(() => matchesArgument({ $pattern: "(?i)[unclosed" }, "anything"), SyntaxError);
+          assert.throws(
+            () => matchesArgument({ $pattern: "(?i)[unclosed" }, "anything"),
+            SyntaxError,
+          );
         });
       });
     });

--- a/evals-cli/src/test/matcher.test.ts
+++ b/evals-cli/src/test/matcher.test.ts
@@ -53,6 +53,54 @@ describe("matcher", () => {
         assert.strictEqual(matchesArgument({ $pattern: ".*" }, 123), false);
         assert.strictEqual(matchesArgument({ $pattern: ".*" }, null), false);
       });
+
+      describe("inline flag prefix", () => {
+        it("honors (?i) for case-insensitive matching", () => {
+          // The bare regex `^colour$` is case-sensitive in V8, and `(?i)` is
+          // POSIX/Python syntax that V8 doesn't parse natively — without the
+          // `buildPattern` shim this would throw SyntaxError.
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)^colou?r$" }, "Color"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)^colou?r$" }, "colour"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)^colou?r$" }, "COLOR"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)^colou?r$" }, "colourful"), false);
+        });
+
+        it("honors (?i) mid-substring", () => {
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)purple" }, "Purple Shoes"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)purple" }, "BUY PURPLE!"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)purple" }, "red"), false);
+        });
+
+        it("honors multiple inline flags, e.g. (?is)", () => {
+          // `s` (dotall) lets `.` match newlines; `i` is case-insensitive.
+          // Both should compose from a single prefix.
+          assert.strictEqual(matchesArgument({ $pattern: "(?is)foo.bar" }, "FOO\nBAR"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "(?i)foo.bar" }, "FOO\nBAR"), false);
+        });
+
+        it("leaves patterns without an inline-flag prefix unchanged", () => {
+          // Regression guard: patterns that don't start with `(?flags)` must
+          // continue to work with case-sensitive default matching.
+          assert.strictEqual(matchesArgument({ $pattern: "^Color$" }, "Color"), true);
+          assert.strictEqual(matchesArgument({ $pattern: "^Color$" }, "color"), false);
+        });
+
+        it("throws on unsupported inline flags with a useful message", () => {
+          // `x` (extended, POSIX/Perl free-spacing) is not supported by V8 —
+          // silently accepting it would mislead authors into thinking
+          // whitespace/comments in patterns get stripped.
+          assert.throws(
+            () => matchesArgument({ $pattern: "(?x) foo # bar" }, "foo"),
+            /Unsupported inline flag "\(\?x\)"/,
+          );
+        });
+
+        it("does not swallow a genuine SyntaxError from a malformed pattern", () => {
+          // Malformed regexes still throw — the shim only handles the inline
+          // flag prefix, not general error recovery.
+          assert.throws(() => matchesArgument({ $pattern: "(?i)[unclosed" }, "anything"), SyntaxError);
+        });
+      });
     });
 
     describe("$contains", () => {


### PR DESCRIPTION
*_AI generated - Claude Opus 4.7_*

### Problem

The matcher's `$pattern` constraint builds regexes with `new RegExp(constraint[key])` — no flags argument (`matcher.ts:44`). V8 doesn't parse the POSIX/Python-style `(?flags)` inline-flag prefix natively, so any eval author who reaches for the familiar `"(?i)^colou?r$"` idiom hits:

```
SyntaxError: Invalid regular expression: /(?i)^colou?r$/: Invalid group
```

That `SyntaxError` propagates out of `matchesConstraint`, up through `matchesArgument`, and gets caught by the `catch {}` in `evaluator/index.ts` — registering as an opaque case-level ERROR with no actionable output. I lost a chunk of time diagnosing this because the failing eval looked structurally identical to passing ones. (The `catch` block's error-swallowing was addressed in the multi-step PR that just merged, so from this point on the underlying error at least surfaces to stderr — but eval authors still can't use natural regex flag syntax.)

### Fix

Parse a leading `(?flags)` prefix in `$pattern` values, translate it to the flags argument of `new RegExp(pattern, flags)`, and strip it from the pattern body. Supported flag characters are the subset V8's `RegExp` accepts: `d g i m s u v y`.

Unknown flags throw a useful error rather than being silently dropped — `(?x)` (extended, POSIX/Perl free-spacing) is the obvious footgun there and would mislead authors into thinking whitespace/comments get stripped.

Patterns without the `(?flags)` prefix are untouched: they continue through `new RegExp(pattern)` with default (case-sensitive) matching, so no existing evals change behavior.

### Tests

Added 6 tests in `matcher.test.ts` covering:

- `(?i)` matches case-insensitively (anchored and unanchored).
- Multiple flags compose from a single prefix, e.g. `(?is)`.
- Patterns without a prefix retain case-sensitive default matching (regression guard).
- Unsupported flags (`(?x)`) throw with a message pointing at the offending flag and the pattern.
- Genuinely malformed patterns (e.g. `(?i)[unclosed`) still throw `SyntaxError` — the shim only handles the flag prefix, not general error recovery.

Existing 60/60 tests still pass; 66/66 with the new ones.

### Real-world context

Found while authoring a case-insensitive `$pattern` for Shopify option-name matching (`{"$pattern": "(?i)^colou?r$"}` to match `"Color"` / `"Colour"`). Rewrote as `"^[Cc]olou?r$"` as a workaround — this PR unblocks the more natural form.

