### PR TITLE
evals-cli: preserve Gemini `thought_signature` on OpenAI-compat multi-turn

### DIFF
--- a/evals-cli/src/evaluator/googleThoughtSignatures.ts
+++ b/evals-cli/src/evaluator/googleThoughtSignatures.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Vertex-backed Gemini (via any OpenAI-compat proxy that fronts Vertex)
+ * emits a `thought_signature` field per tool_call and rejects follow-up
+ * requests that don't echo it back:
+ *
+ *     Unable to submit request because function call `X` in the 2. content
+ *     block is missing a `thought_signature`.
+ *
+ * The signature lives in a provider-extension field
+ * (`tool_calls[N].extra_content.google.thought_signature`) that
+ * `@ai-sdk/openai` doesn't preserve when it builds the next turn's
+ * message history from the previous assistant response. So without any
+ * intervention, multi-turn tool-calling against Gemini through an
+ * OpenAI-compat proxy 400s on the second turn.
+ *
+ * This is a client-side workaround: a `fetch` wrapper that
+ *   1. Intercepts responses and stashes `thought_signature` values,
+ *      keyed by their tool_call `id`.
+ *   2. Intercepts subsequent requests and re-injects the stashed
+ *      signatures into the outgoing `tool_calls[]` inside assistant
+ *      messages.
+ *
+ * The wrapper is scoped per model instance (a fresh Map per
+ * `makeSignaturePreservingFetch()` call), so it doesn't leak signatures
+ * across independent eval runs. Non-JSON responses (e.g. SSE from
+ * streaming APIs) pass through untouched — this only helps
+ * `generateText`-style, non-streaming flows, which is what
+ * `executeLocalEvals` uses.
+ *
+ * Zero-cost for providers that don't emit `extra_content` (OpenAI,
+ * Anthropic-via-compat, Ollama, ...) — the stash simply stays empty and
+ * outgoing requests are unchanged.
+ */
+export function makeSignaturePreservingFetch(): typeof fetch {
+  const signaturesByCallId = new Map<string, string>();
+
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    // ---- outgoing: re-inject stashed signatures --------------------------
+    if (init?.body && typeof init.body === "string" && signaturesByCallId.size > 0) {
+      const patched = injectStashedSignatures(init.body, signaturesByCallId);
+      if (patched !== init.body) {
+        init = { ...init, body: patched };
+      }
+    }
+
+    const res = await fetch(input, init);
+
+    // ---- incoming: stash any newly-emitted signatures --------------------
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!contentType.includes("application/json")) return res;
+
+    // Buffer the body once, then hand back a fresh Response so downstream
+    // consumers can still call .json()/.text() as normal.
+    const raw = await res.clone().text();
+    try {
+      const parsed = JSON.parse(raw) as ChatCompletionResponse;
+      for (const choice of parsed.choices ?? []) {
+        for (const tc of choice.message?.tool_calls ?? []) {
+          const sig = tc.extra_content?.google?.thought_signature;
+          if (sig && typeof tc.id === "string") {
+            signaturesByCallId.set(tc.id, sig);
+          }
+        }
+      }
+    } catch {
+      // Non-JSON body despite the header — leave untouched.
+    }
+
+    return res;
+  };
+}
+
+/**
+ * Walk the outgoing request body's `messages[]`, find each assistant
+ * message's `tool_calls[]`, and inject a stashed `thought_signature` for
+ * any call whose `id` we've seen a signature for and that doesn't already
+ * carry one.
+ *
+ * Returns the (possibly-modified) body as a string, or the original
+ * string if nothing changed / it wasn't parseable JSON.
+ */
+function injectStashedSignatures(body: string, stash: Map<string, string>): string {
+  let parsed: ChatCompletionRequest;
+  try {
+    parsed = JSON.parse(body) as ChatCompletionRequest;
+  } catch {
+    return body;
+  }
+  if (!Array.isArray(parsed.messages)) return body;
+
+  let mutated = false;
+  for (const msg of parsed.messages) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.tool_calls)) continue;
+    for (const tc of msg.tool_calls) {
+      if (!tc.id || tc.extra_content?.google?.thought_signature) continue;
+      const sig = stash.get(tc.id);
+      if (!sig) continue;
+      tc.extra_content = { ...tc.extra_content, google: { thought_signature: sig } };
+      mutated = true;
+    }
+  }
+  return mutated ? JSON.stringify(parsed) : body;
+}
+
+/** Minimal shapes we care about. Everything else is untouched. */
+interface ChatCompletionRequest {
+  messages?: Array<{
+    role: string;
+    tool_calls?: Array<{
+      id?: string;
+      extra_content?: { google?: { thought_signature?: string } };
+    }>;
+  }>;
+}
+interface ChatCompletionResponse {
+  choices?: Array<{
+    message?: {
+      tool_calls?: Array<{
+        id?: string;
+        extra_content?: { google?: { thought_signature?: string } };
+      }>;
+    };
+  }>;
+}

