### PR TITLE
Adding evals for hotel chain

### DIFF
--- a/evals-cli/examples/hotel-chain/evals.json
+++ b/evals-cli/examples/hotel-chain/evals.json
@@ -1,0 +1,79 @@
+[
+  {
+    "name": "Hotel Chain: Search Tokyo and filter amenities",
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I am looking for a hotel in Tokyo - filter for gym and breakfast"
+      }
+    ],
+    "expectedCall": [
+      {
+        "functionName": "search_location",
+        "arguments": {
+          "query": "Tokyo"
+        }
+      },
+      {
+        "functionName": "filter_search_results",
+        "arguments": {
+          "amenities": ["gym", "breakfast"]
+        }
+      },
+      {
+        "functionName": "get_current_search_results",
+        "arguments": {},
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "Hotel Chain: Search Cleveland and filter price & parking",
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "I am looking for a hotel in Cleveland, max price $200, and must have free parking"
+      }
+    ],
+    "expectedCall": [
+      {
+        "functionName": "search_location",
+        "arguments": {
+          "query": "Cleveland"
+        }
+      },
+      {
+        "functionName": "filter_search_results",
+        "arguments": {
+          "max_price": 200,
+          "amenities": ["free parking"]
+        }
+      },
+      {
+        "functionName": "get_current_search_results",
+        "arguments": {},
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "Hotel Chain: View hotel details directly",
+    "messages": [
+      {
+        "role": "user",
+        "type": "message",
+        "content": "View the details for hotel 'The Aurelian Shibuya'"
+      }
+    ],
+    "expectedCall": [
+      {
+        "functionName": "view_hotel",
+        "arguments": {
+          "hotel_name_or_id": "The Aurelian Shibuya"
+        }
+      }
+    ]
+  }
+]

--- a/evals-cli/run_evals.sh
+++ b/evals-cli/run_evals.sh
@@ -5,15 +5,80 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-MODEL="gemini-3.5-flash"
+# Always install and build dependencies once at the start of the execution
+echo "📦 Installing dependencies and building project..."
+npm ci
+npm run build
+echo
+
+MODEL="google:gemini-3.1-flash-lite"
 
 TARGET="${1}"
+RUNS="${2:-1}"
+
+ALL_TARGETS=("doors" "bistro" "pizza" "sport-shop" "hotel-chain")
 
 if [ -z "$TARGET" ]; then
   echo "Error: Missing target parameter."
-  echo "Usage: $0 <doors|bistro|pizza|sport-shop>"
+  echo "Usage: $0 <doors|bistro|pizza|sport-shop|hotel-chain|all> [runs_count]"
   exit 1
 fi
+
+run_single_eval() {
+  local t="${1}"
+  case "$t" in
+    "doors")
+      # 1. Doors Demo
+      echo "🚪 Running Doors Evaluation..."
+      node dist/bin/webmcp-evals.js browser \
+        -m "$MODEL" \
+        -u https://googlechromelabs.github.io/webmcp-tools/demos/doors \
+        -e examples/doors/evals.json \
+        -r "$RUNS"
+      ;;
+    "bistro")
+      # 2. French Bistro Demo
+      echo "🇫🇷 Running French Bistro Evaluation..."
+      node dist/bin/webmcp-evals.js browser \
+        -m "$MODEL" \
+        -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/ \
+        -e examples/french-bistro/evals.json \
+        -r "$RUNS"
+      ;;
+    "pizza")
+      # 3. Pizza Maker Demo
+      echo "🍕 Running Pizza Maker Evaluation..."
+      node dist/bin/webmcp-evals.js browser \
+        -m "$MODEL" \
+        -u https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/ \
+        -e examples/pizza-maker/evals.json \
+        -r "$RUNS"
+      ;;
+    "sport-shop")
+      # 4. Sport Shop Angular Demo
+      echo "🛍️ Running Sport Shop Angular Evaluation..."
+      node dist/bin/webmcp-evals.js browser \
+        -m "$MODEL" \
+        -u https://googlechromelabs.github.io/webmcp-tools/demos/sport-shop-angular/ \
+        -e examples/sport-shop-angular/evals.json \
+        -r "$RUNS"
+      ;;
+    "hotel-chain")
+      # 5. Hotel Chain Demo
+      echo "🏨 Running Hotel Chain Evaluation..."
+      node dist/bin/webmcp-evals.js browser \
+        -m "$MODEL" \
+        -u https://googlechromelabs.github.io/webmcp-tools/demos/hotel-chain/ \
+        -e examples/hotel-chain/evals.json \
+        -r "$RUNS"
+      ;;
+    *)
+      echo "Error: Invalid target '$t'."
+      echo "Supported targets: doors, bistro, pizza, sport-shop, hotel-chain, all"
+      exit 1
+      ;;
+  esac
+}
 
 echo "=============================================================="
 echo "🚀 Running WebMCP Evaluation for: $TARGET"
@@ -21,45 +86,18 @@ echo "🤖 Model: $MODEL"
 echo "=============================================================="
 echo
 
-case "$TARGET" in
-  "doors")
-    # 1. Doors Demo
-    echo "🚪 Running Doors Evaluation..."
-    node dist/bin/webmcp-evals.js browser \
-      -m "$MODEL" \
-      -u https://googlechromelabs.github.io/webmcp-tools/demos/doors \
-      -e examples/doors/evals.json
-    ;;
-  "bistro")
-    # 2. French Bistro Demo
-    echo "🇫🇷 Running French Bistro Evaluation..."
-    node dist/bin/webmcp-evals.js browser \
-      -m "$MODEL" \
-      -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/ \
-      -e examples/french-bistro/evals.json
-    ;;
-  "pizza")
-    # 3. Pizza Maker Demo
-    echo "🍕 Running Pizza Maker Evaluation..."
-    node dist/bin/webmcp-evals.js browser \
-      -m "$MODEL" \
-      -u https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/ \
-      -e examples/pizza-maker/evals.json
-    ;;
-  "sport-shop")
-    # 4. Sport Shop Angular Demo
-    echo "🛍️ Running Sport Shop Angular Evaluation..."
-    node dist/bin/webmcp-evals.js browser \
-      -m "$MODEL" \
-      -u https://googlechromelabs.github.io/webmcp-tools/demos/sport-shop-angular/ \
-      -e examples/sport-shop-angular/evals.json
-    ;;
-  *)
-    echo "Error: Invalid target '$TARGET'."
-    echo "Supported targets: doors, bistro, pizza, sport-shop"
-    exit 1
-    ;;
-esac
+if [ "$TARGET" = "all" ]; then
+  echo "Running all evaluations..."
+  for t in "${ALL_TARGETS[@]}"; do
+    echo "--------------------------------------------------------------"
+    echo "Executing target: $t"
+    echo "--------------------------------------------------------------"
+    run_single_eval "$t"
+  done
+  echo "All evaluations finished!"
+else
+  run_single_eval "$TARGET"
+fi
 
 echo "--------------------------------------------------------------"
 echo "✅ WebMCP evaluation for '$TARGET' completed successfully!"


### PR DESCRIPTION
Adding evals for hotel chain - commonly demoed user journeys.

Updated run_evals.sh script:

- It builds the evals-cli every time in case developer made any changes
- New target: `all` to run all the evals
- You can pass a number of desired runs for easier usage

<img width="543" height="469" alt="image" src="https://github.com/user-attachments/assets/1968feaa-1484-416c-b744-db76fbd1fdf7" />
