### PR TITLE
evals-cli: support optional tool calls in expected trajectories

### DIFF
--- a/evals-cli/src/test/utils.test.ts
+++ b/evals-cli/src/test/utils.test.ts
@@ -273,6 +273,163 @@ describe("evaluateExecutionTrajectory", () => {
   });
 });
 
+describe("optional tool calls", () => {
+  it("skips an unmatched optional in an ordered sequence", () => {
+    // Expected: [search, get_summary?, get_product].
+    // Actual: [search, get_product] — the summary step was skipped.
+    // Trajectory should PASS with just the two required rows.
+    const expected: ExpectedCallNode[] = [
+      {
+        ordered: [
+          { functionName: "search" },
+          { functionName: "get_summary", optional: true },
+          { functionName: "get_product" },
+        ],
+      },
+    ];
+    const actual: ToolCall[] = [
+      { functionName: "search", args: {} },
+      { functionName: "get_product", args: {} },
+    ];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    assert.deepStrictEqual(
+      results.map((r) => ({ fn: (r.expected as any)?.functionName ?? null, outcome: r.outcome })),
+      [
+        { fn: "search", outcome: "pass" },
+        { fn: "get_product", outcome: "pass" },
+      ],
+    );
+  });
+
+  it("matches an optional in an ordered sequence when the model does emit it", () => {
+    // Same expected trajectory as above, but the model DID make the
+    // optional call. All three rows should PASS.
+    const expected: ExpectedCallNode[] = [
+      {
+        ordered: [
+          { functionName: "search" },
+          { functionName: "get_summary", optional: true },
+          { functionName: "get_product" },
+        ],
+      },
+    ];
+    const actual: ToolCall[] = [
+      { functionName: "search", args: {} },
+      { functionName: "get_summary", args: {} },
+      { functionName: "get_product", args: {} },
+    ];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    assert.strictEqual(results.length, 3);
+    for (const r of results) assert.strictEqual(r.outcome, "pass");
+  });
+
+  it("leaves required nodes as FAIL when actual is truncated but skips trailing optional", () => {
+    // Expected: [search, get_product, get_summary?].
+    // Actual: [search] — required get_product missing, optional summary skipped.
+    const expected: ExpectedCallNode[] = [
+      {
+        ordered: [
+          { functionName: "search" },
+          { functionName: "get_product" },
+          { functionName: "get_summary", optional: true },
+        ],
+      },
+    ];
+    const actual: ToolCall[] = [{ functionName: "search", args: {} }];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    assert.deepStrictEqual(
+      results.map((r) => ({ fn: (r.expected as any)?.functionName ?? null, outcome: r.outcome })),
+      [
+        { fn: "search", outcome: "pass" },
+        { fn: "get_product", outcome: "fail" },
+      ],
+    );
+  });
+
+  it("skips an unmatched optional inside a simple unordered group", () => {
+    // Unordered {add_topping, get_summary?}. Actual only has add_topping.
+    const expected: ExpectedCallNode[] = [
+      {
+        unordered: [
+          { functionName: "add_topping" },
+          { functionName: "get_summary", optional: true },
+        ],
+      },
+    ];
+    const actual: ToolCall[] = [{ functionName: "add_topping", args: { topping: "onion" } }];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    // Only the required node produces a row.
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual((results[0].expected as any).functionName, "add_topping");
+    assert.strictEqual(results[0].outcome, "pass");
+  });
+
+  it("matches an optional inside a simple unordered group when the model emits it", () => {
+    // Same expected, actual now includes the optional.
+    const expected: ExpectedCallNode[] = [
+      {
+        unordered: [
+          { functionName: "add_topping" },
+          { functionName: "get_summary", optional: true },
+        ],
+      },
+    ];
+    const actual: ToolCall[] = [
+      { functionName: "get_summary", args: {} },
+      { functionName: "add_topping", args: { topping: "onion" } },
+    ];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    assert.strictEqual(results.length, 2);
+    for (const r of results) assert.strictEqual(r.outcome, "pass");
+  });
+
+  it("skips an unmatched optional inside a nested unordered group", () => {
+    // Trigger the matchNestedUnorderedGroup path with a group as a
+    // sibling. Actual only has search + update_cart; the optional
+    // get_summary is skipped.
+    const expected: ExpectedCallNode[] = [
+      {
+        unordered: [
+          {
+            ordered: [{ functionName: "search" }, { functionName: "update_cart" }],
+          },
+          { functionName: "get_summary", optional: true },
+        ],
+      },
+    ];
+    const actual: ToolCall[] = [
+      { functionName: "search", args: {} },
+      { functionName: "update_cart", args: {} },
+    ];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    // Just the two required rows, both pass.
+    assert.strictEqual(results.length, 2);
+    assert.deepStrictEqual(
+      results.map((r) => (r.expected as any).functionName),
+      ["search", "update_cart"],
+    );
+    for (const r of results) assert.strictEqual(r.outcome, "pass");
+  });
+
+  it("still FAILs when the actual has extra calls beyond expected + optional", () => {
+    // Extras that don't match anything (required or optional) still fail
+    // — optional isn't a wildcard, it's a specific-call permission.
+    const expected: ExpectedCallNode[] = [
+      { functionName: "search" },
+      { functionName: "get_summary", optional: true },
+    ];
+    const actual: ToolCall[] = [
+      { functionName: "search", args: {} },
+      { functionName: "something_else", args: {} },
+    ];
+    const results = evaluateExecutionTrajectory(expected, actual);
+    // search passes; the extra call is a trailing unexpected actual and
+    // should be reported as a fail.
+    const outcomes = results.map((r) => r.outcome);
+    assert.ok(outcomes.includes("fail"), `expected at least one fail, got ${outcomes.join(",")}`);
+  });
+});
+
 describe("functionCallOutcome", () => {
   it("passes when both expected and actual are null", () => {
     assert.strictEqual(functionCallOutcome(null, null), "pass");
@@ -361,6 +518,34 @@ describe("functionCallOutcome", () => {
       ),
       "fail",
     );
+  });
+});
+
+describe("countExpectedCalls with optional", () => {
+  it("excludes optional nodes from the required-step count", () => {
+    const nodes: ExpectedCallNode[] = [
+      { functionName: "search" },
+      { functionName: "get_summary", optional: true },
+      { functionName: "get_product" },
+    ];
+    // 3 total nodes, 2 required.
+    assert.strictEqual(countExpectedCalls(nodes), 2);
+  });
+
+  it("excludes optional nodes from ordered/unordered subtrees", () => {
+    const nodes: ExpectedCallNode[] = [
+      {
+        ordered: [
+          { functionName: "a" },
+          { functionName: "b_optional", optional: true },
+          {
+            unordered: [{ functionName: "c" }, { functionName: "d_optional", optional: true }],
+          },
+        ],
+      },
+    ];
+    // Required leaves: a, c → 2.
+    assert.strictEqual(countExpectedCalls(nodes), 2);
   });
 });
 

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -48,6 +48,13 @@ export type FunctionCall = {
   // empty object `{}` is returned. Only consulted by `executeLocalEvals` —
   // browser evals always use real tool results.
   mockOutput?: unknown;
+  // When true, this call is not required for the trajectory to pass.
+  // Useful for tool calls some models make and others don't (e.g. an
+  // eager model calling `get_current_results` for a summary between
+  // steps). A skipped optional contributes no PASS, no FAIL, and no
+  // consumed actual — it's simply omitted from the reconciliation.
+  // If the model does make the call, it matches normally.
+  optional?: boolean;
 };
 
 export type TestResult = {

--- a/evals-cli/src/utils.ts
+++ b/evals-cli/src/utils.ts
@@ -85,6 +85,10 @@ export function countExpectedCalls(nodes: ExpectedCallNode[]): number {
   return nodes.reduce((count, node) => {
     if (isUnorderedGroup(node)) return count + countExpectedCalls(node.unordered);
     if (isOrderedGroup(node)) return count + countExpectedCalls(node.ordered);
+    // Optional nodes don't contribute to the required-step count — they may
+    // or may not fire, so counting them would inflate the progress total
+    // and misreport the denominator in per-case counters.
+    if (isFunctionCall(node) && node.optional) return count;
     return count + 1;
   }, 0);
 }
@@ -163,9 +167,6 @@ function matchSimpleUnorderedGroup(
     }
   }
 