--- a/evals-cli/src/evaluator/models.ts
+++ b/evals-cli/src/evaluator/models.ts
@@ -7,6 +7,7 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { Config, WebmcpConfig } from "../types/config.js";
+import { makeSignaturePreservingFetch } from "./googleThoughtSignatures.js";
 
 export function getModel(config: Config | WebmcpConfig) {
   const modelId = config.model || "google:gemini-3-flash-preview";
@@ -19,9 +20,22 @@ export function getModel(config: Config | WebmcpConfig) {
     // vLLM, LiteLLM, corporate gateways, etc.) only implements chat completions.
     // Chat completions works against OpenAI itself as well, so this is a safe
     // default that keeps `baseURL` overrides usable.
-    return createOpenAI({ apiKey, baseURL: process.env.OPENAI_BASE_URL }).chat(
-      modelId.replace("openai:", ""),
-    );
+    //
+    // When the compat proxy fronts Vertex-backed Gemini (detected by the
+    // model id), inject a fetch wrapper that preserves `thought_signature`
+    // fields across multi-turn tool-calling — without it, Vertex 400s on
+    // turn 2. Auto-enable to keep single-line usage working; force on/off
+    // via OPENAI_PRESERVE_GOOGLE_THOUGHT_SIGNATURES=1|0 if the heuristic
+    // gets it wrong.
+    const gemini = /(?:^|[:/])(google|gemini)/.test(modelId);
+    const envFlag = process.env.OPENAI_PRESERVE_GOOGLE_THOUGHT_SIGNATURES;
+    const preserveSignatures = envFlag === "1" || (envFlag !== "0" && gemini);
+
+    return createOpenAI({
+      apiKey,
+      baseURL: process.env.OPENAI_BASE_URL,
+      ...(preserveSignatures ? { fetch: makeSignaturePreservingFetch() } : {}),
+    }).chat(modelId.replace("openai:", ""));
   }
 
   if (config.provider === "anthropic" || modelId.startsWith("anthropic:")) {

--- a/evals-cli/src/test/googleThoughtSignatures.test.ts
+++ b/evals-cli/src/test/googleThoughtSignatures.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import * as assert from "node:assert";
+import { makeSignaturePreservingFetch } from "../evaluator/googleThoughtSignatures.js";
+
+/**
+ * A tiny mock of the global `fetch` that captures the request body it was
+ * called with and returns a canned Response. Used to prove the middleware
+ * injects/extracts fields at the boundary without hitting a real API.
+ */
+function makeMockFetch(responseBody: unknown): {
+  fetch: typeof fetch;
+  capturedRequests: Array<{ url: string; body: string | undefined }>;
+} {
+  const capturedRequests: Array<{ url: string; body: string | undefined }> = [];
+  const mockFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    capturedRequests.push({
+      url: typeof input === "string" ? input : input.toString(),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch: mockFetch as any, capturedRequests };
+}
+
+describe("makeSignaturePreservingFetch", () => {
+  it("passes through when neither request nor response carry signatures", async () => {
+    const { fetch: mock, capturedRequests } = makeMockFetch({
+      choices: [{ message: { content: "hi", role: "assistant" } }],
+    });
+    const original = globalThis.fetch;
+    globalThis.fetch = mock;
+    try {
+      const wrapped = makeSignaturePreservingFetch();
+      const res = await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      });
+      const parsed = await res.json();
+      assert.strictEqual(parsed.choices[0].message.content, "hi");
+      assert.strictEqual(capturedRequests.length, 1);
+      // Body forwarded unchanged when the wrapper has nothing to inject.
+      assert.deepStrictEqual(JSON.parse(capturedRequests[0].body!), {
+        messages: [{ role: "user", content: "hi" }],
+      });
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("stashes a thought_signature from a tool_call response", async () => {
+    // First response includes a signature; second request's assistant
+    // message should carry the same signature back.
+    const original = globalThis.fetch;
+    const { fetch: mock, capturedRequests } = makeMockFetch({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: { name: "search_catalog", arguments: "{}" },
+                extra_content: { google: { thought_signature: "SIG-1" } },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    globalThis.fetch = mock;
+    try {
+      const wrapped = makeSignaturePreservingFetch();
+
+      // Turn 1: user prompt, no assistant messages yet.
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({ messages: [{ role: "user", content: "search" }] }),
+      });
+
+      // Turn 2: caller replays the assistant tool_call in message history
+      // *without* the signature (as the AI SDK's OpenAI provider does today).
+      // The middleware should splice the stashed SIG-1 back in.
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            { role: "user", content: "search" },
+            {
+              role: "assistant",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: { name: "search_catalog", arguments: "{}" },
+                },
+              ],
+            },
+            { role: "tool", tool_call_id: "call-1", content: "{}" },
+          ],
+        }),
+      });
+
+      const turn2Body = JSON.parse(capturedRequests[1].body!);
+      const signature =
+        turn2Body.messages[1].tool_calls[0].extra_content?.google?.thought_signature;
+      assert.strictEqual(signature, "SIG-1");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("does not overwrite a signature that's already present on the request", async () => {
+    const original = globalThis.fetch;
+    const { fetch: mock, capturedRequests } = makeMockFetch({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: { name: "f", arguments: "{}" },
+                extra_content: { google: { thought_signature: "OLD-SIG" } },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    globalThis.fetch = mock;
+    try {
+      const wrapped = makeSignaturePreservingFetch();
+
+      // Turn 1: stash OLD-SIG.
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({ messages: [{ role: "user", content: "x" }] }),
+      });
+
+      // Turn 2: caller already provided their own signature. Wrapper must
+      // respect it rather than overwrite from the stash.
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "assistant",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: { name: "f", arguments: "{}" },
+                  extra_content: { google: { thought_signature: "CALLER-PROVIDED" } },
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      const turn2Body = JSON.parse(capturedRequests[1].body!);
+      const signature =
+        turn2Body.messages[0].tool_calls[0].extra_content?.google?.thought_signature;
+      assert.strictEqual(signature, "CALLER-PROVIDED");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("stashes signatures per tool_call id independently", async () => {
+    const original = globalThis.fetch;
+    const { fetch: mock, capturedRequests } = makeMockFetch({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-A",
+                type: "function",
+                function: { name: "f", arguments: "{}" },
+                extra_content: { google: { thought_signature: "SIG-A" } },
+              },
+              {
+                id: "call-B",
+                type: "function",
+                function: { name: "g", arguments: "{}" },
+                extra_content: { google: { thought_signature: "SIG-B" } },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    globalThis.fetch = mock;
+    try {
+      const wrapped = makeSignaturePreservingFetch();
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({ messages: [] }),
+      });
+      // Turn 2 replays both tool_calls without signatures.
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "assistant",
+              tool_calls: [
+                { id: "call-A", type: "function", function: { name: "f", arguments: "{}" } },
+                { id: "call-B", type: "function", function: { name: "g", arguments: "{}" } },
+              ],
+            },
+          ],
+        }),
+      });
+      const body = JSON.parse(capturedRequests[1].body!);
+      assert.strictEqual(
+        body.messages[0].tool_calls[0].extra_content.google.thought_signature,
+        "SIG-A",
+      );
+      assert.strictEqual(
+        body.messages[0].tool_calls[1].extra_content.google.thought_signature,
+        "SIG-B",
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("ignores non-JSON responses without erroring", async () => {
+    // Streaming (SSE) or other non-JSON content types should pass through
+    // without the middleware attempting to parse them.
+    const capturedRequests: Array<{ url: string; body: string | undefined }> = [];
+    const mock: typeof fetch = async (input, init) => {
+      capturedRequests.push({
+        url: typeof input === "string" ? input : input.toString(),
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      return new Response("data: chunk\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+    const original = globalThis.fetch;
+    globalThis.fetch = mock;
+    try {
+      const wrapped = makeSignaturePreservingFetch();
+      const res = await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({ messages: [] }),
+      });
+      const text = await res.text();
+      assert.strictEqual(text, "data: chunk\n\n");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("survives a malformed request body (invalid JSON)", async () => {
+    const original = globalThis.fetch;
+    const { fetch: mock, capturedRequests } = makeMockFetch({ choices: [] });
+    globalThis.fetch = mock;
+    try {
+      const wrapped = makeSignaturePreservingFetch();
+      // First stash a signature so the wrapper has something to try to inject.
+      // (Populates the internal Map so the injection path runs.)
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "assistant",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: { name: "f", arguments: "{}" },
+                  extra_content: { google: { thought_signature: "SIG" } },
+                },
+              ],
+            },
+          ],
+        }),
+      });
+      // Now send an unparseable body. Should not throw, request should still
+      // fire with the body forwarded unchanged.
+      await wrapped("https://example/api", {
+        method: "POST",
+        body: "not-json{",
+      });
+      assert.strictEqual(capturedRequests[1].body, "not-json{");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("keeps per-instance state isolated (fresh Map per factory call)", async () => {
+    const original = globalThis.fetch;
+    const { fetch: mock, capturedRequests } = makeMockFetch({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: { name: "f", arguments: "{}" },
+                extra_content: { google: { thought_signature: "SIG-FIRST" } },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    globalThis.fetch = mock;
+    try {
+      // First wrapper stashes SIG-FIRST for call-1.
+      const first = makeSignaturePreservingFetch();
+      await first("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({ messages: [] }),
+      });
+      // A second, independent wrapper should not see SIG-FIRST.
+      const second = makeSignaturePreservingFetch();
+      await second("https://example/api", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "assistant",
+              tool_calls: [
+                { id: "call-1", type: "function", function: { name: "f", arguments: "{}" } },
+              ],
+            },
+          ],
+        }),
+      });
+      const body = JSON.parse(capturedRequests[1].body!);
+      assert.strictEqual(body.messages[0].tool_calls[0].extra_content, undefined);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});


