### PR TITLE
Evals: Bugfix for runs vs steps, and full LLM trajectory

### DIFF
--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -271,9 +271,10 @@ export class VercelBackend implements Backend {
             }
           }
 
-          const rawSteps = resultPayload.steps && resultPayload.steps.length > 0
-            ? resultPayload.steps
-            : stepsHistory;
+          const rawSteps =
+            resultPayload.steps && resultPayload.steps.length > 0
+              ? resultPayload.steps
+              : stepsHistory;
 
           const trajectory = rawSteps.map((step, idx) => ({
             text: step.text,

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -268,13 +268,21 @@ export class VercelBackend implements Backend {
 
           if (trajectories.length === 0) {
             const response: any = { text: resultPayload.text };
-            const stepResult: TestResult = { test, response, outcome: "pass", trajectory };
+            const stepResult: TestResult = {
+              test,
+              response,
+              outcome: "pass",
+              trajectory,
+              runIndex: r + 1,
+              stepIndex: 1,
+            };
             testResults.push(stepResult);
             passCount++;
             if (onEvent) {
               onEvent({ type: "progress", testNumber: testCount, result: stepResult });
             }
           } else {
+            let stepIndex = 1;
             for (const traj of trajectories) {
               let response: any = traj.actual;
               if (!response && executedCalls.length === 0 && resultPayload.text) {
@@ -292,6 +300,8 @@ export class VercelBackend implements Backend {
                 response,
                 outcome: traj.outcome,
                 trajectory,
+                runIndex: r + 1,
+                stepIndex: stepIndex++,
               };
 
               testResults.push(stepResult);
@@ -313,6 +323,8 @@ export class VercelBackend implements Backend {
             test,
             response: null as any,
             outcome: "error",
+            runIndex: r + 1,
+            stepIndex: 1,
           };
           testResults.push(result);
           if (onEvent) {

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -179,6 +179,9 @@ export class VercelBackend implements Backend {
           );
         }
 
+        const availableToolsPerStep: Array<Array<Tool>> = [];
+        const stepsHistory: any[] = [];
+
         try {
           const model = getModel(config);
 
@@ -212,18 +215,26 @@ export class VercelBackend implements Backend {
                   }
                 }
               : undefined,
-            onStepFinish: config.debug
-              ? (event) => {
-                  console.log(
-                    `[DEBUG] Step ${event.stepNumber || ""} finished (${event.finishReason}). Total Tokens: ${event.usage.totalTokens}`,
-                  );
-                }
-              : undefined,
+            onStepFinish: (event) => {
+              if (config.debug) {
+                console.log(
+                  `[DEBUG] Step ${event.stepNumber || ""} finished (${event.finishReason}). Total Tokens: ${event.usage.totalTokens}`,
+                );
+              }
+              stepsHistory.push({
+                text: event.text,
+                reasoningText: event.reasoningText,
+                toolCalls: event.toolCalls,
+                toolResults: event.toolResults,
+              });
+            },
             prepareStep: async (_opts: any): Promise<any> => {
               let rawTools = await getToolsFromBrowserPage(page!);
               if (rawTools.length > 0) {
                 currentTools = mapRawBrowserToolsToConfig(rawTools, currentTools);
               }
+
+              availableToolsPerStep.push([...currentTools]);
 
               // Clear the object
               for (const key in aiToolsWithExecution) {
@@ -260,7 +271,17 @@ export class VercelBackend implements Backend {
             }
           }
 
-          const trajectory = resultPayload.steps || [];
+          const rawSteps = resultPayload.steps && resultPayload.steps.length > 0
+            ? resultPayload.steps
+            : stepsHistory;
+
+          const trajectory = rawSteps.map((step, idx) => ({
+            text: step.text,
+            reasoningText: step.reasoningText,
+            toolCalls: step.toolCalls,
+            toolResults: step.toolResults,
+            availableTools: availableToolsPerStep[idx] || [],
+          }));
 
           const trajectories = test.expectedCall
             ? evaluateExecutionTrajectory(test.expectedCall, executedCalls as ToolCall[])
@@ -319,12 +340,20 @@ export class VercelBackend implements Backend {
         } catch (e: any) {
           console.warn("Error running test:", e);
           errorCount++;
+          const trajectory = stepsHistory.map((step, idx) => ({
+            text: step.text,
+            reasoningText: step.reasoningText,
+            toolCalls: step.toolCalls,
+            toolResults: step.toolResults,
+            availableTools: availableToolsPerStep[idx] || [],
+          }));
           const result: TestResult = {
             test,
             response: null as any,
             outcome: "error",
             runIndex: r + 1,
             stepIndex: 1,
+            trajectory,
           };
           testResults.push(result);
           if (onEvent) {

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -6,7 +6,7 @@
 import { generateText, stepCountIs, ToolLoopAgent } from "ai";
 import { Browser, Page } from "puppeteer-core";
 import { Config, WebmcpConfig } from "../types/config.js";
-import { Eval, TestResult, TestResults } from "../types/evals.js";
+import { Eval, TestResult, TestResults, TrajectoryStep } from "../types/evals.js";
 import { Tool, ToolCall } from "../types/tools.js";
 import { countExpectedCalls, evaluateExecutionTrajectory, findChromePath } from "../utils.js";
 
@@ -180,7 +180,7 @@ export class VercelBackend implements Backend {
         }
 
         const availableToolsPerStep: Array<Array<Tool>> = [];
-        const stepsHistory: any[] = [];
+        const stepsHistory: TrajectoryStep[] = [];
 
         try {
           const model = getModel(config);

--- a/evals-cli/src/evaluator/index.ts
+++ b/evals-cli/src/evaluator/index.ts
@@ -77,13 +77,20 @@ export async function executeLocalEvals(
 
         if (trajectories.length === 0) {
           // No expected calls and no actual calls
-          const result: TestResult = { test, response: null, outcome: "pass" };
+          const result: TestResult = {
+            test,
+            response: null,
+            outcome: "pass",
+            runIndex: r + 1,
+            stepIndex: 1,
+          };
           testResults.push(result);
           passCount++;
           if (onEvent) {
             onEvent({ type: "progress", testNumber: testCount, result });
           }
         } else {
+          let stepIndex = 1;
           for (const traj of trajectories) {
             const stepResult: TestResult = {
               test: {
@@ -93,6 +100,8 @@ export async function executeLocalEvals(
               },
               response: traj.actual,
               outcome: traj.outcome,
+              runIndex: r + 1,
+              stepIndex: stepIndex++,
             };
             testResults.push(stepResult);
             if (traj.outcome === "pass") {
@@ -123,6 +132,8 @@ export async function executeLocalEvals(
           test,
           response: null as any,
           outcome: "error",
+          runIndex: r + 1,
+          stepIndex: 1,
         };
         testResults.push(result);
         if (onEvent) {

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -81,7 +81,7 @@ function renderEvalsSummary(testResults: TestResults): string {
     ),
   );
   const totalCases = caseNames.size;
-  const runs = Math.max(...testResults.results.map((r) => r.runIndex || 1), 1);
+  const runs = testResults.results.reduce((max, r) => Math.max(max, r.runIndex || 1), 1);
 
   return `
         <p class="text-sm text-slate-500 mb-4 font-medium">

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -58,15 +58,33 @@ export function renderReport(config: Config, testResults: TestResults): string {
 }
 
 function renderEvalsSummary(testResults: TestResults): string {
+  const totalEvals = testResults.passCount + testResults.failCount + testResults.errorCount;
   const passRate = (
-    (testResults.passCount / (testResults.passCount + testResults.failCount)) *
-    100
+    totalEvals > 0
+      ? (testResults.passCount / totalEvals) * 100
+      : 0
   ).toFixed(1);
+
+  const caseNames = new Set(
+    testResults.results.map(
+      (r) =>
+        r.test.name ||
+        (r.test.messages[0] && r.test.messages[0].type === "message"
+          ? r.test.messages[0].content
+          : ""),
+    ),
+  );
+  const totalCases = caseNames.size;
+  const runs = Math.max(...testResults.results.map((r) => r.runIndex || 1), 1);
+
   return `
+        <p class="text-sm text-slate-500 mb-4 font-medium">
+          Evaluated ${totalCases} test case${totalCases !== 1 ? "s" : ""} across ${runs} run${runs !== 1 ? "s" : ""}.
+        </p>
         <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
             <div class="bg-slate-50 p-4 rounded-lg border border-slate-100 flex flex-col">
                 <span class="text-sm text-slate-500 font-medium">Total Evals</span>
-                <span class="text-2xl font-bold text-slate-900">${testResults.testCount}</span>
+                <span class="text-2xl font-bold text-slate-900">${totalEvals}</span>
             </div>
             <div class="bg-emerald-50 p-4 rounded-lg border border-emerald-100 flex flex-col">
                 <span class="text-sm text-emerald-600 font-medium">Passed</span>
@@ -127,7 +145,7 @@ function renderDetails(testResults: Array<TestResult>): string {
   for (const result of testResults) {
     const firstMsg = result.test.messages[0];
     const fallbackName =
-      firstMsg && firstMsg.type === "message" ? firstMsg.content : `Case #${originalIndex}`;
+      firstMsg && firstMsg.type === "message" ? firstMsg.content : `Test case #${originalIndex}`;
     const caseName = result.test.name || fallbackName;
 
     if (!groupsMap.has(caseName)) {
@@ -181,15 +199,16 @@ function renderDetails(testResults: Array<TestResult>): string {
   }
 
   const groups = Array.from(groupsMap.values());
+  const totalCases = groups.length;
 
   return `
     <div class="space-y-6">
-      ${groups.map((group) => renderTestCase(group)).join("")}
+      ${groups.map((group, index) => renderTestCase(group, index + 1, totalCases)).join("")}
     </div>
   `;
 }
 
-function renderTestCase(group: TestCase): string {
+function renderTestCase(group: TestCase, caseIndex: number, totalCases: number): string {
   const hasFailures = group.failCount > 0 || group.errorCount > 0;
   const isOpen = hasFailures ? "open" : "";
 
@@ -213,6 +232,7 @@ function renderTestCase(group: TestCase): string {
       : "bg-rose-100 text-rose-800 border-rose-200";
 
   const passRateText = `${group.passCount}/${group.totalCount} Passed`;
+  const totalRuns = group.runs.length;
 
   return `
     <div class="${containerClass}">
@@ -222,28 +242,39 @@ function renderTestCase(group: TestCase): string {
             <svg class="w-5 h-5 text-slate-400 group-open/case:rotate-90 transition-transform duration-200 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" />
             </svg>
-            <h3 class="text-base font-semibold ${titleColorClass} truncate font-sans">
-              ${group.name}
-            </h3>
+            <div class="truncate">
+              <span class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider block mb-0.5">Test case #${caseIndex}/${totalCases}</span>
+              <h3 class="text-base font-semibold ${titleColorClass} truncate font-sans">
+                ${group.name}
+              </h3>
+            </div>
           </div>
           <div class="flex items-center space-x-3 shrink-0">
-            <span class="px-3 py-1 rounded-full text-xs font-semibold border ${badgeClass}">
+            <span class="px-3 py-1 rounded text-xs font-semibold border ${badgeClass}">
               ${passRateText}
             </span>
           </div>
         </summary>
         
         <div class="p-5 border-t border-slate-100 bg-slate-50/50 space-y-5">
-          ${group.runs.map((run) => renderRunIteration(run)).join("")}
+          ${group.runs.map((run) => renderRunIteration(run, caseIndex, totalCases, totalRuns)).join("")}
         </div>
       </details>
     </div>
   `;
 }
 
-function renderRunIteration(run: TestRun): string {
+function renderRunIteration(
+  run: TestRun,
+  caseIndex: number,
+  totalCases: number,
+  totalRuns: number,
+): string {
   const isPass = run.outcome === "pass";
   const isOpen = !isPass ? "open" : "";
+
+  const totalSteps = run.steps.length;
+  const passedSteps = run.steps.filter((s) => s.result.outcome === "pass").length;
 
   const badgeClass =
     run.outcome === "pass"
@@ -251,6 +282,8 @@ function renderRunIteration(run: TestRun): string {
       : run.outcome === "fail"
         ? "bg-rose-100 text-rose-800 border-rose-200"
         : "bg-amber-100 text-amber-800 border-amber-200";
+
+  const runBadgeText = `${passedSteps}/${totalSteps} Passed`;
 
   return `
     <div class="border border-slate-200 rounded-lg bg-white shadow-xs overflow-hidden">
@@ -260,10 +293,10 @@ function renderRunIteration(run: TestRun): string {
             <svg class="w-4 h-4 text-slate-400 group-open/run:rotate-90 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
             </svg>
-            <span class="font-semibold">Run #${run.runIndex}</span>
+            <span class="font-semibold">Run #${run.runIndex}/${totalRuns}</span>
           </div>
-          <span class="px-2.5 py-0.5 rounded-full text-xs font-semibold border ${badgeClass}">
-            ${run.outcome.toUpperCase()}
+          <span class="px-2.5 py-0.5 rounded text-xs font-semibold border ${badgeClass}">
+            ${runBadgeText}
           </span>
         </summary>
         
@@ -282,7 +315,7 @@ function renderRunIteration(run: TestRun): string {
 
           <div class="space-y-4">
             <h4 class="text-xs font-semibold text-slate-500 uppercase tracking-wider">Steps Evaluation</h4>
-            ${run.steps.map((step) => renderStepDetails(step, run.steps.length, run.runIndex)).join("")}
+            ${run.steps.map((step) => renderStepDetails(step, run.steps.length)).join("")}
           </div>
 
           ${renderTrajectory(run.trajectory)}
@@ -292,8 +325,11 @@ function renderRunIteration(run: TestRun): string {
   `;
 }
 
-function renderStepDetails(stepEval: TestStep, totalSteps: number, runIndex: number): string {
-  const { stepIndex, originalIndex, result } = stepEval;
+function renderStepDetails(
+  stepEval: TestStep,
+  totalSteps: number,
+): string {
+  const { stepIndex, result } = stepEval;
 
   const functionNameOutcome =
     (result.test.expectedCall?.[0] as FunctionCall)?.functionName ===
@@ -319,7 +355,7 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number, runIndex: num
     <div class="bg-white rounded-lg border border-slate-200 overflow-hidden">
       <div class="flex items-center justify-between bg-slate-50/80 p-3 border-b border-slate-200">
         <h5 class="text-xs font-semibold text-slate-700">
-          Step #${stepIndex}/${totalSteps} <span class="text-slate-400 font-normal ml-1">(Overall Test #${originalIndex} of Run #${runIndex})</span>
+          Step #${stepIndex}/${totalSteps}
         </h5>
         <span class="px-2 py-0.5 rounded text-[10px] font-semibold border ${statusColor}">
           ${result.outcome.toUpperCase()}
@@ -403,21 +439,21 @@ function renderTrajectory(trajectory?: any[]): string {
                 '<div><em class="text-xs font-semibold text-slate-500 uppercase tracking-wider block mb-1">' +
                 'Available Tools (' + step.availableTools.length + '):' +
                 '</em>' +
-                '<ul class="space-y-2 mt-2 bg-slate-50 p-3 rounded-md border border-slate-200 max-h-60 overflow-y-auto">' +
+              '<div class="grid grid-cols-[180px_1fr] gap-x-4 gap-y-2.5 mt-2 bg-slate-50 p-3 rounded-md border border-slate-200 max-h-60 overflow-y-auto font-sans">' +
                 step.availableTools
                   .map(
                     (t: any) =>
-                      '<li class="flex items-start space-x-2 text-xs">' +
-                      '<span class="px-1.5 py-0.5 font-mono font-semibold bg-slate-200 text-slate-800 border border-slate-300 rounded shrink-0 text-[10px]">' +
+                      '<div class="flex items-start">' +
+                      '<span class="px-1.5 py-0.5 font-mono font-semibold bg-slate-200 text-slate-800 border border-slate-300 rounded text-[10px] truncate max-w-full" title="' + t.functionName + '">' +
                       t.functionName +
                       "</span>" +
-                      '<span class="text-slate-600 mt-0.5">' +
+                      "</div>" +
+                      '<div class="text-xs text-slate-600 text-left align-top mt-0.5">' +
                       (t.description || '<em class="text-slate-400">No description</em>') +
-                      "</span>" +
-                      "</li>",
+                      "</div>",
                   )
                   .join("") +
-                "</ul></div>";
+                "</div></div>";
             }
             if (step.toolCalls && step.toolCalls.length > 0) {
               html +=

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -282,7 +282,7 @@ function renderRunIteration(run: TestRun): string {
 
           <div class="space-y-4">
             <h4 class="text-xs font-semibold text-slate-500 uppercase tracking-wider">Steps Evaluation</h4>
-            ${run.steps.map((step) => renderStepDetails(step)).join("")}
+            ${run.steps.map((step) => renderStepDetails(step, run.steps.length, run.runIndex)).join("")}
           </div>
 
           ${renderTrajectory(run.trajectory)}
@@ -292,7 +292,7 @@ function renderRunIteration(run: TestRun): string {
   `;
 }
 
-function renderStepDetails(stepEval: TestStep): string {
+function renderStepDetails(stepEval: TestStep, totalSteps: number, runIndex: number): string {
   const { stepIndex, originalIndex, result } = stepEval;
 
   const functionNameOutcome =
@@ -319,7 +319,7 @@ function renderStepDetails(stepEval: TestStep): string {
     <div class="bg-white rounded-lg border border-slate-200 overflow-hidden">
       <div class="flex items-center justify-between bg-slate-50/80 p-3 border-b border-slate-200">
         <h5 class="text-xs font-semibold text-slate-700">
-          Step #${stepIndex} <span class="text-slate-400 font-normal ml-1">(Overall Test #${originalIndex})</span>
+          Step #${stepIndex}/${totalSteps} <span class="text-slate-400 font-normal ml-1">(Overall Test #${originalIndex} of Run #${runIndex})</span>
         </h5>
         <span class="px-2 py-0.5 rounded text-[10px] font-semibold border ${statusColor}">
           ${result.outcome.toUpperCase()}
@@ -390,12 +390,34 @@ function renderTrajectory(trajectory?: any[]): string {
               (index + 1) +
               "</strong>";
 
-            if (step.text) {
+            const thoughts = step.reasoningText || step.text;
+            if (thoughts) {
               html +=
                 '<div><em class="text-xs font-semibold text-slate-500 uppercase tracking-wider block mb-1">Thoughts:</em>' +
                 '<pre class="whitespace-pre-wrap bg-slate-50 p-3 rounded-md text-sm text-slate-700 border border-slate-200 font-sans">' +
-                step.text +
+              thoughts +
                 "</pre></div>";
+            }
+            if (step.availableTools && step.availableTools.length > 0) {
+              html +=
+                '<div><em class="text-xs font-semibold text-slate-500 uppercase tracking-wider block mb-1">' +
+                'Available Tools (' + step.availableTools.length + '):' +
+                '</em>' +
+                '<ul class="space-y-2 mt-2 bg-slate-50 p-3 rounded-md border border-slate-200 max-h-60 overflow-y-auto">' +
+                step.availableTools
+                  .map(
+                    (t: any) =>
+                      '<li class="flex items-start space-x-2 text-xs">' +
+                      '<span class="px-1.5 py-0.5 font-mono font-semibold bg-slate-200 text-slate-800 border border-slate-300 rounded shrink-0 text-[10px]">' +
+                      t.functionName +
+                      "</span>" +
+                      '<span class="text-slate-600 mt-0.5">' +
+                      (t.description || '<em class="text-slate-400">No description</em>') +
+                      "</span>" +
+                      "</li>",
+                  )
+                  .join("") +
+                "</ul></div>";
             }
             if (step.toolCalls && step.toolCalls.length > 0) {
               html +=

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -454,7 +454,9 @@ function renderTrajectory(trajectory?: any[]): string {
                       "</span>" +
                       "</div>" +
                       '<div class="text-xs text-slate-600 text-left align-top mt-0.5">' +
-                      (t.description ? escapeHtml(t.description) : '<em class="text-slate-400">No description</em>') +
+                      (t.description
+                        ? escapeHtml(t.description)
+                        : '<em class="text-slate-400">No description</em>') +
                       "</div>",
                   )
                   .join("") +
@@ -503,18 +505,14 @@ function renderMessage(message: Message): string {
       content = `<div class="bg-slate-50 border border-slate-200 p-3 rounded-md text-sm text-slate-700 whitespace-pre-wrap">${escapeHtml(message.content)}</div>`;
       break;
     case "functioncall":
-      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-blue-300 m-0">${escapeHtml(JSON.stringify(
-        { function: message.name, args: message.arguments },
-        null,
-        2,
-      ))}</pre></div>`;
+      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-blue-300 m-0">${escapeHtml(
+        JSON.stringify({ function: message.name, args: message.arguments }, null, 2),
+      )}</pre></div>`;
       break;
     case "functionresponse":
-      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-emerald-300 m-0">${escapeHtml(JSON.stringify(
-        { function: message.name, args: message.response },
-        null,
-        2,
-      ))}</pre></div>`;
+      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-emerald-300 m-0">${escapeHtml(
+        JSON.stringify({ function: message.name, args: message.response }, null, 2),
+      )}</pre></div>`;
       break;
   }
   return `

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -59,11 +59,7 @@ export function renderReport(config: Config, testResults: TestResults): string {
 
 function renderEvalsSummary(testResults: TestResults): string {
   const totalEvals = testResults.passCount + testResults.failCount + testResults.errorCount;
-  const passRate = (
-    totalEvals > 0
-      ? (testResults.passCount / totalEvals) * 100
-      : 0
-  ).toFixed(1);
+  const passRate = (totalEvals > 0 ? (testResults.passCount / totalEvals) * 100 : 0).toFixed(1);
 
   const caseNames = new Set(
     testResults.results.map(
@@ -175,7 +171,7 @@ function renderDetails(testResults: Array<TestResult>): string {
     }
 
     run.steps.push({
-      stepIndex: result.stepIndex || (run.steps.length + 1),
+      stepIndex: result.stepIndex || run.steps.length + 1,
       originalIndex,
       result,
     });
@@ -325,15 +321,11 @@ function renderRunIteration(
   `;
 }
 
-function renderStepDetails(
-  stepEval: TestStep,
-  totalSteps: number,
-): string {
+function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
   const { stepIndex, result } = stepEval;
 
   const functionNameOutcome =
-    (result.test.expectedCall?.[0] as FunctionCall)?.functionName ===
-    result.response?.functionName
+    (result.test.expectedCall?.[0] as FunctionCall)?.functionName === result.response?.functionName
       ? "pass"
       : "fail";
 
@@ -407,7 +399,6 @@ function renderStepDetails(
   `;
 }
 
-
 function renderTrajectory(trajectory?: any[]): string {
   if (!trajectory || trajectory.length === 0) return "";
 
@@ -431,20 +422,24 @@ function renderTrajectory(trajectory?: any[]): string {
               html +=
                 '<div><em class="text-xs font-semibold text-slate-500 uppercase tracking-wider block mb-1">Thoughts:</em>' +
                 '<pre class="whitespace-pre-wrap bg-slate-50 p-3 rounded-md text-sm text-slate-700 border border-slate-200 font-sans">' +
-              thoughts +
+                thoughts +
                 "</pre></div>";
             }
             if (step.availableTools && step.availableTools.length > 0) {
               html +=
                 '<div><em class="text-xs font-semibold text-slate-500 uppercase tracking-wider block mb-1">' +
-                'Available Tools (' + step.availableTools.length + '):' +
-                '</em>' +
-              '<div class="grid grid-cols-[180px_1fr] gap-x-4 gap-y-2.5 mt-2 bg-slate-50 p-3 rounded-md border border-slate-200 max-h-60 overflow-y-auto font-sans">' +
+                "Available Tools (" +
+                step.availableTools.length +
+                "):" +
+                "</em>" +
+                '<div class="grid grid-cols-[180px_1fr] gap-x-4 gap-y-2.5 mt-2 bg-slate-50 p-3 rounded-md border border-slate-200 max-h-60 overflow-y-auto font-sans">' +
                 step.availableTools
                   .map(
                     (t: any) =>
                       '<div class="flex items-start">' +
-                      '<span class="px-1.5 py-0.5 font-mono font-semibold bg-slate-200 text-slate-800 border border-slate-300 rounded text-[10px] truncate max-w-full" title="' + t.functionName + '">' +
+                      '<span class="px-1.5 py-0.5 font-mono font-semibold bg-slate-200 text-slate-800 border border-slate-300 rounded text-[10px] truncate max-w-full" title="' +
+                      t.functionName +
+                      '">' +
                       t.functionName +
                       "</span>" +
                       "</div>" +

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -8,6 +8,16 @@ import { Message, TestResult, TestResults, FunctionCall } from "../types/evals.j
 import { matchesArgument } from "../matcher.js";
 import { sortObjectKeys } from "../utils.js";
 
+function escapeHtml(str: string | null | undefined): string {
+  if (str === null || str === undefined) return "";
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export function renderReport(config: Config, testResults: TestResults): string {
   return `
 <!DOCTYPE html>
@@ -241,7 +251,7 @@ function renderTestCase(group: TestCase, caseIndex: number, totalCases: number):
             <div class="truncate">
               <span class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider block mb-0.5">Test case #${caseIndex}/${totalCases}</span>
               <h3 class="text-base font-semibold ${titleColorClass} truncate font-sans">
-                ${group.name}
+                ${escapeHtml(group.name)}
               </h3>
             </div>
           </div>
@@ -366,8 +376,8 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
           <tbody class="divide-y divide-slate-100">
             <tr class="hover:bg-slate-50/30">
               <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap">Function Name</td>
-              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${(result.test.expectedCall?.[0] as FunctionCall)?.functionName || null}</code></td>
-              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${result.response?.functionName || null}</code></td>
+              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml((result.test.expectedCall?.[0] as FunctionCall)?.functionName || null)}</code></td>
+              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml(result.response?.functionName || null)}</code></td>
               <td class="px-4 py-3">
                 <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs">
                   ${functionNameOutcome.toUpperCase()}
@@ -378,12 +388,12 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
               <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap align-top">Arguments</td>
               <td class="px-4 py-3">
                 <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
-                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys((result.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2)}</pre>
+                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${escapeHtml(JSON.stringify(sortObjectKeys((result.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2))}</pre>
                 </div>
               </td>
               <td class="px-4 py-3">
                 <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
-                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys(result.response?.args) || null, null, 2)}</pre>
+                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${escapeHtml(JSON.stringify(sortObjectKeys(result.response?.args) || null, null, 2))}</pre>
                 </div>
               </td>
               <td class="px-4 py-3 align-top">
@@ -422,7 +432,7 @@ function renderTrajectory(trajectory?: any[]): string {
               html +=
                 '<div><em class="text-xs font-semibold text-slate-500 uppercase tracking-wider block mb-1">Thoughts:</em>' +
                 '<pre class="whitespace-pre-wrap bg-slate-50 p-3 rounded-md text-sm text-slate-700 border border-slate-200 font-sans">' +
-                thoughts +
+                escapeHtml(thoughts) +
                 "</pre></div>";
             }
             if (step.availableTools && step.availableTools.length > 0) {
@@ -438,13 +448,13 @@ function renderTrajectory(trajectory?: any[]): string {
                     (t: any) =>
                       '<div class="flex items-start">' +
                       '<span class="px-1.5 py-0.5 font-mono font-semibold bg-slate-200 text-slate-800 border border-slate-300 rounded text-[10px] truncate max-w-full" title="' +
-                      t.functionName +
+                      escapeHtml(t.functionName) +
                       '">' +
-                      t.functionName +
+                      escapeHtml(t.functionName) +
                       "</span>" +
                       "</div>" +
                       '<div class="text-xs text-slate-600 text-left align-top mt-0.5">' +
-                      (t.description || '<em class="text-slate-400">No description</em>') +
+                      (t.description ? escapeHtml(t.description) : '<em class="text-slate-400">No description</em>') +
                       "</div>",
                   )
                   .join("") +
@@ -455,7 +465,7 @@ function renderTrajectory(trajectory?: any[]): string {
                 '<div><em class="text-xs font-semibold text-blue-500 uppercase tracking-wider block mb-1">Tool Calls:</em>' +
                 '<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700">' +
                 '<pre class="text-xs text-blue-300 font-mono m-0">' +
-                JSON.stringify(step.toolCalls, null, 2) +
+                escapeHtml(JSON.stringify(step.toolCalls, null, 2)) +
                 "</pre>" +
                 "</div></div>";
             }
@@ -464,7 +474,7 @@ function renderTrajectory(trajectory?: any[]): string {
                 '<div><em class="text-xs font-semibold text-emerald-500 uppercase tracking-wider block mb-1">Tool Results:</em>' +
                 '<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700">' +
                 '<pre class="text-xs text-emerald-300 font-mono m-0">' +
-                JSON.stringify(step.toolResults, null, 2) +
+                escapeHtml(JSON.stringify(step.toolResults, null, 2)) +
                 "</pre>" +
                 "</div></div>";
             }
@@ -490,21 +500,21 @@ function renderMessage(message: Message): string {
 
   switch (message.type) {
     case "message":
-      content = `<div class="bg-slate-50 border border-slate-200 p-3 rounded-md text-sm text-slate-700 whitespace-pre-wrap">${message.content}</div>`;
+      content = `<div class="bg-slate-50 border border-slate-200 p-3 rounded-md text-sm text-slate-700 whitespace-pre-wrap">${escapeHtml(message.content)}</div>`;
       break;
     case "functioncall":
-      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-blue-300 m-0">${JSON.stringify(
+      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-blue-300 m-0">${escapeHtml(JSON.stringify(
         { function: message.name, args: message.arguments },
         null,
         2,
-      )}</pre></div>`;
+      ))}</pre></div>`;
       break;
     case "functionresponse":
-      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-emerald-300 m-0">${JSON.stringify(
+      content = `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto border border-slate-700"><pre class="text-xs font-mono text-emerald-300 m-0">${escapeHtml(JSON.stringify(
         { function: message.name, args: message.response },
         null,
         2,
-      )}</pre></div>`;
+      ))}</pre></div>`;
       break;
   }
   return `

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -97,13 +97,23 @@ function renderConfiguration(config: Config): string {
 </ul>`;
 }
 
-interface CaseGroup {
+interface TestStep {
+  stepIndex: number;
+  originalIndex: number;
+  result: TestResult;
+}
+
+interface TestRun {
+  runIndex: number;
+  steps: TestStep[];
+  outcome: "pass" | "fail" | "error";
+  messages: Message[];
+  trajectory?: any[];
+}
+
+interface TestCase {
   name: string;
-  results: Array<{
-    runIndex: number;
-    originalIndex: number;
-    result: TestResult;
-  }>;
+  runs: TestRun[];
   passCount: number;
   failCount: number;
   errorCount: number;
@@ -111,7 +121,7 @@ interface CaseGroup {
 }
 
 function renderDetails(testResults: Array<TestResult>): string {
-  const groupsMap = new Map<string, CaseGroup>();
+  const groupsMap = new Map<string, TestCase>();
   let originalIndex = 1;
 
   for (const result of testResults) {
@@ -123,7 +133,7 @@ function renderDetails(testResults: Array<TestResult>): string {
     if (!groupsMap.has(caseName)) {
       groupsMap.set(caseName, {
         name: caseName,
-        results: [],
+        runs: [],
         passCount: 0,
         failCount: 0,
         errorCount: 0,
@@ -132,13 +142,31 @@ function renderDetails(testResults: Array<TestResult>): string {
     }
 
     const group = groupsMap.get(caseName)!;
-    const runIndex = group.results.length + 1;
+    const runIdx = result.runIndex || 1;
 
-    group.results.push({
-      runIndex,
+    let run = group.runs.find((r) => r.runIndex === runIdx);
+    if (!run) {
+      run = {
+        runIndex: runIdx,
+        steps: [],
+        outcome: "pass",
+        messages: result.test.messages,
+        trajectory: result.trajectory,
+      };
+      group.runs.push(run);
+    }
+
+    run.steps.push({
+      stepIndex: result.stepIndex || (run.steps.length + 1),
       originalIndex,
       result,
     });
+
+    if (result.outcome === "error") {
+      run.outcome = "error";
+    } else if (result.outcome === "fail" && run.outcome !== "error") {
+      run.outcome = "fail";
+    }
 
     group.totalCount++;
     if (result.outcome === "pass") {
@@ -156,12 +184,12 @@ function renderDetails(testResults: Array<TestResult>): string {
 
   return `
     <div class="space-y-6">
-      ${groups.map((group) => renderCaseGroup(group)).join("")}
+      ${groups.map((group) => renderTestCase(group)).join("")}
     </div>
   `;
 }
 
-function renderCaseGroup(group: CaseGroup): string {
+function renderTestCase(group: TestCase): string {
   const hasFailures = group.failCount > 0 || group.errorCount > 0;
   const isOpen = hasFailures ? "open" : "";
 
@@ -206,38 +234,21 @@ function renderCaseGroup(group: CaseGroup): string {
         </summary>
         
         <div class="p-5 border-t border-slate-100 bg-slate-50/50 space-y-5">
-          ${group.results.map(({ runIndex, originalIndex, result }) => renderRunIteration(runIndex, originalIndex, result)).join("")}
+          ${group.runs.map((run) => renderRunIteration(run)).join("")}
         </div>
       </details>
     </div>
   `;
 }
 
-function renderRunIteration(
-  runIndex: number,
-  originalIndex: number,
-  testResult: TestResult,
-): string {
-  const isPass = testResult.outcome === "pass";
+function renderRunIteration(run: TestRun): string {
+  const isPass = run.outcome === "pass";
   const isOpen = !isPass ? "open" : "";
 
-  const functionNameOutcome =
-    (testResult.test.expectedCall?.[0] as FunctionCall)?.functionName ===
-    testResult.response?.functionName
-      ? "pass"
-      : "fail";
-
-  const argsOutcome = matchesArgument(
-    (testResult.test.expectedCall?.[0] as FunctionCall)?.arguments,
-    testResult.response?.args,
-  )
-    ? "pass"
-    : "fail";
-
   const badgeClass =
-    testResult.outcome === "pass"
+    run.outcome === "pass"
       ? "bg-emerald-100 text-emerald-800 border-emerald-200"
-      : testResult.outcome === "fail"
+      : run.outcome === "fail"
         ? "bg-rose-100 text-rose-800 border-rose-200"
         : "bg-amber-100 text-amber-800 border-amber-200";
 
@@ -249,11 +260,10 @@ function renderRunIteration(
             <svg class="w-4 h-4 text-slate-400 group-open/run:rotate-90 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
             </svg>
-            <span class="font-semibold">Run #${runIndex}</span>
-            <span class="text-slate-400 text-xs">(Overall Test #${originalIndex})</span>
+            <span class="font-semibold">Run #${run.runIndex}</span>
           </div>
           <span class="px-2.5 py-0.5 rounded-full text-xs font-semibold border ${badgeClass}">
-            ${testResult.outcome.toUpperCase()}
+            ${run.outcome.toUpperCase()}
           </span>
         </summary>
         
@@ -266,64 +276,101 @@ function renderRunIteration(
               </svg>
             </summary>
             <div class="p-3 border-t border-slate-150 bg-slate-50/20">
-              ${renderMessages(testResult.test.messages)}
+              ${renderMessages(run.messages)}
             </div>
           </details>
 
-          <div class="bg-white rounded-lg border border-slate-200 overflow-hidden">
-            <h4 class="text-xs font-semibold text-slate-600 bg-slate-50/80 p-3 border-b border-slate-200">
-              <a href="#result-${originalIndex}" class="hover:text-blue-600 transition-colors">Evaluation Match Details</a>
-            </h4>
-            <div class="overflow-x-auto">
-              <table class="w-full text-left text-xs text-slate-600">
-                <thead class="bg-slate-50 text-slate-500 border-b border-slate-200 font-medium">
-                  <tr>
-                    <th class="px-4 py-2">Type</th>
-                    <th class="px-4 py-2">Expected Pattern</th>
-                    <th class="px-4 py-2">Actual Result</th>
-                    <th class="px-4 py-2 w-24">Status</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-slate-100">
-                  <tr class="hover:bg-slate-50/30">
-                    <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap">Function Name</td>
-                    <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${(testResult.test.expectedCall?.[0] as FunctionCall)?.functionName || null}</code></td>
-                    <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${testResult.response?.functionName || null}</code></td>
-                    <td class="px-4 py-3">
-                      <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs">
-                        ${functionNameOutcome.toUpperCase()}
-                      </span>
-                    </td>
-                  </tr>
-                  <tr class="hover:bg-slate-50/30">
-                    <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap align-top">Arguments</td>
-                    <td class="px-4 py-3">
-                      <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
-                        <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys((testResult.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2)}</pre>
-                      </div>
-                    </td>
-                    <td class="px-4 py-3">
-                      <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
-                        <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys(testResult.response?.args) || null, null, 2)}</pre>
-                      </div>
-                    </td>
-                    <td class="px-4 py-3 align-top">
-                      <span class="${argsOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs mt-2 inline-block">
-                        ${argsOutcome.toUpperCase()}
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+          <div class="space-y-4">
+            <h4 class="text-xs font-semibold text-slate-500 uppercase tracking-wider">Steps Evaluation</h4>
+            ${run.steps.map((step) => renderStepDetails(step)).join("")}
           </div>
 
-          ${renderTrajectory(testResult.trajectory)}
+          ${renderTrajectory(run.trajectory)}
         </div>
       </details>
     </div>
   `;
 }
+
+function renderStepDetails(stepEval: TestStep): string {
+  const { stepIndex, originalIndex, result } = stepEval;
+
+  const functionNameOutcome =
+    (result.test.expectedCall?.[0] as FunctionCall)?.functionName ===
+    result.response?.functionName
+      ? "pass"
+      : "fail";
+
+  const argsOutcome = matchesArgument(
+    (result.test.expectedCall?.[0] as FunctionCall)?.arguments,
+    result.response?.args,
+  )
+    ? "pass"
+    : "fail";
+
+  const statusColor =
+    result.outcome === "pass"
+      ? "text-emerald-700 bg-emerald-50 border-emerald-200"
+      : result.outcome === "fail"
+        ? "text-rose-700 bg-rose-50 border-rose-200"
+        : "text-amber-700 bg-amber-50 border-amber-200";
+
+  return `
+    <div class="bg-white rounded-lg border border-slate-200 overflow-hidden">
+      <div class="flex items-center justify-between bg-slate-50/80 p-3 border-b border-slate-200">
+        <h5 class="text-xs font-semibold text-slate-700">
+          Step #${stepIndex} <span class="text-slate-400 font-normal ml-1">(Overall Test #${originalIndex})</span>
+        </h5>
+        <span class="px-2 py-0.5 rounded text-[10px] font-semibold border ${statusColor}">
+          ${result.outcome.toUpperCase()}
+        </span>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="w-full text-left text-xs text-slate-600">
+          <thead class="bg-slate-50 text-slate-500 border-b border-slate-200 font-medium">
+            <tr>
+              <th class="px-4 py-2">Type</th>
+              <th class="px-4 py-2">Expected Pattern</th>
+              <th class="px-4 py-2">Actual Result</th>
+              <th class="px-4 py-2 w-24">Status</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-100">
+            <tr class="hover:bg-slate-50/30">
+              <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap">Function Name</td>
+              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${(result.test.expectedCall?.[0] as FunctionCall)?.functionName || null}</code></td>
+              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${result.response?.functionName || null}</code></td>
+              <td class="px-4 py-3">
+                <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs">
+                  ${functionNameOutcome.toUpperCase()}
+                </span>
+              </td>
+            </tr>
+            <tr class="hover:bg-slate-50/30">
+              <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap align-top">Arguments</td>
+              <td class="px-4 py-3">
+                <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
+                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys((result.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2)}</pre>
+                </div>
+              </td>
+              <td class="px-4 py-3">
+                <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
+                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${JSON.stringify(sortObjectKeys(result.response?.args) || null, null, 2)}</pre>
+                </div>
+              </td>
+              <td class="px-4 py-3 align-top">
+                <span class="${argsOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs mt-2 inline-block">
+                  ${argsOutcome.toUpperCase()}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `;
+}
+
 
 function renderTrajectory(trajectory?: any[]): string {
   if (!trajectory || trajectory.length === 0) return "";

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ToolCall } from "./tools.js";
+import { Tool, ToolCall } from "./tools.js";
 
 export type Message = ContentMessage | FunctionCallMessage | FunctionResponseMessage;
 
@@ -57,11 +57,19 @@ export type FunctionCall = {
   optional?: boolean;
 };
 
+export interface TrajectoryStep {
+  text?: string;
+  reasoningText?: string;
+  toolCalls?: any[];
+  toolResults?: any[];
+  availableTools?: Tool[];
+}
+
 export type TestResult = {
   test: Eval;
   response: ToolCall | null;
   outcome: "pass" | "fail" | "error";
-  trajectory?: any[];
+  trajectory?: TrajectoryStep[];
   runIndex?: number;
   stepIndex?: number;
 };

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -62,7 +62,10 @@ export type TestResult = {
   response: ToolCall | null;
   outcome: "pass" | "fail" | "error";
   trajectory?: any[];
+  runIndex?: number;
+  stepIndex?: number;
 };
+
 
 export type TestResults = {
   results: Array<TestResult>;

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -66,7 +66,6 @@ export type TestResult = {
   stepIndex?: number;
 };
 
-
 export type TestResults = {
   results: Array<TestResult>;
   testCount: number;


### PR DESCRIPTION
Fixes #61 

* Fix bug where Runs and Steps were confused
* Enhance report UI: clarify Steps vs Runs, display pass status for each, mention run # in report summary
* Display available tools at each step
* Renaming in the code: TestCase, TestRun, TestStep

See screenshots.

@Kulikowski Questions for you:
* I've tested with sports shop, what's another good multi-step demo to test this with?
* The summary displays a pass rate % and for now I've kept each test case summary and run summary to display a pass ratio (n/n). Are we happy with that?
* (One observation: AFAICS the step count can vary even for a specific run and test case, because it depends on what tools the LLM will decide to call. This wasn't intuitive to me at first and also means that the eval count isn't constant, because its step-based. Would it make sense to clarify that in the UI or think of alternatives?)
* Issue #61 mentions "all interactions that happened with browser". This PR surfaces available tools, what do we need to add? Thinking process at each step?


---

<img width="1702" height="930" alt="image" src="https://github.com/user-attachments/assets/087c8fa0-a956-42b9-a485-3b16c2ea5dde" />
<img width="1704" height="1442" alt="image" src="https://github.com/user-attachments/assets/72c60ee2-aa94-4899-a1d2-80ceb97254ae" />
<img width="1548" height="862" alt="image" src="https://github.com/user-attachments/assets/8005838b-5970-4702-87c1-51d962fe5b40" />