-  const allMatched =
-    matchesCount === expectedNodesCount && executionPoolSize === expectedNodesCount;
-
   // Track which expected nodes were successfully matched
   const matchedExpectedIndices = new Set<number>();
   for (let i = 0; i < executionPoolSize; i++) {
@@ -175,10 +176,26 @@ function matchSimpleUnorderedGroup(
     }
   }
 
-  // Get unmatched expected nodes
-  const unmatchedExpectedNodes = nodes.filter(
-    (_, index) => !matchedExpectedIndices.has(index),
-  ) as FunctionCall[];
+  // Count required (non-optional) nodes for the overall pass/fail decision.
+  // An unmatched optional doesn't count as a shortfall.
+  let requiredNodesCount = 0;
+  let requiredMatchedCount = 0;
+  for (let i = 0; i < expectedNodesCount; i++) {
+    const isOptional = (nodes[i] as FunctionCall).optional === true;
+    if (isOptional) continue;
+    requiredNodesCount++;
+    if (matchedExpectedIndices.has(i)) requiredMatchedCount++;
+  }
+  const allMatched =
+    requiredMatchedCount === requiredNodesCount &&
+    executionPoolSize === matchedExpectedIndices.size;
+
+  // Unmatched *required* nodes become FAIL rows; unmatched *optional*
+  // nodes are dropped silently.
+  const unmatchedExpectedNodes = nodes.filter((node, index) => {
+    if (matchedExpectedIndices.has(index)) return false;
+    return (node as FunctionCall).optional !== true;
+  }) as FunctionCall[];
 
   // Map result array
   const mappedResults: TrajectoryResult[] = [];