### PR DESCRIPTION
*_Generated by AI: Claude Opus 4.7_*

### Problem

Vertex-backed Gemini (via any OpenAI-compat proxy that fronts Vertex — Google's own compat endpoint, Shopify's AI proxy, corporate LiteLLM instances, etc.) emits a `thought_signature` field on every tool_call:

```json
{
  "tool_calls": [{
    "id": "call-1",
    "function": { "name": "search_catalog", "arguments": "{...}" },
    "extra_content": { "google": { "thought_signature": "AY89a..." } }
  }]
}
```

Vertex rejects follow-up requests that don't echo it back:

```
Unable to submit request because function call `search_catalog` in the 2.
content block is missing a `thought_signature`.
```

`@ai-sdk/openai` doesn't know about the `extra_content` provider-extension field, so when it builds turn N+1's message history from the previous assistant response it drops the signature. The net effect: multi-turn tool-calling against any Gemini variant through an OpenAI-compat proxy 400s on the second turn.

I ran into this while pointing the newly-merged `executeLocalEvals` multi-step support (that PR you just landed) at Vertex Gemini through the Shopify AI proxy — every case in an 11-eval suite errored on turn 2 with that message. Confirmed via direct `curl` against `POST /v1/chat/completions` that echoing the signature back inside `tool_calls[N].extra_content.google.thought_signature` on the second turn makes the same request succeed — the fix is fully client-side.

