### PR TITLE
Add WebMCP polyfill and integrate it with some demos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
           mkdir -p deployment-root/demos
 
           cp -r demos/french-bistro deployment-root/demos/french-bistro
+          cp -r demos/shared deployment-root/demos/shared
           cp -r demos/react-flightsearch/dist deployment-root/demos/react-flightsearch
           cp -r demos/pizza-maker deployment-root/demos/pizza-maker
           cp -r demos/doors deployment-root/demos/doors

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a suite of developer utilities and demos designed to su
 
 - [**WebMCP - Model Context Tool Inspector**](https://github.com/beaufortfrancois/model-context-tool-inspector): A Chrome Extension to let web developers inspect web pages to verify if WebMCP tools are correctly exposed, visualize the input schema, and debug connection issues directly within the browser.
 - [**WebMCP Evals**](evals-cli/): A CLI Tool to evaluate the tool-calling capabilities of LLMs by defining test cases and schemas to verify if an interactive agent correctly calls tools based on user inputs.
+- [**WebMCP Polyfill**](demos/shared/webmcp-polyfill.js): A JavaScript polyfill to make WebMCP tools and CSS pseudo-classes work in browsers that do not support the API natively.
 
 ## Demos
 

--- a/demos/french-bistro/README.md
+++ b/demos/french-bistro/README.md
@@ -4,6 +4,8 @@
 
 This project demonstrates a **WebMCP** implementation for a restaurant reservation system. It allows an AI agent to interact directly with a web-based booking form, validating and submitting data on behalf of the user using declarative tool definitions.
 
+It imports the [WebMCP Polyfill](../shared/webmcp-polyfill.js) so that WebMCP is fully simulated in browsers that do not support it yet natively.
+
 ## 🛠️ How It Works
 
 The form in `index.html` is tagged with a `toolname` and a `tooldescription`. Each input field provides a `toolparamdescription` which acts as a prompt for the AI agent to know what data to collect.

--- a/demos/french-bistro/agent.html
+++ b/demos/french-bistro/agent.html
@@ -59,6 +59,7 @@
         </div>
       </div>
     </div>
+    <script src="../shared/webmcp-polyfill.js"></script>
     <script type="module" src="agent.js"></script>
   </body>
 </html>

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -103,7 +103,11 @@ function initSharedWorker(apiKey) {
       case 'GET_TOOLS':
         const tools = await getTools();
         // FIXME: tool.window needs to be removed because it's not serializable.
-        const serializableTools = tools.map(({ window, ...toolWithoutWindow }) => toolWithoutWindow);
+        const serializableTools = tools.map(({ name, description, inputSchema }) => ({
+          name,
+          description,
+          inputSchema,
+        }));
         worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: serializableTools, id });
         break;
 

--- a/demos/french-bistro/index.html
+++ b/demos/french-bistro/index.html
@@ -168,6 +168,7 @@
         </div>
       </div>
     </div>
+    <script src="../shared/webmcp-polyfill.js"></script>
     <script type="module" src="script.js"></script>
     <script type="module">
       const params = new URLSearchParams(window.location.search);

--- a/demos/french-bistro/result.html
+++ b/demos/french-bistro/result.html
@@ -55,6 +55,7 @@
       </div>
     </div>
   </div>