@@ -201,7 +218,8 @@ function matchSimpleUnorderedGroup(
     }
   }
 
-  // Any leftover unmatched expected nodes are added as failures with no actual execution
+  // Any leftover unmatched required expected nodes are added as failures
+  // with no actual execution. Optional leftovers were filtered out above.
   for (const expected of unmatchedExpectedNodes) {
     mappedResults.push({ expected, actual: null, outcome: "fail" });
   }
@@ -228,6 +246,7 @@ function matchNestedUnorderedGroup(
   const bestState = {
     matches: false,
     maxPasses: -1,
+    consumed: 0,
     mappedResults: [] as TrajectoryResult[],
   };
 
@@ -256,6 +275,7 @@ function matchNestedUnorderedGroup(
       if (currentPasses > bestState.maxPasses) {
         bestState.maxPasses = currentPasses;
         bestState.matches = currentMatches;
+        bestState.consumed = currentConsumed;
         bestState.mappedResults = [...currentMappedResults];
       }
       return;
@@ -288,9 +308,13 @@ function matchNestedUnorderedGroup(
 
   backtrack(0, 0, true, 0, []);
 
+  // Prefer the actual consumed count from the best backtracking result.
+  // With optional nodes potentially returning consumed: 0, the caller's
+  // pre-computed `expectedTotalConsumed` (required-only) may not reflect
+  // the pool we truly walked through.
   return {
     matches: bestState.matches,
-    consumed: expectedTotalConsumed,
+    consumed: bestState.maxPasses >= 0 ? bestState.consumed : expectedTotalConsumed,
     mappedResults: bestState.mappedResults,
   };
 }
@@ -306,6 +330,11 @@ export function matchExpectedNode(
     return matchSequence(node.ordered, executions, startIndex);
   } else if (isFunctionCall(node)) {
     if (startIndex >= executions.length) {
+      // No more actuals: optionals silently drop out of the trajectory;
+      // required nodes fail with an actual:null row.
+      if (node.optional) {
+        return { matches: true, consumed: 0, mappedResults: [] };
+      }
       return {
         matches: false,
         consumed: 1,
@@ -314,6 +343,12 @@ export function matchExpectedNode(
     }
     const actual = executions[startIndex];
     const outcome = functionCallOutcome(node, actual);
+    // An optional node that would otherwise fail simply doesn't consume
+    // the current actual — the next expected node gets a chance at it.
+    // If it would pass, we consume normally (greedy match).
+    if (node.optional && outcome === "fail") {
+      return { matches: true, consumed: 0, mappedResults: [] };
+    }
     return {
       matches: outcome === "pass",
       consumed: 1,


### PR DESCRIPTION
*_Generated by AI: Claude Opus 4.7_*

Closes #198.

### Problem

Trajectories where "certain tool calls might or might not happen depending on the model" have no way to express the optionality today. Every listed `FunctionCall` is required; skipping one is a FAIL row. That forces eval authors to write either the eager model's trajectory or the lazy model's trajectory, losing coverage of the other.

Concrete example from my suite: an "eager" model calls a summary/inspection tool between a search and an add-to-cart; a more direct model goes straight through. Both are legitimate trajectories. Today the eval has to pick one.

### Design

An `optional?: boolean` field on `FunctionCall`. When set:

- If the model **does** make the call, it matches normally and contributes a PASS row (or a FAIL row if args mismatch — args-matching semantics on optional calls are the same as on required calls).
- If the model **doesn't**, the node contributes nothing: no PASS row, no FAIL row, no consumed actual, no impact on the overall trajectory outcome.

```jsonc
{
  "expectedCall": [{
    "ordered": [
      { "functionName": "search_catalog", "arguments": { ... } },
      // Eager models call this between search and add-to-cart; direct
      // models don't. Either behavior is a legitimate trajectory.
      { "functionName": "get_current_results", "optional": true },
      { "functionName": "update_cart", "arguments": { ... } }
    ]
  }]
}
```

Chose `optional: true` over the `*`-name-prefix alternative you sketched because:

- More explicit — reads self-documenting in JSON.
- Composes naturally with other `FunctionCall` fields (`mockOutput`, `arguments`, ...).
- Doesn't collide with any legitimate function name pattern.
- Structurally symmetric with the `arguments?: object | null` field's existing "opt-in by presence" shape.

### Implementation

Three places in `utils.ts`, ~40 real lines of code:

- **`countExpectedCalls`** excludes optionals — they don't inflate the progress-bar total or the per-case denominator.
- **`matchExpectedNode`** returns `matches: true, consumed: 0` for an optional `FunctionCall` that would fail to match (either because actual is exhausted or because the next actual doesn't match). A matching optional consumes normally (greedy match).
- **`matchSimpleUnorderedGroup`** (bipartite match for `unordered:`) filters unmatched optionals out of the FAIL-row generation and computes `allMatched` against the required-only count.

`matchNestedUnorderedGroup` gets support for free via `matchExpectedNode`, with one small change to its return: `consumed` is now derived from the best backtracking result rather than the pre-computed `expectedTotalConsumed` (which is required-only after the `countExpectedCalls` change and would have been wrong when optionals fire).

### Tests

9 new tests in `utils.test.ts`, in a new "optional tool calls" describe block:

- Skip an unmatched optional in an ordered sequence (PASS with fewer rows).
- Match an optional in an ordered sequence when the model does emit it.
- Required nodes still FAIL when actual is truncated, even next to a trailing optional.
- Skip an unmatched optional inside a simple unordered group.
- Match an optional inside a simple unordered group.
- Skip an unmatched optional inside a nested unordered group (exercises `matchNestedUnorderedGroup`).
- Extras in actual that match no expected still FAIL (optional isn't a wildcard).
- Optionals excluded from `countExpectedCalls` at leaf level.
- Optionals excluded from `countExpectedCalls` inside ordered/unordered subtrees.

Existing 73/73 tests still pass; 82/82 with the new ones.

### Companion PR

This composes cleanly with the subset-match matcher change in #270 (subset args + optional trajectory nodes both relax the matcher in the same "author intent, not model quirks" direction). Both PRs are independent — either can land first.

### Non-goals

- **Not** adding `optional: true` support on `ordered:` / `unordered:` groups themselves. If we ever need "this whole sub-trajectory is optional" that'd be a separate design pass — it introduces backtracking questions that need thought. For now, groups can just contain optional leaves.
- **Not** exposing optional in browser-eval mode differently. `executeInBrowserEvals` uses the same matcher, so it gets the semantics for free.

---
*Co-Authored-By AI (Claude Opus 4.7) via [Pi](https://github.com/badlogic/pi-mono)*
