### PR TITLE
Expose `execute_batch` tool and introduce "Code Mode" for Page Agent

### DIFF
--- a/demos/page-agent/README.md
+++ b/demos/page-agent/README.md
@@ -34,13 +34,52 @@ When the Gemini model decides to call a tool, the agent uses `executeTool` to pe
 const result = await document.modelContext.executeTool(tool, inputArgs);
 ```
 
+### 3. Code Mode (Batch Tool Execution)
+
+Code Mode introduces an optimized way for AI agents to interact with WebMCP tools. Instead of calling multiple individual tools in separate conversational turns (which consumes more context tokens and increases latency), the agent generates a single declarative steps array that calls multiple tools sequentially, resolving data dependencies between them.
+
+The agent uses a single tool called `execute_batch` with the following parameters:
+
+```json
+{
+  "steps": [
+    {
+      "id": "step1",
+      "tool": "set_pizza_size",
+      "args": { "size": "Large" }
+    },
+    {
+      "id": "step2",
+      "tool": "set_pizza_style",
+      "args": { "style": "BBQ" }
+    },
+    {
+      "id": "step3",
+      "tool": "add_topping",
+      "args": {
+        "topping": "🍄",
+        "count": 5,
+        "size": "$ref:step1"
+      }
+    }
+  ]
+}
+```
+
+#### How it works:
+1. **TypeScript Definitions**: The agent harness generates a TypeScript declaration (`mcp` interface) containing type signatures and descriptions for all available tools on the page.
+2. **System Instruction**: The declaration is injected into the agent's system instructions, alongside instructions on how to use declarative steps.
+3. **Single Tool Exposure**: Only the `execute_batch` tool is exposed to the model.
+4. **Execution**: The agent generates a sequence of steps. Step parameters can reference outputs of previous steps using the string format `"$ref:stepId"` or `"$ref:stepId.nestedProperty"`.
+5. **Output**: The batch execution parses and executes the steps sequentially, resolving any dependencies, and returns a list of step execution outputs (inputs, outputs/results, errors).
+
 ## ✨ Features
 
 - **Dynamic Tool Discovery**: Automatically detects tools from any WebMCP-compatible URL entered in the address bar.
+- **Normal & Code Mode**: Toggle between standard tool-calling and Cloudflare-style "Code Mode" to see the difference in context efficiency and speed.
 - **Gemini Integration**: Uses the Gemini 3.5 Flash model to interpret user intent and map it to available tools.
 - **Cross-Origin Support**: Safely interacts with tools across different origins via the WebMCP protocol.
-- **Real-time Feedback**: Shows system messages when tools are being executed.
-
+- **Real-time Feedback**: Shows system messages and live console logs when tools or scripts are being executed.
 ## 🚀 Getting Started
 
 1. Open the [Live Demo](https://googlechromelabs.github.io/webmcp-tools/demos/page-agent).

--- a/demos/page-agent/index.html
+++ b/demos/page-agent/index.html
@@ -43,6 +43,13 @@
             <div id="chat-container" class="hidden">
                 <div class="header">
                     <h2 style="margin: 0">Interact with WebMCP tools</h2>
+                    <div class="mode-toggle-container">
+                        <label class="switch">
+                            <input type="checkbox" id="code-mode-checkbox">
+                            <span class="slider round"></span>
+                        </label>
+                        <span class="mode-label">Code Mode</span>
+                    </div>
                     <button class="btn-clear" id="logout-btn">Log Out</button>
                 </div>
 

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -4,6 +4,7 @@
  */
 
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
+import { executeDeclarativeBatch } from '../shared/webmcp-batch.js';
 
 const setupContainer = document.getElementById('setup-container');
 const chatContainer = document.getElementById('chat-container');
@@ -91,75 +92,6 @@ function getTSType(schema) {
     case 'object': return 'any';
     default: return 'any';
   }
-}
-
-function resolveReferences(val, results) {
-  if (typeof val === 'string') {
-    if (val.startsWith('$ref:')) {
-      const refPath = val.slice(5);
-      return getNestedProperty(results, refPath);
-    }
-    return val;
-  }
-  
-  if (Array.isArray(val)) {
-    return val.map(item => resolveReferences(item, results));
-  }
-  
-  if (val !== null && typeof val === 'object') {
-    const resolved = {};
-    for (const [k, v] of Object.entries(val)) {
-      resolved[k] = resolveReferences(v, results);
-    }
-    return resolved;
-  }
-  
-  return val;
-}
-
-function getNestedProperty(obj, path) {
-  const parts = path.split('.');
-  let current = obj;
-  for (const part of parts) {
-    if (current === null || current === undefined) return undefined;
-    current = current[part];
-  }
-  return current;
-}
-
-async function executeDeclarativeBatch(steps, executeToolFn) {
-  const results = {};
-  const outputs = [];
-
-  for (const step of steps) {
-    const { id, tool, args } = step;
-    const resolvedArgs = resolveReferences(args, results);
-    
-    try {
-      const result = await executeToolFn(tool, resolvedArgs);
-      if (id) {
-        results[id] = result;
-      }
-      outputs.push({
-        id,
-        tool,
-        args: resolvedArgs,
-        success: true,
-        result: result
-      });
-    } catch (err) {
-      outputs.push({
-        id,
-        tool,
-        args: resolvedArgs,
-        success: false,
-        error: err.message || String(err)
-      });
-      break;
-    }
-  }
-  
-  return outputs;
 }
 
 async function executeBatchLocally(steps) {

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -332,8 +332,22 @@ async function handleUserSubmit() {
 
     chat ??= ai.chats.create({ model: 'gemini-3.5-flash' });
 
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let networkCallsCount = 0;
+    const startTime = performance.now();
+
+    const addUsage = (result) => {
+      networkCallsCount++;
+      if (result && result.usageMetadata) {
+        totalInputTokens += result.usageMetadata.promptTokenCount || 0;
+        totalOutputTokens += result.usageMetadata.candidatesTokenCount || 0;
+      }
+    };
+
     const sendMessageParams = { message: text, config: await getConfig() };
     let currentResult = await chat.sendMessage(sendMessageParams);
+    addUsage(currentResult);
     let finalResponseGiven = false;
 
     while (!finalResponseGiven) {
@@ -390,8 +404,16 @@ async function handleUserSubmit() {
         }
         const sendMessageParams = { message: toolResponses, config: await getConfig() };
         currentResult = await chat.sendMessage(sendMessageParams);
+        addUsage(currentResult);
       }
     }
+
+    const duration = ((performance.now() - startTime) / 1000).toFixed(2);
+    appendMessage(
+      'System',
+      `📊 Turn metrics:<br>↳ Input (Billed): <strong>${totalInputTokens.toLocaleString()}</strong> tokens<br>↳ Output (Billed): <strong>${totalOutputTokens.toLocaleString()}</strong> tokens<br>↳ Total: <strong>${(totalInputTokens + totalOutputTokens).toLocaleString()}</strong> tokens<br>↳ Roundtrips: <strong>${networkCallsCount}</strong><br>↳ Time elapsed: <strong>${duration}s</strong>`,
+      'token-indicator'
+    );
 
     userInput.disabled = false;
     sendBtn.disabled = false;

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -15,8 +15,16 @@ const saveKeyBtn = document.getElementById('save-key-btn');
 const logoutBtn = document.getElementById('logout-btn');
 const urlInput = document.getElementById('url-input');
 const iframe = document.getElementById('iframe');
+const codeModeCheckbox = document.getElementById('code-mode-checkbox');
 
 let ai, chat;
+
+codeModeCheckbox.addEventListener('change', () => {
+  chat = null;
+  chatWindow.innerHTML = '';
+  appendMessage('System', `🔄 Switched to ${codeModeCheckbox.checked ? 'Code Mode' : 'Normal Mode'}. Chat restarted.`, 'tool-indicator');
+});
+
 
 async function getTools() {
   const iframeOrigin = new URL(iframe.src).origin;
@@ -24,13 +32,217 @@ async function getTools() {
   return tools;
 }
 
+function generateTSDeclaration(tools) {
+  let decl = `declare const mcp: {\n`;
+  for (const tool of tools) {
+    if (tool.name === 'execute_batch') continue;
+    
+    if (tool.description) {
+      decl += `  /**\n   * ${tool.description.split('\n').join('\n   * ')}\n   */\n`;
+    }
+    
+    let paramsType = 'Record<string, unknown>';
+    if (tool.inputSchema) {
+      try {
+        const schema = typeof tool.inputSchema === 'string' ? JSON.parse(tool.inputSchema) : tool.inputSchema;
+        if (schema && schema.properties) {
+          const props = [];
+          for (const [key, value] of Object.entries(schema.properties)) {
+            const isRequired = Array.isArray(schema.required) && schema.required.includes(key);
+            const propType = getTSType(value);
+            const desc = value.description ? ` // ${value.description}` : '';
+            props.push(`${key}${isRequired ? '' : '?'}: ${propType};${desc}`);
+          }
+          paramsType = `{\n    ${props.join('\n    ')}\n  }`;
+        }
+      } catch (e) {}
+    }
+    
+    decl += `  ${tool.name}: (args: ${paramsType}) => Promise<any>;\n\n`;
+    
+    const normalized = tool.name
+      .replace(/[.-]([a-zA-Z0-9])/g, (_, g) => g.toUpperCase())
+      .replace(/[^a-zA-Z0-9_]/g, '');
+    if (normalized !== tool.name) {
+      if (tool.description) {
+        decl += `  /**\n   * Alias for ${tool.name}\n   * ${tool.description.split('\n').join('\n   * ')}\n   */\n`;
+      }
+      decl += `  ${normalized}: (args: ${paramsType}) => Promise<any>;\n\n`;
+    }
+  }
+  decl += `};`;
+  return decl;
+}
+
+function getTSType(schema) {
+  if (schema.enum) {
+    return schema.enum.map(v => typeof v === 'string' ? `'${v}'` : String(v)).join(' | ');
+  }
+  switch (schema.type) {
+    case 'string': return 'string';
+    case 'number':
+    case 'integer': return 'number';
+    case 'boolean': return 'boolean';
+    case 'array':
+      if (schema.items) {
+        return `${getTSType(schema.items)}[]`;
+      }
+      return 'any[]';
+    case 'object': return 'any';
+    default: return 'any';
+  }
+}
+
+function resolveReferences(val, results) {
+  if (typeof val === 'string') {
+    if (val.startsWith('$ref:')) {
+      const refPath = val.slice(5);
+      return getNestedProperty(results, refPath);
+    }
+    return val;
+  }
+  
+  if (Array.isArray(val)) {
+    return val.map(item => resolveReferences(item, results));
+  }
+  
+  if (val !== null && typeof val === 'object') {
+    const resolved = {};
+    for (const [k, v] of Object.entries(val)) {
+      resolved[k] = resolveReferences(v, results);
+    }
+    return resolved;
+  }
+  
+  return val;
+}
+
+function getNestedProperty(obj, path) {
+  const parts = path.split('.');
+  let current = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+async function executeDeclarativeBatch(steps, executeToolFn) {
+  const results = {};
+  const outputs = [];
+
+  for (const step of steps) {
+    const { id, tool, args } = step;
+    const resolvedArgs = resolveReferences(args, results);
+    
+    try {
+      const result = await executeToolFn(tool, resolvedArgs);
+      if (id) {
+        results[id] = result;
+      }
+      outputs.push({
+        id,
+        tool,
+        args: resolvedArgs,
+        success: true,
+        result: result
+      });
+    } catch (err) {
+      outputs.push({
+        id,
+        tool,
+        args: resolvedArgs,
+        success: false,
+        error: err.message || String(err)
+      });
+      break;
+    }
+  }
+  
+  return outputs;
+}
+
+async function executeBatchLocally(steps) {
+  const executeToolFn = async (toolName, args) => {
+    const tools = await getTools();
+    const targetTool = tools.find(t => t.name === toolName);
+    if (!targetTool) {
+      throw new Error(`Tool ${toolName} not found`);
+    }
+    return await document.modelContext.executeTool(targetTool, JSON.stringify(args || {}));
+  };
+  
+  const outputs = await executeDeclarativeBatch(steps, executeToolFn);
+  const success = outputs.every(o => o.success);
+  return {
+    success,
+    outputs
+  };
+}
+
 async function getConfig() {
+  const tools = await getTools();
+  
+  if (codeModeCheckbox.checked) {
+    const systemInstruction = [
+      'You are an assistant embedded in a web page.',
+      'You interact with the page by generating a batch of tool calls using the `execute_batch` tool.',
+      'You MUST use `execute_batch` to perform any action on the page. Do NOT attempt to use other tools directly.',
+      'Inside the batch, you specify a sequence of steps. Each step calls one of the functions on the `mcp` object.',
+      'You can reference the results of previous steps in subsequent steps using the format "$ref:stepId" or "$ref:stepId.property".',
+      'For example, if step 1 returns `{ id: "123" }`, you can pass `"$ref:step1.id"` as an argument in step 2.',
+      'Below is the TypeScript declaration of the available functions under the `mcp` object:',
+      '```typescript',
+      generateTSDeclaration(tools),
+      '```',
+      'Write the steps carefully and return them as the array input for `execute_batch`.',
+    ].join('\n');
+
+    const executeBatchDecl = {
+      name: 'execute_batch',
+      description: 'Execute a sequential list of WebMCP tool calls, resolving data dependencies between steps (e.g. referencing previous steps output via "$ref:stepId.property").',
+      parametersJsonSchema: {
+        type: 'object',
+        properties: {
+          steps: {
+            type: 'array',
+            description: 'A list of tool call steps to run sequentially.',
+            items: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                  description: 'A unique ID for this step, to reference its output in later steps.'
+                },
+                tool: {
+                  type: 'string',
+                  description: 'The name of the tool to execute.'
+                },
+                args: {
+                  type: 'object',
+                  description: 'Arguments to pass to the tool. Can contain string values like "$ref:stepId.someProperty" to resolve data from earlier steps.'
+                }
+              },
+              required: ['tool']
+            }
+          }
+        },
+        required: ['steps']
+      }
+    };
+
+    return {
+      systemInstruction,
+      tools: [{ functionDeclarations: [executeBatchDecl] }]
+    };
+  }
+
+  // Normal Mode
   const systemInstruction = [
     'You are an assistant embedded in a web page.',
     'CRITICAL RULE: Do not try to use other tools than the available ones.',
-  ];
+  ].join('\n');
 
