### PR TITLE
Add skill lock configuration for evals-cli

### DIFF
--- a/evals-cli/.gitignore
+++ b/evals-cli/.gitignore
@@ -3,3 +3,4 @@ dist/
 .DS_Store
 .env
 report*.html
+.agents/skills/*

--- a/evals-cli/skills-lock.json
+++ b/evals-cli/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "ai-sdk": {
+      "source": "vercel/ai",
+      "sourceType": "github",
+      "skillPath": "skills/use-ai-sdk/SKILL.md",
+      "computedHash": "da25c27a274ef2b71017c255f95a26350d2519765a75cb54ee1a37872b121dab"
+    }
+  }
+}


### PR DESCRIPTION
Add skill lock configuration for evals-cli, and vercel skill as per https://ai-sdk.dev/.
Are we happy with this living under evals-cli considering the evals tooling needs specific dependencies not needed in other directories, or do we think managing skills globally for webmcp-tools makes more sense?

Side note: while installing this skill I saw Vercel made a skill dedicated to help us migrate the AI SDK to the next version, could come in handy