### PR TITLE
evals-cli: subset-match arguments in `matchesRecursive`

### DIFF
--- a/evals-cli/src/matcher.ts
+++ b/evals-cli/src/matcher.ts
@@ -137,12 +137,20 @@ function isConstraintObject(obj: any): boolean {
 
 /**
  * Recursively checks equality between two values.
- * If values are objects or arrays, it recurses into them.
- * Crucially, it calls `matchesArgument` for children, enabling nested constraints.
  *
- * @param expected The expected structure.
- * @param actual The actual structure.
- * @returns True if structures match recursively.
+ * Object matching is **subset-based**: every key present in `expected` must
+ * exist in `actual` with a matching value, but extra keys in `actual` are
+ * ignored. This means an eval that specifies only the args it cares about
+ * (e.g. `{ query: { $contains: "shoe" } }`) matches a real tool call that
+ * also happens to include model-added fields like `pagination`.
+ *
+ * Array matching stays **strict**: expected and actual must have the same
+ * length and match positionally. Arrays are typically meaningful sequences
+ * (`line_items`, `selected_options`, ...) where silently accepting extra
+ * elements would surprise authors more often than help.
+ *
+ * Recurses via `matchesArgument`, so nested constraints (`$pattern`,
+ * `$contains`, `$any`, ...) continue to work inside subset-matched objects.
  */
 function matchesRecursive(expected: any, actual: any): boolean {
   if (expected === actual) {
@@ -158,14 +166,25 @@ function matchesRecursive(expected: any, actual: any): boolean {
     return false;
   }
 
-  const keys1 = Object.keys(expected);
-  const keys2 = Object.keys(actual);
-
-  if (keys1.length !== keys2.length) {
+  // Arrays keep strict length + positional matching.
+  const expectedIsArray = Array.isArray(expected);
+  if (expectedIsArray !== Array.isArray(actual)) {
     return false;
   }
+  if (expectedIsArray) {
+    if (expected.length !== actual.length) {
+      return false;
+    }
+    for (let i = 0; i < expected.length; i++) {
+      if (!matchesArgument(expected[i], actual[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
 
-  for (const key of keys1) {
+  // Objects use subset-match: extra keys in `actual` are allowed.
+  for (const key of Object.keys(expected)) {
     if (
       !Object.prototype.hasOwnProperty.call(actual, key) ||
       !matchesArgument(expected[key], actual[key])

--- a/evals-cli/src/test/matcher.test.ts
+++ b/evals-cli/src/test/matcher.test.ts
@@ -39,6 +39,83 @@ describe("matcher", () => {
     });
   });
 
+  describe("subset object matching", () => {
+    it("accepts extra keys in actual at the top level", () => {
+      // The motivating case: an eval that constrains `query` but doesn't
+      // mention `pagination` should still pass when the model adds
+      // pagination on its own.
+      assert.strictEqual(
+        matchesArgument(
+          { catalog: { query: { $contains: "shoe" } } },
+          { catalog: { query: "purple shoe", pagination: { limit: 5 } } },
+        ),
+        true,
+      );
+    });
+
+    it("accepts extra keys at nested levels", () => {
+      assert.strictEqual(
+        matchesArgument(
+          { catalog: { query: "shoe" } },
+          { catalog: { query: "shoe", pagination: { limit: 5 }, sort: "asc" } },
+        ),
+        true,
+      );
+    });
+
+    it("still fails when an expected key is missing from actual", () => {
+      // Subset relaxes extras-in-actual, not missing-keys-in-actual.
+      assert.strictEqual(matchesArgument({ query: "shoe" }, { pagination: { limit: 5 } }), false);
+    });
+
+    it("still fails when an expected key has the wrong value", () => {
+      // Extras allowed; wrong values not.
+      assert.strictEqual(
+        matchesArgument({ query: "shoe" }, { query: "boot", pagination: {} }),
+        false,
+      );
+    });
+
+    it('treats an empty expected object as "any object accepted"', () => {
+      // Consequence of subset semantics: `{}` imposes no constraints.
+      assert.strictEqual(matchesArgument({}, {}), true);
+      assert.strictEqual(matchesArgument({}, { anything: "goes" }), true);
+      // Non-object actuals still don't match — expected is an object.
+      assert.strictEqual(matchesArgument({}, null), false);
+      assert.strictEqual(matchesArgument({}, "not-an-object"), false);
+      assert.strictEqual(matchesArgument({}, [1, 2]), false);
+    });
+
+    it("keeps arrays strict on length", () => {
+      // Arrays are typically meaningful sequences (line_items,
+      // selected_options, ...). Extra elements would surprise more often
+      // than help — they stay strict-length.
+      assert.strictEqual(matchesArgument([1, 2], [1, 2, 3]), false);
+      assert.strictEqual(matchesArgument([1, 2], [1]), false);
+      assert.strictEqual(matchesArgument([{ a: 1 }], [{ a: 1, b: 2 }]), true); // element subset applies
+    });
+
+    it("composes with nested constraints inside subset objects", () => {
+      const schema = {
+        catalog: {
+          query: { $contains: "shoe" },
+          filters: { color: { $pattern: "^[Pp]urple$" } },
+        },
+      };
+      // Actual carries extra `pagination` alongside the constrained keys.
+      assert.strictEqual(
+        matchesArgument(schema, {
+          catalog: {
+            query: "purple shoe",
+            filters: { color: "Purple", material: "canvas" },
+            pagination: { limit: 10 },
+          },
+        }),
+        true,
+      );
+    });
+  });
+
   describe("constraints", () => {
     describe("$pattern", () => {
       it("matches strings against regex", () => {

--- a/evals-cli/src/test/utils.test.ts
+++ b/evals-cli/src/test/utils.test.ts
@@ -341,10 +341,11 @@ describe("functionCallOutcome", () => {
     );
   });
 
-  it("treats explicit `arguments: {}` as a strict no-args assertion", () => {
-    // Opposite of the omit-key case: an author who writes `"arguments": {}`
-    // is asserting the call takes no args. `{}` matches `{}` under the
-    // existing recursive check.
+  it("treats explicit `arguments: {}` as an unconstrained match under subset semantics", () => {
+    // With object matching now subset-based (see matcher.ts:matchesRecursive),
+    // an empty expected object imposes no constraints on any of actual's
+    // keys — the loop "for every key in expected" doesn't iterate. Any actual
+    // shape matches.
     assert.strictEqual(
       functionCallOutcome(
         { functionName: "foo", arguments: {} },
@@ -352,14 +353,13 @@ describe("functionCallOutcome", () => {
       ),
       "pass",
     );
-    // A stricter reading of `{}` ("no extra keys allowed") would still be
-    // enforced by matchesArgument — documented here as a regression guard.
+    // Extra keys in actual are permitted — same as any other subset match.
     assert.strictEqual(
       functionCallOutcome(
         { functionName: "foo", arguments: {} },
         { functionName: "foo", args: { x: 1 } },
       ),
-      "fail",
+      "pass",
     );
   });
 });


### PR DESCRIPTION
*_Generated by AI: Claude Opus 4.7_*

Closes #268.

### Problem

`matchesRecursive` currently requires expected and actual objects to have exactly the same key set — `keys1.length !== keys2.length` (`matcher.ts:143`) short-circuits to false. In practice this means an eval that expresses "I care about `query`, I don't care about anything else" has no way to say so: any extra key the model adds (`pagination`, per-tool metadata, provider-injected defaults) fails the match, even when the constrained key(s) matched perfectly.

Actual example from my suite:

```
exp: { catalog: { query: { $contains: "hoodie" } } }
act: { catalog: { pagination: { limit: 5 }, query: "black hoodie" } }
     → FAIL
```

The workaround authors reach for is `pagination: { $any: true }`, but `$any` requires the key to be **present** — the eval then flips from "extra pagination fails" to "missing pagination fails". Different models add pagination inconsistently, so no static author-time value matches both worlds.

### Fix

Switch object matching to subset semantics per your comment on #268 ("relaxing matcher and making subset a default makes a lot of sense"). Every key in `expected` must exist in `actual` with a matching value; extras in `actual` are allowed. Arrays keep their existing strict length + positional match — those are typically meaningful sequences (`line_items`, `selected_options`, ...) where silently accepting extras would surprise authors more often than help.

The change in `matchesRecursive`:

- Delete the `keys1.length !== keys2.length` gate for objects.
- Add an explicit branch for arrays that keeps strict-length behavior (both must be arrays, same length, positional match).
- Iterate only expected's keys when walking the object.

### Consequences worth calling out

- **Existing evals that used `arguments: {}` to assert "must have no args"** now silently accept any args — the empty expected set imposes no constraints. The one test that documented the old strict reading as a regression guard (added in #263) is updated in this PR to reflect the new contract.
- **`$strict: true` marker** as a future opt-back-in to exact-key-set is easy to add if anyone hits a case that needs it. Not included here — you mentioned that direction in the issue and I agree it's worth waiting until someone has a concrete need.
- **Arrays are still strict-length.** `[{a:1}]` matches `[{a:1,b:2}]` because the element itself subset-matches, but `[1,2]` does not match `[1,2,3]`.

### Tests

7 new tests in `matcher.test.ts` under a new "subset object matching" describe block:

- Extra keys in actual at the top level (the motivating case)
- Extra keys at nested levels
- Missing expected key in actual still fails
- Wrong value on an expected key still fails
- Empty expected object acts as "any object accepted" (documents the new contract)
- Arrays stay strict on length
- Subset composes with nested `$pattern` / `$contains` constraints

Existing 73/73 tests still pass (one had its assertion updated per the `{}` semantic change above); 80/80 with the new ones.

### Real-world impact

I dropped the modified `matcher.ts` into a vendored copy and re-ran my 11-case eval suite (against both Gemini and GPT-5.1). Two entries that were XFAIL'd in the storefront-kit expected-failures config immediately flipped to XPASS purely from this change:

- Gemini's `List collections when the user is exploring` — model added `navigate: false`, eval expected `{}`
- GPT-5.1's `Navigate to a product page on request` — model added `pagination`, eval expected `{ query: ... }` only

Both models now green with 0 unexpected fails.

Companion PR for #198 (optional tool calls at trajectory level) is coming right after this one.

---
*Co-Authored-By AI (Claude Opus 4.7) via [Pi](https://github.com/badlogic/pi-mono)*
