### PR TITLE
evals-cli: add basic npm release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,57 @@
+name: npm Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+          cache-dependency-path: "evals-cli/package-lock.json"
+
+      - name: Install dependencies
+        working-directory: ./evals-cli
+        run: npm ci
+
+      - name: Build distribution
+        working-directory: ./evals-cli
+        run: npm run build
+
+      - name: Dry run (verify build & CLI help commands)
+        working-directory: ./evals-cli
+        run: |
+          node dist/bin/webmcpevals.js --help
+          node dist/bin/runevals.js --help
+          node dist/bin/serve.js --help
+          npm publish --dry-run
+
+      # Configure Node.js with Wombat registry for publishing
+      - name: Setup Node.js for Wombat registry
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://wombat-dressing-room.appspot.com/"
+
+      - name: Publish to npm (Wombat)
+        working-directory: ./evals-cli
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/evals-cli/.npmignore
+++ b/evals-cli/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+src
+*.config.json
+tsconfig.*
+report*.html

--- a/evals-cli/package-lock.json
+++ b/evals-cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "webmcp-evals-cli",
+  "name": "webmcp-evals",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "webmcp-evals-cli",
+      "name": "webmcp-evals",
       "version": "0.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -29,6 +29,12 @@
         "ora": "^9.3.0",
         "puppeteer-core": "^25.0.4",
         "zod": "^4.3.6"
+      },
+      "bin": {
+        "runevals": "dist/bin/runevals.js",
+        "webmcp-evals": "dist/bin/webmcpevals.js",
+        "webmcp-evals-serve": "dist/bin/serve.js",
+        "webmcpevals": "dist/bin/webmcpevals.js"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",

--- a/evals-cli/package.json
+++ b/evals-cli/package.json
@@ -1,14 +1,27 @@
 {
-  "name": "webmcp-evals-cli",
+  "name": "webmcp-evals",
   "version": "0.1.0",
   "description": "A command-line tool to run evals for WebMCP schema definitions",
   "license": "Apache-2.0",
+  "bin": {
+    "runevals": "dist/bin/runevals.js",
+    "webmcp-evals": "dist/bin/webmcpevals.js",
+    "webmcp-evals-serve": "dist/bin/serve.js",
+    "webmcpevals": "dist/bin/webmcpevals.js"
+  },
+  "files": [
+    "dist",
+    "ui/dist",
+    "examples",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "scripts": {
     "postinstall": "npm install --prefix ui",
-    "build": "tsc",
+    "build": "tsc && npm run build --prefix ui",
     "test": "tsc && node --test dist/test/*.test.js",
-    "serve": "tsc && npm run build --prefix ui && node dist/bin/serve.js",
+    "serve": "npm run build && node dist/bin/serve.js",
     "lint": "oxlint",
     "format": "oxfmt --write"
   },

--- a/evals-cli/src/bin/runevals.ts
+++ b/evals-cli/src/bin/runevals.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -18,6 +20,24 @@ import { cleanOldReports } from "../utils.js";
 dotenv.config();
 
 const args = minimist(process.argv.slice(2));
+
+if (args.help || args.h) {
+  console.log(`
+Usage: runevals [options]
+
+Options:
+  --tools <string>     Path to the tool schema JSON file (required)
+  --evals <string>     Path to the evals JSON file (required)
+  --backend <string>   Execution backend (gemini, ollama, vercel) (default: gemini)
+  --provider <string>  Model provider (e.g., google, openai, anthropic)
+  --model <string>     Model name (default: gemini-3-flash-preview)
+  --runs <number>      Number of runs (default: 1)
+  --max-steps <number> Maximum evaluation steps
+  --help, -h           Show help
+`);
+  process.exit(0);
+}
+
 if (!args.tools) {
   console.error("The 'tools' argument is required.");
   process.exit(1);

--- a/evals-cli/src/bin/webmcpevals.ts
+++ b/evals-cli/src/bin/webmcpevals.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -20,6 +22,23 @@ import { sortObjectKeys, cleanOldReports } from "../utils.js";
 dotenv.config();
 
 const args = minimist(process.argv.slice(2));
+
+if (args.help || args.h) {
+  console.log(`
+Usage: webmcpevals [options]
+
+Options:
+  --url <string>       URL of the page to evaluate (required)
+  --evals <string>     Path to the evals JSON file (required)
+  --backend <string>   Execution backend (gemini, ollama, vercel) (default: vercel)
+  --provider <string>  Model provider (e.g., google, openai, anthropic) (default: gemini)
+  --model <string>     Model name (default: gemini-3-flash-preview)
+  --runs <number>      Number of runs (default: 1)
+  --debug, --verbose   Enable debug output
+  --help, -h           Show help
+`);
+  process.exit(0);
+}
 
 if (!args.url) {
   console.error("The 'url' argument is required.");

--- a/evals-cli/ui/.npmignore
+++ b/evals-cli/ui/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+src
+*.config.ts
+*.config.js
+tsconfig.*


### PR DESCRIPTION
- Rename package to `webmcp-evals` and configure `bin` (`webmcp-evals`, `webmcpevals`, `runevals`, `webmcp-evals-serve`) and `files` properties.
- Add shebang and `--help` / `-h` handling to `webmcpevals.ts` and `runevals.ts`.
- Add `.npmignore` files to `evals-cli/` and `evals-cli/ui/` to ensure `dist/` and `ui/dist/` are included in npm tarballs.
- Create `.github/workflows/npm-release.yml` for automated releases via Wombat Dressing Room.