### PR TITLE
Gemini and Ollama following Backend interface contract

### DIFF
--- a/evals-cli/src/backends/gemini.ts
+++ b/evals-cli/src/backends/gemini.ts
@@ -7,7 +7,7 @@ import { Content, FunctionDeclaration, GoogleGenAI } from "@google/genai";
 import { WebmcpConfig } from "../types/config.js";
 import { Eval, Message, TestResults } from "../types/evals.js";
 import { Tool, ToolCall } from "../types/tools.js";
-import { Backend, RunEvent } from "./index.js";
+import { Backend, LocalEvalResult, RunEvent } from "./index.js";
 
 export class GeminiBackend implements Backend {
   private googleGenAI: GoogleGenAI;
@@ -21,16 +21,8 @@ export class GeminiBackend implements Backend {
     this.googleGenAI = new GoogleGenAI({ apiKey });
   }
 
-  async executeLocalEvals(test: Eval): Promise<any> {
-    const toolCall = await this.execute(test.messages);
-    if (toolCall) {
-      return {
-        functionName: toolCall.functionName,
-        args: toolCall.args || {},
-      };
-    } else {
-      return { text: "No tool calls generated." };
-    }
+  async executeLocalEvals(test: Eval): Promise<LocalEvalResult> {
+    return this.execute(test.messages);
   }
 
   executeInBrowserEvals(
@@ -46,7 +38,7 @@ export class GeminiBackend implements Backend {
     return `Gemini Backend using model: ${this.model}`;
   }
 
-  async execute(messages: Message[]): Promise<ToolCall | null> {
+  async execute(messages: Message[]): Promise<LocalEvalResult> {
     const functionDeclarations: Array<FunctionDeclaration> = this.tools.map((t) => {
       return {
         name: t.functionName,
@@ -102,19 +94,23 @@ export class GeminiBackend implements Backend {
 
     const response = await this.googleGenAI.models.generateContent(request);
 
-    if (!response.functionCalls) {
-      return null;
-    }
-
-    const functionCalls: Array<ToolCall> = response.functionCalls
+    const toolCalls: Array<ToolCall> = (response.functionCalls || [])
       .filter((f) => f.name && f.args)
       .map((f) => {
         return {
-          args: f.args!,
+          args: f.args as Record<string, unknown>,
           functionName: f.name!,
         };
       });
 
-    return functionCalls[0];
+    const textParts = response.candidates?.[0]?.content?.parts
+      ?.map((p) => p.text)
+      .filter((t): t is string => Boolean(t))
+      .join("");
+
+    return {
+      toolCalls,
+      text: textParts || undefined,
+    };
   }
 }

--- a/evals-cli/src/backends/ollama.ts
+++ b/evals-cli/src/backends/ollama.ts
@@ -7,7 +7,7 @@ import { Ollama, Message as OllamaMessage, Tool as OllamaTool } from "ollama";
 import { WebmcpConfig } from "../types/config.js";
 import { Eval, Message, TestResults } from "../types/evals.js";
 import { Tool, ToolCall } from "../types/tools.js";
-import { Backend, RunEvent } from "./index.js";
+import { Backend, LocalEvalResult, RunEvent } from "./index.js";
 
 export class OllamaBackend implements Backend {
   private ollama: Ollama;
@@ -21,16 +21,8 @@ export class OllamaBackend implements Backend {
     this.ollama = new Ollama({ host });
   }
 
-  async executeLocalEvals(test: Eval): Promise<any> {
-    const toolCall = await this.execute(test.messages);
-    if (toolCall) {
-      return {
-        functionName: toolCall.functionName,
-        args: toolCall.args || {},
-      };
-    } else {
-      return { text: "No tool calls generated." };
-    }
+  async executeLocalEvals(test: Eval): Promise<LocalEvalResult> {
+    return this.execute(test.messages);
   }
 
   executeInBrowserEvals(
@@ -46,7 +38,7 @@ export class OllamaBackend implements Backend {
     return `Ollama Backend using model: ${this.model}`;
   }
 
-  async execute(messages: Message[]): Promise<ToolCall | null> {
+  async execute(messages: Message[]): Promise<LocalEvalResult> {
     let ollamaTools: Array<OllamaTool> = this.tools.map((t) => {
       return {
         function: {
@@ -105,17 +97,16 @@ export class OllamaBackend implements Backend {
       stream: false,
     });
 
-    if (!response.message.tool_calls) {
-      return null;
-    }
-
-    const toolCalls: Array<ToolCall> = response.message.tool_calls.map((t) => {
+    const toolCalls: Array<ToolCall> = (response.message.tool_calls || []).map((t) => {
       return {
-        args: t.function.arguments,
+        args: t.function.arguments as Record<string, unknown>,
         functionName: t.function.name,
       };
     });
 
-    return toolCalls[0];
+    return {
+      toolCalls,
+      text: response.message.content || undefined,
+    };
   }
 }

--- a/evals-cli/src/test/geminiBackend.test.ts
+++ b/evals-cli/src/test/geminiBackend.test.ts
@@ -61,6 +61,20 @@ describe("GeminiBackend", () => {
                 args: { query: "running shoes" },
               },
             ],
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        name: "search_product",
+                        args: { query: "running shoes" },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
           };
         },
       },
@@ -74,8 +88,13 @@ describe("GeminiBackend", () => {
 
     const result = await backend.executeLocalEvals(testEval);
     assert.deepStrictEqual(result, {
-      functionName: "search_product",
-      args: { query: "running shoes" },
+      toolCalls: [
+        {
+          functionName: "search_product",
+          args: { query: "running shoes" },
+        },
+      ],
+      text: undefined,
     });
   });
 
@@ -92,6 +111,13 @@ describe("GeminiBackend", () => {
         generateContent: async (_request: any) => {
           return {
             functionCalls: null,
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "No tool calls generated." }],
+                },
+              },
+            ],
           };
         },
       },
@@ -104,7 +130,7 @@ describe("GeminiBackend", () => {
     };
 
     const result = await backend.executeLocalEvals(testEval);
-    assert.deepStrictEqual(result, { text: "No tool calls generated." });
+    assert.deepStrictEqual(result, { toolCalls: [], text: "No tool calls generated." });
   });
 
   it("should map multi-turn messages correctly during API execution", async () => {
@@ -125,6 +151,20 @@ describe("GeminiBackend", () => {
               {
                 name: "search_product",
                 args: {},
+              },
+            ],
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      functionCall: {
+                        name: "search_product",
+                        args: {},
+                      },
+                    },
+                  ],
+                },
               },
             ],
           };

--- a/evals-cli/src/test/ollamaBackend.test.ts
+++ b/evals-cli/src/test/ollamaBackend.test.ts
@@ -82,8 +82,13 @@ describe("OllamaBackend", () => {
     assert.strictEqual(passedRequest.messages[0].role, "system");
     assert.strictEqual(passedRequest.messages[0].content, "System prompt");
     assert.deepStrictEqual(result, {
-      functionName: "search_product",
-      args: { query: "helmet" },
+      toolCalls: [
+        {
+          functionName: "search_product",
+          args: { query: "helmet" },
+        },
+      ],
+      text: undefined,
     });
   });
 
@@ -112,6 +117,6 @@ describe("OllamaBackend", () => {
     };
 
     const result = await backend.executeLocalEvals(testEval);
-    assert.deepStrictEqual(result, { text: "No tool calls generated." });
+    assert.deepStrictEqual(result, { toolCalls: [], text: "Hello" });
   });
 });


### PR DESCRIPTION
Update `GeminiBackend` and `OllamaBackend` to return `LocalEvalResult` (`{ toolCalls, text }`), matching the `Backend` interface contract. 
Also fixes a `@google/genai` SDK console warning when tool calls are present by extracting text directly from candidate parts instead of accessing `response.text`.