### PR TITLE
Add webmcpify to Libraries & Tools in AWESOME_WEBMCP.md

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -72,6 +72,7 @@ A curated list of awesome WebMCP demos, libraries, and tools.
 
 - [webmcp-types](https://www.npmjs.com/package/webmcp-types) - TypeScript type definitions for WebMCP.
 - [WebMCP - Model Context Tool Inspector](https://github.com/beaufortfrancois/model-context-tool-inspector) - A Chrome Extension to let web developers inspect web pages to verify if WebMCP tools are correctly exposed, visualize the input schema, and debug connection issues directly within the browser.
+- [webmcpify](https://github.com/TueJon/webmcpify) - An agent skill that integrates WebMCP into an existing web app end to end: it inventories the app, proposes a tool manifest for approval, integrates the tools, then verifies each one in a real browser and heals failures.
 
 ## Contributing
 


### PR DESCRIPTION
Adds [webmcpify](https://github.com/TueJon/webmcpify) to the Libraries & Tools section.

webmcpify is an MIT-licensed agent skill that integrates WebMCP into an existing web application end to end: it inventories the app, proposes a tool manifest for human approval, integrates the tools against `document.modelContext`, then verifies each tool by executing it in a real browser and heals failures. It follows the tool-design patterns from this repo's demos and treats the WebMCP guides in GoogleChrome/modern-web-guidance as the source of current best practices.