+  <script src="../shared/webmcp-polyfill.js"></script>
   <script>
     const params = new URLSearchParams(window.location.search);
     if (params.has('agentiframe')) {

--- a/demos/french-bistro/style.css
+++ b/demos/french-bistro/style.css
@@ -184,11 +184,6 @@ button.submit-btn:hover {
 
 /* --- ACTIVE CLASSES --- */
 
-/* Class to apply to the .booking-container */
-*:tool-form-active {
-  outline: none; /* Removes default blue browser focus rings */
-}
-
 /* --- 1. The Shimmer Animation (Light reflection moving across) --- */
 @keyframes gold-shimmer {
   0% {

--- a/demos/page-agent/README.md
+++ b/demos/page-agent/README.md
@@ -6,6 +6,8 @@
 
 The **WebMCP Page Agent** is a "meta-demo" that demonstrates how to get tools from an iframe (cross-origin or not) and execute them in a chat session powered by Gemini. It allows users to control any WebMCP-enabled website by typing natural language commands.
 
+It imports the [WebMCP Polyfill](../shared/webmcp-polyfill.js) so that WebMCP is fully simulated in browsers that do not support it yet natively.
+
 ## 🛠️ How It Works
 
 This demo uses the `document.modelContext` API to discover and execute tools provided by the site loaded in the iframe.

--- a/demos/page-agent/index.html
+++ b/demos/page-agent/index.html
@@ -56,6 +56,7 @@
         </div>
     </div>
 
+    <script src="../shared/webmcp-polyfill.js"></script>
     <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/demos/pizza-maker/README.md
+++ b/demos/pizza-maker/README.md
@@ -4,6 +4,8 @@
 
 This project demonstrates a **WebMCP** implementation for an interactive pizza builder. It allows an AI agent to interact directly with the pizza creation process, such as adding toppings, changing styles, and adjusting sizes by registering custom tools.
 
+It imports the [WebMCP Polyfill](../shared/webmcp-polyfill.js) so that WebMCP is fully simulated in browsers that do not support it yet natively.
+
 ## 🛠️ How It Works
 
 Unlike declarative forms, this demo uses the `document.modelContext.registerTool` API in `script.js` to expose fine-grained control over the application state to an AI agent.

--- a/demos/pizza-maker/index.html
+++ b/demos/pizza-maker/index.html
@@ -65,6 +65,7 @@
       </div>
     </div>
 
+    <script src="../shared/webmcp-polyfill.js"></script>
     <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/demos/shared/webmcp-polyfill.js
+++ b/demos/shared/webmcp-polyfill.js
@@ -1,0 +1,447 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+(function () {
+  if (window.document.modelContext) {
+    return;
+  }
+
+  window.__webmcp_registered_tools = window.__webmcp_registered_tools || new Map();
+
+  function getLocalTools(win) {
+    const tools = [];
+
+    // 1. Imperative tools registered on this window
+    if (win.__webmcp_registered_tools) {
+      for (const tool of win.__webmcp_registered_tools.values()) {
+        tools.push(tool);
+      }
+    }
+
+    // 2. Declarative tools (forms) on this window
+    try {
+      const forms = win.document.querySelectorAll('form[toolname]');
+      for (const form of forms) {
+        const name = form.getAttribute('toolname');
+        const description = form.getAttribute('tooldescription') || '';
+
+        // Build inputSchema
+        const properties = {};
+        const required = [];
+        const elements = form.querySelectorAll('input[name], select[name], textarea[name]');
+        for (const el of elements) {
+          const propName = el.name;
+          const propDesc = el.getAttribute('toolparamdescription') || '';
+          let type = 'string';
+          let enumValues = undefined;
+
+          if (el.tagName === 'SELECT') {
+            type = 'string';
+            enumValues = Array.from(el.options).map((opt) => opt.value || opt.text);
+          } else if (el.type === 'number' || el.type === 'range') {
+            type = 'number';
+          } else if (el.type === 'checkbox') {
+            type = 'boolean';
+          }
+
+          const property = { type };
+          if (propDesc) {
+            property.description = propDesc;
+          }
+          if (enumValues) {
+            property.enum = enumValues;
+          }
+          properties[propName] = property;
+
+          if (el.hasAttribute('required')) {
+            required.push(propName);
+          }
+        }
+
+        const inputSchema = {
+          type: 'object',
+          properties,
+        };
+        if (required.length > 0) {
+          inputSchema.required = required;
+        }
+
+        tools.push({
+          name,
+          description,
+          inputSchema: JSON.stringify(inputSchema),
+          window: win,
+          _form: form,
+        });
+      }
+    } catch (e) {
+      // Ignore cross-origin frame document access errors
+    }
+
+    return tools;
+  }
+
+  class ModelContext extends EventTarget {
+    #ontoolchange = null;
+
+    get ontoolchange() {
+      return this.#ontoolchange;
+    }
+
+    set ontoolchange(handler) {
+      if (this.#ontoolchange) {
+        this.removeEventListener('toolchange', this.#ontoolchange);
+      }
+      this.#ontoolchange = handler;
+      if (handler) {
+        this.addEventListener('toolchange', handler);
+      }
+    }
+
+    async registerTool(tool, options = {}) {
+      if (!tool || typeof tool !== 'object') {
+        throw new DOMException('Invalid tool object', 'TypeError');
+      }
+
+      const name = tool.name;
+      const description = tool.description;
+
+      if (!name || typeof name !== 'string') {
+        throw new DOMException('Invalid tool name', 'InvalidStateError');
+      }
+      if (!description || typeof description !== 'string') {
+        throw new DOMException('Invalid tool description', 'InvalidStateError');
+      }
+
+      // Name length must be between 1 and 128, only ASCII alphanumeric, _, -, and .
+      const nameRegex = /^[a-zA-Z0-9_.-]{1,128}$/;
+      if (!nameRegex.test(name)) {
+        throw new DOMException('Invalid tool name format', 'InvalidStateError');
+      }
+
+      if (window.__webmcp_registered_tools.has(name)) {
+        throw new DOMException(`Tool "${name}" is already registered`, 'InvalidStateError');
+      }
+
+      let stringifiedInputSchema = '';
+      if (tool.inputSchema) {
+        try {
+          stringifiedInputSchema = JSON.stringify(tool.inputSchema);
+        } catch (e) {
+          throw new TypeError('Failed to stringify inputSchema');
+        }
+      }
+
+      const signal = options.signal;
+      if (signal) {
+        if (signal.aborted) {
+          throw signal.reason || new DOMException('Aborted', 'AbortError');
+        }
+        signal.addEventListener('abort', () => {
+          this.#unregisterTool(name);
+        });
+      }
+
+      // Store a normalized tool copy with a stringified inputSchema
+      const normalizedTool = {
+        name,
+        description,
+        inputSchema: stringifiedInputSchema,
+        window: window,
+        origin: window.origin,
+        annotations: tool.annotations,
+        _execute: tool.execute,
+      }
+
+      window.__webmcp_registered_tools.set(name, normalizedTool);
+      this.dispatchEvent(new Event('toolchange'));
+    }
+
+    #unregisterTool(name) {
+      if (window.__webmcp_registered_tools.delete(name)) {
+        this.dispatchEvent(new Event('toolchange'));
+      }
+    }
+
+    async getTools(options = {}) {
+      const allWindows = new Set([window]);
+      if (window.parent) {
+        allWindows.add(window.parent);
+        try {
+          for (let i = 0; i < window.parent.frames.length; i++) {
+            allWindows.add(window.parent.frames[i]);
+          }
+        } catch (e) { }
+      }
+      try {
+        const iframes = document.querySelectorAll('iframe');
+        for (const iframe of iframes) {
+          if (iframe.contentWindow) {
+            allWindows.add(iframe.contentWindow);
+          }
+        }
+      } catch (e) { }
+
+      const allTools = [];
+      for (const win of allWindows) {
+        try {
+          // Check if we can access the window origin
+          if (win.origin === window.origin || win.document) {
+            allTools.push(...getLocalTools(win));
+          }
+        } catch (e) {
+          // Cross-origin, ignore
+        }
+      }
+
+      const uniqueTools = [];
+      const seenNames = new Set();
+      for (const t of allTools) {
+        if (!seenNames.has(t.name)) {
+          seenNames.add(t.name);
+          uniqueTools.push(t);
+        }
+      }
+
+      let filteredTools = uniqueTools;
+      if (options && Array.isArray(options.fromOrigins)) {
+        const origins = new Set(options.fromOrigins);
+        filteredTools = uniqueTools.filter((t) => {
+          const win = t.window || window;
+          try {
+            return origins.has(win.origin);
+          } catch (e) {
+            return false;
+          }
+        });
+      }
+
+      return filteredTools;
+    }
+
+    async executeTool(tool, args) {
+      const win = tool.window || window;
+
+      if (win !== window && win.document && win.document.modelContext && win.document.modelContext.executeTool) {
+        return win.document.modelContext.executeTool(tool, args);
+      }
+
+      let parsedArgs = args;
+      if (typeof args === 'string') {
+        try {
+          parsedArgs = JSON.parse(args);
+        } catch (e) { }
+      }
+
+      // 1. Check if it's an imperative tool registered here
+      if (win.__webmcp_registered_tools && win.__webmcp_registered_tools.has(tool.name)) {
+        const registeredTool = win.__webmcp_registered_tools.get(tool.name);
+        return registeredTool._execute(parsedArgs);
+      }
+
+      // 2. Check if it's a declarative tool
+      const form = tool._form || win.document.querySelector(`form[toolname="${tool.name}"]`);
+      if (!form) {
+        throw new Error(`Tool ${tool.name} not found`);
+      }
+
+      // Apply styling classes
+      form.classList.add('tool-form-active');
+      const submitBtn = form.querySelector('button[type="submit"], input[type="submit"]');
+      if (submitBtn) {
+        submitBtn.classList.add('tool-submit-active');
+      }
+
+      // Fill form fields
+      for (const [key, value] of Object.entries(parsedArgs)) {
+        const input = form.elements[key] || form.querySelector(`[name="${key}"]`);
+        if (input) {
+          if (input.tagName === 'SELECT') {
+            input.value = value;
+          } else if (input.type === 'checkbox') {
+            input.checked = !!value;
+          } else if (input.type === 'radio') {
+            const radio = form.querySelector(`input[name="${key}"][value="${value}"]`);
+            if (radio) radio.checked = true;
+          } else {
+            input.value = value;
+          }
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+          input.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+      }
+
+      // Dispatch toolactivated event on the target window
+      const activatedEvent = new Event('toolactivated');
+      activatedEvent.toolName = tool.name;
+      win.dispatchEvent(activatedEvent);
+
+      return new Promise((resolve) => {
+        let resolved = false;
+        let observer;
+
+        const cleanup = () => {
+          form.classList.remove('tool-form-active');
+          if (submitBtn) {
+            submitBtn.classList.remove('tool-submit-active');
+          }
+          form.removeEventListener('reset', onReset);
+          form.removeEventListener('submit', onSubmit, { capture: true });
+          if (observer) {
+            observer.disconnect();
+          }
+        };
+
+        const onReset = () => {
+          resolved = true;
+          cleanup();
+          const cancelEvent = new Event('toolcancel');
+          cancelEvent.toolName = tool.name;
+          win.dispatchEvent(cancelEvent);
+          resolve(null);
+        };
+        form.addEventListener('reset', onReset);
+
+        const onSubmit = (e) => {
+          if (resolved) return;
+          e.agentInvoked = true;
+          e.respondWith = (val) => {
+            if (val && typeof val.then === 'function') {
+              val.then((actualVal) => {
+                resolved = true;
+                cleanup();
+                resolve(actualVal);
+              }).catch((err) => {
+                resolved = true;
+                cleanup();
+                resolve({ error: err.message || err });
+              });
+            } else {
+              resolved = true;
+              cleanup();
+              resolve(val);
+            }
+          };
+        };
+        form.addEventListener('submit', onSubmit, { capture: true });
+
+        observer = new MutationObserver((mutations) => {
+          let formRemoved = !win.document.body.contains(form);
+          let attributesChanged = false;
+
+          for (const mutation of mutations) {
+            if (mutation.type === 'attributes' && mutation.target === form) {
+              if (mutation.attributeName === 'toolname' || mutation.attributeName === 'tooldescription') {
+                attributesChanged = true;
+              }
+            }
+          }
+
+          if (formRemoved || attributesChanged) {
+            resolved = true;
+            cleanup();
+            const cancelEvent = new Event('toolcancel');
+            cancelEvent.toolName = tool.name;
+            win.dispatchEvent(cancelEvent);
+            resolve(null);
+          }
+        });
+        observer.observe(form, { attributes: true });
+        if (form.parentNode) {
+          observer.observe(form.parentNode, { childList: true });
+        }
+
+        if (form.hasAttribute('toolautosubmit')) {
+          const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
+          form.dispatchEvent(submitEvent);
+
+          // Timeout only for autosubmit (in case site has a bug and doesn't call respondWith)
+          setTimeout(() => {
+            if (!resolved) {
+              cleanup();
+              resolve(null);
+            }
+          }, 5000);
+        } else {
+          if (submitBtn) {
+            submitBtn.focus();
+          }
+        }
+      });
+    }
+  }
+
+  function polyfillCSSPseudoClasses(win) {
+    const styles = [];
+
+    const processCSSText = (text) => {
+      const regexForm = /:tool-form-active/g;
+      const regexSubmit = /:tool-submit-active/g;
+      const newText = text
+        .replace(regexForm, '.tool-form-active')
+        .replace(regexSubmit, '.tool-submit-active');
+      return newText !== text ? newText : null;
+    };
+
+    // 1. Process existing stylesheets in document
+    for (const sheet of Array.from(win.document.styleSheets)) {
+      if (sheet.href) {
+        // Always fetch external stylesheets to get raw CSS before browser parses and discards invalid selectors
+        fetch(sheet.href)
+          .then((res) => res.text())
+          .then((text) => {
+            const processed = processCSSText(text);
+            if (processed) {
+              const styleEl = win.document.createElement('style');
+              styleEl.textContent = processed;
+              win.document.head.appendChild(styleEl);
+            }
+          })
+          .catch(() => { });
+      } else {
+        try {
+          const rules = sheet.cssRules || sheet.rules;
+          if (rules) {
+            for (const rule of Array.from(rules)) {
+              const ruleText = rule.cssText;
+              const processed = processCSSText(ruleText);
+              if (processed) {
+                styles.push(processed);
+              }
+            }
+          }
+        } catch (e) { }
+      }
+    }
+
+    // 2. Process inline style tags
+    for (const styleTag of Array.from(win.document.querySelectorAll('style'))) {
+      const processed = processCSSText(styleTag.textContent);
+      if (processed) {
+        styles.push(processed);
+      }
+    }
+
+    if (styles.length > 0) {
+      const styleEl = win.document.createElement('style');
+      styleEl.textContent = styles.join('\n');
+      win.document.head.appendChild(styleEl);
+    }
+  }
+
+  const modelContext = new ModelContext();
+
+  Object.defineProperty(window.document, 'modelContext', {
+    value: modelContext,
+    writable: false,
+    configurable: true,
+  });
+
+  if (window.document.readyState === 'loading') {
+    window.document.addEventListener('DOMContentLoaded', () => polyfillCSSPseudoClasses(window));
+  } else {
+    polyfillCSSPseudoClasses(window);
+  }
+})();

--- a/demos/sport-shop-angular/README.md
+++ b/demos/sport-shop-angular/README.md
@@ -48,7 +48,7 @@ WebMCP Sports registers 13 in-browser tools categorized by scope:
 ## 🛠 Tech Stack
 
 - **Framework**: Angular 22 (Signals & Standalone Components)
-- **AI & Protocol**: Google GenAI SDK (`@google/genai`), WebMCP (`document.modelContext`)
+- **AI & Protocol**: Google GenAI SDK (`@google/genai`), WebMCP (`document.modelContext`), [WebMCP Polyfill](../shared/webmcp-polyfill.js)
 - **Styling**: Vanilla CSS & TailwindCSS v4
 - **Build Tool**: Angular CLI / Vite
 - **Testing**: Vitest

--- a/demos/sport-shop-angular/angular.json
+++ b/demos/sport-shop-angular/angular.json
@@ -27,6 +27,9 @@
             ],
             "styles": [
               "src/tailwind-output.css"
+            ],
+            "scripts": [
+              "../shared/webmcp-polyfill.js"
             ]
           },
           "configurations": {


### PR DESCRIPTION
- Add shared `webmcp-polyfill.js` implementing current WebMCP API shape in Chromium.
- Refactor ModelContext to extend EventTarget with ontoolchange event handler support.
- Implement `registerTool()` supporting AbortSignal cancellation, and `getTools()` supporting origin filtering options.
- Implement `executeTool()` supporting both imperative callback execution and declarative form-filling tools.
- Support pending execution on forms without `toolautosubmit`, capturing submit events and resolving with `e.respondWith()` values.
- Dynamically translate CSS pseudo-classes (`:tool-form-active`, `:tool-submit-active`) to class selectors to support visual styling.
- Prevent tool serialization failures over French Bistro SharedWorker by returning only name, description, and inputSchema.
- Integrate the polyfill in French Bistro, Page Agent, Pizza Maker, and Sport Shop demos.

## Safari
<img width="1840" height="1191" alt="Screenshot 2026-07-09 at 12 37 29" src="https://github.com/user-attachments/assets/623ed7c0-2325-444c-8aa7-42e474d68b88" />


## Firefox
<img width="1840" height="1191" alt="Screenshot 2026-07-09 at 12 36 12" src="https://github.com/user-attachments/assets/8a120e11-6b8c-40f7-9728-e51008ae531e" />