-  const tools = await getTools();
   const functionDeclarations = tools.map((tool) => {
     return {
       name: tool.name,
@@ -43,6 +255,7 @@ async function getConfig() {
 
   return { systemInstruction, tools: [{ functionDeclarations }] };
 }
+
 
 const storedKey = localStorage.getItem('gemini_api_key');
 if (storedKey) {
@@ -138,7 +351,35 @@ async function handleUserSubmit() {
             appendMessage('System', `⚙️ Executing tool: ${name}...`, 'tool-indicator');
             const tools = await getTools();
             const tool = tools.find((t) => t.name == name);
-            const result = await document.modelContext.executeTool(tool, inputArgs);
+            
+            let result;
+            if (name === 'execute_batch' && !tool) {
+              result = await executeBatchLocally(args.steps);
+            } else {
+              result = await document.modelContext.executeTool(tool, inputArgs);
+            }
+
+            if (name === 'execute_batch') {
+              const batchResult = typeof result === 'string' ? JSON.parse(result) : result;
+              if (batchResult && Array.isArray(batchResult.outputs)) {
+                for (const out of batchResult.outputs) {
+                  if (out.success) {
+                    appendMessage(
+                      'Console',
+                      `⚙️ Step [${out.id || 'anonymous'}]: called <strong>${out.tool}</strong> with args: <code>${JSON.stringify(out.args)}</code><br>↳ Result: <code>${typeof out.result === 'object' ? JSON.stringify(out.result) : String(out.result)}</code>`,
+                      'console-log'
+                    );
+                  } else {
+                    appendMessage(
+                      'Console',
+                      `❌ Step [${out.id || 'anonymous'}]: call to <strong>${out.tool}</strong> failed.<br>↳ Error: <span style="color:red">${out.error}</span>`,
+                      'console-log'
+                    );
+                  }
+                }
+              }
+            }
+
             toolResponses.push({ functionResponse: { name, response: { result } } });
           } catch (error) {
             appendMessage('System', `Error: ${error.message}`, 'error');

--- a/demos/page-agent/styles.css
+++ b/demos/page-agent/styles.css
@@ -194,3 +194,82 @@ button:disabled {
     padding: 6px 12px;
     font-size: 0.9em;
 }
+
+.mode-toggle-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9em;
+    font-weight: bold;
+}
+
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 22px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  transform: translateX(22px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 22px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
+.console-log {
+    background: #e2e3e5;
+    color: #383d41;
+    font-size: 0.85em;
+    font-family: monospace;
+    margin-right: auto;
+    border: 1px solid #d6d8db;
+    border-left: 4px solid #6c757d;
+}
+
+

--- a/demos/page-agent/styles.css
+++ b/demos/page-agent/styles.css
@@ -272,4 +272,15 @@ input:checked + .slider:before {
     border-left: 4px solid #6c757d;
 }
 
+.token-indicator {
+    background: #e2f0d9;
+    color: #385723;
+    font-size: 0.85em;
+    font-family: monospace;
+    margin-right: auto;
+    border: 1px solid #c5e0b4;
+    border-left: 4px solid #548235;
+}
+
+
 

--- a/demos/shared/webmcp-batch.js
+++ b/demos/shared/webmcp-batch.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function resolveReferences(val, results) {
+  if (typeof val === 'string') {
+    if (val.startsWith('$ref:')) {
+      const refPath = val.slice(5); // e.g. "step1.property"
+      return getNestedProperty(results, refPath);
+    }
+    return val;
+  }
+  
+  if (Array.isArray(val)) {
+    return val.map(item => resolveReferences(item, results));
+  }
+  
+  if (val !== null && typeof val === 'object') {
+    const resolved = {};
+    for (const [k, v] of Object.entries(val)) {
+      resolved[k] = resolveReferences(v, results);
+    }
+    return resolved;
+  }
+  
+  return val;
+}
+
+function getNestedProperty(obj, path) {
+  const parts = path.split('.');
+  let current = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+async function executeDeclarativeBatch(steps, executeToolFn) {
+  const results = {};
+  const outputs = [];
+
+  for (const step of steps) {
+    const { id, tool, args } = step;
+    const resolvedArgs = resolveReferences(args, results);
+    
+    try {
+      const result = await executeToolFn(tool, resolvedArgs);
+      if (id) {
+        results[id] = result;
+      }
+      outputs.push({
+        id,
+        tool,
+        args: resolvedArgs,
+        success: true,
+        result: result
+      });
+    } catch (err) {
+      outputs.push({
+        id,
+        tool,
+        args: resolvedArgs,
+        success: false,
+        error: err.message || String(err)
+      });
+      break;
+    }
+  }
+  
+  return outputs;
+}
+
+// Browser implementation and registration
+if (typeof window !== 'undefined' && window.document && window.document.modelContext) {
+  window.document.modelContext.registerTool({
+    name: 'execute_batch',
+    description: 'Execute a sequential list of WebMCP tool calls, resolving data dependencies between steps (e.g. referencing previous steps output via "$ref:stepId.property").',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        steps: {
+          type: 'array',
+          description: 'A list of tool call steps to run sequentially.',
+          items: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+                description: 'A unique ID for this step, to reference its output in later steps.'
+              },
+              tool: {
+                type: 'string',
+                description: 'The name of the tool to execute.'
+              },
+              args: {
+                type: 'object',
+                description: 'Arguments to pass to the tool. Can contain string values like "$ref:stepId.someProperty" to resolve data from earlier steps.'
+              }
+            },
+            required: ['tool']
+          }
+        }
+      },
+      required: ['steps']
+    },
+    execute: async ({ steps }) => {
+      const executeToolFn = async (toolName, args) => {
+        const tools = await window.document.modelContext.getTools();
+        const targetTool = tools.find(t => t.name === toolName);
+        if (!targetTool) {
+          throw new Error(`Tool ${toolName} not found`);
+        }
+        return await window.document.modelContext.executeTool(targetTool, JSON.stringify(args || {}));
+      };
+      
+      const outputs = await executeDeclarativeBatch(steps, executeToolFn);
+      
+      const success = outputs.every(o => o.success);
+      return {
+        success,
+        outputs
+      };
+    }
+  }, { exposedTo: ['*'] }).catch(() => {});
+}
+
+// Node.js exports for unit testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    resolveReferences,
+    getNestedProperty,
+    executeDeclarativeBatch
+  };
+}