### Fix

A tiny `fetch` wrapper (`evaluator/googleThoughtSignatures.ts`, ~130 lines with docs) that:

1. **Intercepts responses** and stashes any `thought_signature` values, keyed by their tool_call `id`, in a per-instance `Map`.
2. **Intercepts subsequent requests** and re-injects the stashed signatures into outgoing `tool_calls[]` inside assistant messages — but only for calls that don't already carry one, so a caller who explicitly provides `extra_content` wins.

Wired into `getModel` on the OpenAI-compat path. Auto-enabled when the model id looks Google-shaped (`openai:google:*` or `openai:*gemini*`); force on/off via `OPENAI_PRESERVE_GOOGLE_THOUGHT_SIGNATURES=1|0`. Pure OpenAI / Anthropic-via-compat / Ollama traffic pays zero cost — those responses never carry `extra_content`, so the stash stays empty and outgoing requests are unchanged.

### Scope

- **Non-streaming only.** `generateText` (which `executeLocalEvals` uses) is non-streaming; that covers the immediate need. Streaming (SSE) support would need SSE-aware buffering to peek at each chunk; deferred until there's a caller that needs it.
- **JSON responses only.** Non-JSON content types (`text/event-stream`, etc.) pass through without inspection.
- **Per-instance state.** A fresh `Map` per `makeSignaturePreservingFetch()` call, so signatures don't leak across independent eval runs.

### Verification

Against a real Vertex-fronted proxy, my 11-case suite:

- **Before:** all 11 cases errored (`AI_APICallError: Bad Request` on turn 2, silently swallowed as case-level ERRORs before your recent `catch` fix)
- **After:** 0 framework errors, multi-step trajectories complete cleanly

Remaining suite failures are unrelated eval-authoring quirks (Gemini over-explores when a mock returns `{}`, matcher exact-key-set strictness on args like `pagination`) — I'll open a separate issue about the matcher strictness.

### Tests

7 new tests in `googleThoughtSignatures.test.ts`:

- Passthrough when no signatures are in play
- Extract-from-response, inject-into-next-request round trip
- Respect a caller-provided signature (no overwrite)
- Per-tool_call-id stashing (parallel calls in one turn)
- Non-JSON responses (SSE) pass through cleanly
- Malformed request bodies don't throw
- Fresh `Map` per factory call (isolation across independent eval runs)

Existing 66/66 pass; 73/73 with the new ones.