--- a/demos/shared/webmcp-batch.js
+++ b/demos/shared/webmcp-batch.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-function resolveReferences(val, results) {
+export function resolveReferences(val, results) {
   if (typeof val === 'string') {
     if (val.startsWith('$ref:')) {
       const refPath = val.slice(5); // e.g. "step1.property"
@@ -27,7 +27,7 @@ function resolveReferences(val, results) {
   return val;
 }
 
-function getNestedProperty(obj, path) {
+export function getNestedProperty(obj, path) {
   const parts = path.split('.');
   let current = obj;
   for (const part of parts) {
@@ -37,7 +37,7 @@ function getNestedProperty(obj, path) {
   return current;
 }
 
-async function executeDeclarativeBatch(steps, executeToolFn) {
+export async function executeDeclarativeBatch(steps, executeToolFn) {
   const results = {};
   const outputs = [];
 
@@ -72,9 +72,10 @@ async function executeDeclarativeBatch(steps, executeToolFn) {
   return outputs;
 }
 
-// Browser implementation and registration
-if (typeof window !== 'undefined' && window.document && window.document.modelContext) {
-  window.document.modelContext.registerTool({
+export function registerExecuteBatchTool(modelContext = typeof window !== 'undefined' ? window.document?.modelContext : undefined) {
+  if (!modelContext) return;
+
+  modelContext.registerTool({
     name: 'execute_batch',
     description: 'Execute a sequential list of WebMCP tool calls, resolving data dependencies between steps (e.g. referencing previous steps output via "$ref:stepId.property").',
     inputSchema: {
@@ -107,12 +108,12 @@ if (typeof window !== 'undefined' && window.document && window.document.modelCon
     },
     execute: async ({ steps }) => {
       const executeToolFn = async (toolName, args) => {
-        const tools = await window.document.modelContext.getTools();
+        const tools = await modelContext.getTools();
         const targetTool = tools.find(t => t.name === toolName);
         if (!targetTool) {
           throw new Error(`Tool ${toolName} not found`);
         }
-        return await window.document.modelContext.executeTool(targetTool, JSON.stringify(args || {}));
+        return await modelContext.executeTool(targetTool, JSON.stringify(args || {}));
       };
       
       const outputs = await executeDeclarativeBatch(steps, executeToolFn);
@@ -126,11 +127,7 @@ if (typeof window !== 'undefined' && window.document && window.document.modelCon
   }, { exposedTo: ['*'] }).catch(() => {});
 }
 
-// Node.js exports for unit testing
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {
-    resolveReferences,
-    getNestedProperty,
-    executeDeclarativeBatch
-  };
+// Auto-register in browser environment if modelContext is available
+if (typeof window !== 'undefined' && window.document && window.document.modelContext) {
+  registerExecuteBatchTool(window.document.modelContext);
 }

--- a/demos/shared/webmcp-batch.js
+++ b/demos/shared/webmcp-batch.js
@@ -44,11 +44,19 @@ export async function executeDeclarativeBatch(steps, executeToolFn) {
   for (const step of steps) {
     const { id, tool, args } = step;
     const resolvedArgs = resolveReferences(args, results);
-    
+
     try {
       const result = await executeToolFn(tool, resolvedArgs);
+      let parsedResult = result;
+      if (typeof result === 'string') {
+        try {
+          parsedResult = JSON.parse(result);
+        } catch {
+          // Keep original string if not valid JSON
+        }
+      }
       if (id) {
-        results[id] = result;
+        results[id] = parsedResult;
       }
       outputs.push({
         id,

--- a/demos/shared/webmcp-batch.test.js
+++ b/demos/shared/webmcp-batch.test.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { resolveReferences, getNestedProperty, executeDeclarativeBatch } = require('./webmcp-batch.js');
+
+test('getNestedProperty helper', () => {
+  const obj = {
+    a: 1,
+    b: {
+      c: 'hello',
+      d: {
+        e: true
+      }
+    }
+  };
+
+  assert.strictEqual(getNestedProperty(obj, 'a'), 1);
+  assert.strictEqual(getNestedProperty(obj, 'b.c'), 'hello');
+  assert.strictEqual(getNestedProperty(obj, 'b.d.e'), true);
+  assert.strictEqual(getNestedProperty(obj, 'b.x'), undefined);
+  assert.strictEqual(getNestedProperty(obj, 'y.z'), undefined);
+  assert.strictEqual(getNestedProperty(null, 'a'), undefined);
+});
+
+test('resolveReferences basic and nested resolution', () => {
+  const results = {
+    step1: 'Medium',
+    step2: {
+      pizzaId: '12345',
+      toppings: ['cheese', 'onion']
+    }
+  };
+
+  // Basic string resolution
+  assert.deepEqual(resolveReferences('$ref:step1', results), 'Medium');
+  
+  // Nested resolution
+  assert.deepEqual(resolveReferences('$ref:step2.pizzaId', results), '12345');
+  assert.deepEqual(resolveReferences('$ref:step2.toppings.1', results), 'onion');
+  
+  // Object resolution
+  const inputObj = {
+    size: '$ref:step1',
+    toppings: ['$ref:step2.toppings.0', 'pepperoni'],
+    extra: {
+      id: '$ref:step2.pizzaId',
+      staticVal: 'hello'
+    }
+  };
+
+  const expectedObj = {
+    size: 'Medium',
+    toppings: ['cheese', 'pepperoni'],
+    extra: {
+      id: '12345',
+      staticVal: 'hello'
+    }
+  };
+
+  assert.deepEqual(resolveReferences(inputObj, results), expectedObj);
+});
+
+test('executeDeclarativeBatch execution and reference forwarding', async () => {
+  const steps = [
+    {
+      id: 'stepA',
+      tool: 'createPizza',
+      args: { style: 'BBQ' }
+    },
+    {
+      id: 'stepB',
+      tool: 'addTopping',
+      args: {
+        pizza: '$ref:stepA.pizzaId',
+        topping: '🍄'
+      }
+    }
+  ];
+
+  const db = {
+    createdPizzas: []
+  };
+
+  const mockExecuteTool = async (tool, args) => {
+    if (tool === 'createPizza') {
+      const pizza = { pizzaId: 'pizza_999', style: args.style };
+      db.createdPizzas.push(pizza);
+      return pizza;
+    }
+    if (tool === 'addTopping') {
+      return { status: 'success', pizzaId: args.pizza, topping: args.topping };
+    }
+    throw new Error(`Unknown tool: ${tool}`);
+  };
+
+  const outputs = await executeDeclarativeBatch(steps, mockExecuteTool);
+
+  assert.strictEqual(outputs.length, 2);
+  assert.strictEqual(outputs[0].success, true);
+  assert.deepEqual(outputs[0].result, { pizzaId: 'pizza_999', style: 'BBQ' });
+  
+  assert.strictEqual(outputs[1].success, true);
+  assert.deepEqual(outputs[1].args, { pizza: 'pizza_999', topping: '🍄' });
+  assert.deepEqual(outputs[1].result, { status: 'success', pizzaId: 'pizza_999', topping: '🍄' });
+});
+
+test('executeDeclarativeBatch failure halts execution', async () => {
+  const steps = [
+    {
+      id: 'step1',
+      tool: 'succeed',
+      args: {}
+    },
+    {
+      id: 'step2',
+      tool: 'fail',
+      args: {}
+    },
+    {
+      id: 'step3',
+      tool: 'succeed',
+      args: {}
+    }
+  ];
+
+  let step3Called = false;
+  const mockExecuteTool = async (tool, args) => {
+    if (tool === 'succeed') {
+      if (tool === 'step3') step3Called = true;
+      return 'ok';
+    }
+    if (tool === 'fail') {
+      throw new Error('Forced failure');
+    }
+  };
+
+  const outputs = await executeDeclarativeBatch(steps, mockExecuteTool);
+
+  assert.strictEqual(outputs.length, 2);
+  assert.strictEqual(outputs[0].success, true);
+  assert.strictEqual(outputs[1].success, false);
+  assert.strictEqual(outputs[1].error, 'Forced failure');
+  assert.strictEqual(step3Called, false);
+});

--- a/demos/shared/webmcp-batch.test.js
+++ b/demos/shared/webmcp-batch.test.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const test = require('node:test');
-const assert = require('node:assert');
-const { resolveReferences, getNestedProperty, executeDeclarativeBatch } = require('./webmcp-batch.js');
+import test from 'node:test';
+import assert from 'node:assert';
+import { resolveReferences, getNestedProperty, executeDeclarativeBatch } from './webmcp-batch.js';
 
 test('getNestedProperty helper', () => {
   const obj = {


### PR DESCRIPTION
This PR adds a secure, declarative **Code Mode** (batch tool execution engine) for WebMCP. It allows AI agents to bundle multiple tool invocations and resolve data dependencies between steps (using a `$ref:stepId.property` format) in a single turn without executing arbitrary stringified code (e.g. avoiding insecure `eval`/`Function` call execution).

### Key Additions & Changes

1. **Standalone Batch Tool (`demos/shared/webmcp-batch.js`)**
   - Implements the `execute_batch` tool that executes steps sequentially, resolving any `$ref:stepId.nestedProperty` values from previous step results.
   - Halts execution upon encountering the first error to keep the client state predictable.
   - Exported UMD-style module to support both browser injection and Node.js importing.

2. **Unit Tests (`demos/shared/webmcp-batch.test.js`)**
   - Added 4 test suites for property resolution, recursive object reference replacement, reference forwarding between steps, and failure halting using Node's built-in `node:test` runner.

3. **Page Agent Upgrade (`demos/page-agent/`)**
   - **UI Toggle**: Added a switch in the header to alternate between Normal Mode (direct tool declaration) and Code Mode (exposing only `execute_batch`).
   - **TS Declarations Generator**: Generates type declarations for all available iframe guest tools to inject as system instructions for the LLM.
   - **Execution Logging**: Formats and prints structured step-by-step executions (input arguments, resolved values, output/results) directly inside the chat window.
   - **Local Fallback**: Automatically executes batch steps locally if the iframe page does not natively expose the `execute_batch` tool.

4. **Documentation**
   - Updated the Page Agent `README.md` to document Code Mode, the JSON steps structure, reference formats, and benefits.

### Testing Locally
- **Unit Tests**: Run `node --test demos/shared/webmcp-batch.test.js`.
- **Demos**: Run `./build-demos.sh`, open `demos/page-agent/index.html` in your browser, switch to **Code Mode**, and send a multi-step prompt.

### Demo

1 tool call for the model, triggering 4 tool calls on the website:

<img width="1271" height="692" alt="Screenshot 2026-07-14 at 11 18 27" src="https://github.com/user-attachments/assets/eea7c44b-f358-4530-9f67-596747fffecb" />

