### PR TITLE
Handle manual form submissions in evals-cli

### DIFF
--- a/evals-cli/examples/french-bistro/evals-toolautosubmit.json
+++ b/evals-cli/examples/french-bistro/evals-toolautosubmit.json
@@ -28,7 +28,9 @@
             "$contains": "anniversary"
           }
         },
-        "result": "pending form submission"
+        "result": {
+          "$contains": "welcoming you"
+        }
       }
     ]
   },
@@ -54,7 +56,9 @@
           "guests": "6",
           "seating": "Private Booth"
         },
-        "result": "pending form submission"
+        "result": {
+          "$contains": "welcoming you"
+        }
       }
     ]
   }

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -87,9 +87,16 @@ export class VercelBackend implements Backend {
     for (const step of aiResult.steps ?? []) {
       for (const call of (step.toolCalls ?? []) as any[]) {
         if (validToolNames.has(call.toolName)) {
+          const matchingResult: any = (step.toolResults ?? []).find(
+            (r: any) => r.toolCallId === call.toolCallId || r.toolName === call.toolName,
+          );
+          const result = matchingResult
+            ? (matchingResult.result ?? matchingResult.output)
+            : undefined;
           toolCalls.push({
             functionName: call.toolName,
             args: call.input || call.args || call.arguments || {},
+            result,
           });
         }
       }
@@ -185,13 +192,22 @@ export class VercelBackend implements Backend {
 
       // Gather executed tool calls across all steps
       const executedCalls: ToolCall[] = [];
-      if (resultPayload.steps && resultPayload.steps.length > 0) {
-        for (const step of resultPayload.steps) {
+      const stepsToIterate =
+        resultPayload.steps && resultPayload.steps.length > 0 ? resultPayload.steps : stepsHistory;
+      if (stepsToIterate && stepsToIterate.length > 0) {
+        for (const step of stepsToIterate) {
           if (step.toolCalls && step.toolCalls.length > 0) {
             for (const call of step.toolCalls) {
+              const matchingResult: any = (step.toolResults ?? []).find(
+                (r: any) => r.toolCallId === call.toolCallId || r.toolName === call.toolName,
+              );
+              const result = matchingResult
+                ? (matchingResult.result ?? matchingResult.output)
+                : undefined;
               executedCalls.push({
                 functionName: call.toolName,
                 args: (call as any).input || (call as any).args || (call as any).arguments || {},
+                result,
               });
             }
           }

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -87,9 +87,14 @@ export class VercelBackend implements Backend {
     for (const step of aiResult.steps ?? []) {
       for (const call of (step.toolCalls ?? []) as any[]) {
         if (validToolNames.has(call.toolName)) {
-          const matchingResult: any = (step.toolResults ?? []).find(
-            (r: any) => r.toolCallId === call.toolCallId || r.toolName === call.toolName,
+          const matchingResult: any = (step.toolResults ?? []).find((r: any) =>
+            call.toolCallId ? r.toolCallId === call.toolCallId : r.toolName === call.toolName,
           );
+          if (!matchingResult && call.toolCallId) {
+            this.logger.debug(
+              `[DEBUG] Could not find matching tool result for call ID "${call.toolCallId}" (${call.toolName})`,
+            );
+          }
           const result = matchingResult
             ? (matchingResult.result ?? matchingResult.output)
             : undefined;
@@ -198,9 +203,14 @@ export class VercelBackend implements Backend {
         for (const step of stepsToIterate) {
           if (step.toolCalls && step.toolCalls.length > 0) {
             for (const call of step.toolCalls) {
-              const matchingResult: any = (step.toolResults ?? []).find(
-                (r: any) => r.toolCallId === call.toolCallId || r.toolName === call.toolName,
+              const matchingResult: any = (step.toolResults ?? []).find((r: any) =>
+                call.toolCallId ? r.toolCallId === call.toolCallId : r.toolName === call.toolName,
               );
+              if (!matchingResult && call.toolCallId) {
+                this.logger.debug(
+                  `[DEBUG] Could not find matching tool result for call ID "${call.toolCallId}" (${call.toolName})`,
+                );
+              }
               const result = matchingResult
                 ? (matchingResult.result ?? matchingResult.output)
                 : undefined;

--- a/evals-cli/src/commands/index.ts
+++ b/evals-cli/src/commands/index.ts
@@ -208,11 +208,44 @@ export async function runWebCommand(options: CommandOptions, command?: Command):
   }
 }
 
+import { matchesArgument } from "../matcher.js";
+
+function getFailureDetail(res: any): string {
+  if (res.outcome === "pass") return "-";
+  if (!res.response) return "No tool called";
+
+  const expected = res.test.expectedCall?.[0] as FunctionCall | undefined;
+  if (!expected) return "Unexpected tool call";
+
+  if (expected.functionName !== res.response.functionName) {
+    return `Function mismatch (expected "${expected.functionName}", got "${res.response.functionName}")`;
+  }
+
+  if (expected.arguments != null && !matchesArgument(expected.arguments, res.response.args)) {
+    return "Arguments mismatch";
+  }
+
+  if (expected.result !== undefined && !matchesArgument(expected.result, res.response.result)) {
+    const expStr =
+      typeof expected.result === "object"
+        ? JSON.stringify(expected.result)
+        : String(expected.result);
+    const actStr =
+      typeof res.response.result === "object"
+        ? JSON.stringify(res.response.result)
+        : String(res.response.result ?? null);
+    const truncatedAct = actStr.length > 40 ? actStr.slice(0, 37) + "..." : actStr;
+    return `Result mismatch: expected "${expStr}", got "${truncatedAct}"`;
+  }
+
+  return res.outcome === "error" ? "Execution error" : "Failed";
+}
+
 function printConsoleSummary(finalResults: any): void {
   console.log("\n" + chalk.bold.underline("Evaluation Summary") + "\n");
 
   const table = new Table({
-    head: ["Step", "Status", "Expected Function", "Actual Function"],
+    head: ["Step", "Status", "Expected Function", "Actual Function", "Details"],
     style: {
       head: ["cyan"],
       border: ["grey"],
@@ -227,6 +260,7 @@ function printConsoleSummary(finalResults: any): void {
       passed ? chalk.green("PASS") : chalk.red(res.outcome.toUpperCase()),
       (res.test.expectedCall?.[0] as FunctionCall)?.functionName || "-",
       res.response?.functionName || "-",
+      getFailureDetail(res),
     ]);
   }
 

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -73,12 +73,36 @@ export class BrowserToolRegistry implements ToolRegistry {
               const tools = await mc.getTools();
               const tool = tools.find((item) => item.name === name);
               if (tool) {
-                const resStr = await mc.executeTool(tool, JSON.stringify(callArgs || {}));
-                try {
-                  return { success: true, data: JSON.parse(resStr as string) };
-                } catch {
-                  return { success: true, data: resStr };
-                }
+                return new Promise((resolve) => {
+                  let timer: any = null;
+
+                  const onActivated = (e: any) => {
+                    if (!e.toolName || e.toolName === name) {
+                      timer = setTimeout(() => {
+                        window.removeEventListener("toolactivated", onActivated);
+                        resolve({ success: true, data: "pending form submission" });
+                      }, 1000);
+                    }
+                  };
+
+                  window.addEventListener("toolactivated", onActivated);
+
+                  mc.executeTool(tool, JSON.stringify(callArgs || {}))
+                    .then((resStr: any) => {
+                      if (timer) clearTimeout(timer);
+                      window.removeEventListener("toolactivated", onActivated);
+                      try {
+                        resolve({ success: true, data: JSON.parse(resStr as string) });
+                      } catch {
+                        resolve({ success: true, data: resStr });
+                      }
+                    })
+                    .catch((err: any) => {
+                      if (timer) clearTimeout(timer);
+                      window.removeEventListener("toolactivated", onActivated);
+                      resolve({ success: false, error: err?.message || String(err) });
+                    });
+                });
               }
             }
           }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -46,52 +46,6 @@ export async function launchBrowser(): Promise<Browser> {
   });
 }
 
-/**
- * Launches Chrome Canary, navigates to the given URL, and retrieves the list
- * of tools exposed by the page via Puppeteer.
- *
- * Requires Chrome Canary 150+ with the `chrome://flags/#enable-webmcp-testing`
- * flag enabled. The browser is always closed after the tools are retrieved,
- * even if an error occurs.
- */
-export async function listToolsFromPage(url: string): Promise<Tool[]> {
-  const executablePath = await findChromePath();
-  let browser: Browser | null = null;
-
-  try {
-    console.log(`Launching Chrome Canary from: ${executablePath}`);
-    browser = await launchBrowser();
-
-    const page = await browser.newPage();
-
-    console.log(`Navigating to: ${url}`);
-    const response = await page.goto(url, {
-      waitUntil: "networkidle2",
-      timeout: 30000,
-    });
-
-    if (!response || !response.ok()) {
-      throw new Error(
-        `Failed to navigate to ${url}. HTTP status: ${response?.status() ?? "unknown"}`,
-      );
-    }
-
-    const rawTools = await getToolsFromBrowserPage(page);
-    if (rawTools.length === 0) {
-      throw new Error(
-        `WebMCP Tools are not available on ${url} (0 tools registered on page).\nDebug info: [URL="${url}", Executable="${executablePath}", Flags="${PUPPETEER_FLAGS.join(" ")}"]`,
-      );
-    }
-
-    console.log(`Found ${rawTools.length} tool(s) via Puppeteer/Native API.`);
-    return mapRawBrowserToolsToConfig(rawTools, []);
-  } finally {
-    if (browser) {
-      await browser.close();
-    }
-  }
-}
-
 export class BrowserToolRegistry implements ToolRegistry {
   private currentTools: Tool[] = [];
 

--- a/evals-cli/src/evaluator/index.ts
+++ b/evals-cli/src/evaluator/index.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { listToolsFromPage } from "./browser.js";
 import { executeInBrowserEvals } from "./browserEvaluator.js";
 import { executeLocalEvals } from "./localEvaluator.js";
 
-export { executeInBrowserEvals, executeLocalEvals, listToolsFromPage };
+export { executeInBrowserEvals, executeLocalEvals };

--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -348,18 +348,24 @@ function renderRunIteration(run: TestRun, totalRuns: number): string {
 
 function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
   const { stepIndex, result } = stepEval;
+  const expected = result.test.expectedCall?.[0] as FunctionCall | undefined;
 
   const functionNameOutcome =
-    (result.test.expectedCall?.[0] as FunctionCall)?.functionName === result.response?.functionName
+    expected?.functionName === result.response?.functionName ? "pass" : "fail";
+
+  const argsOutcome =
+    expected?.arguments == null || matchesArgument(expected?.arguments, result.response?.args)
       ? "pass"
       : "fail";
 
-  const argsOutcome = matchesArgument(
-    (result.test.expectedCall?.[0] as FunctionCall)?.arguments,
-    result.response?.args,
-  )
-    ? "pass"
-    : "fail";
+  const hasExpectedResult = expected?.result !== undefined;
+  const hasActualResult = result.response?.result !== undefined;
+  const hasResultRow = hasExpectedResult || hasActualResult;
+
+  const resultOutcome =
+    expected?.result === undefined || matchesArgument(expected?.result, result.response?.result)
+      ? "pass"
+      : "fail";
 
   const statusColor =
     result.outcome === "pass"
@@ -391,7 +397,7 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
           <tbody class="divide-y divide-slate-100">
             <tr class="hover:bg-slate-50/30">
               <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap">Function Name</td>
-              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml((result.test.expectedCall?.[0] as FunctionCall)?.functionName || null)}</code></td>
+              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml(expected?.functionName || null)}</code></td>
               <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml(result.response?.functionName || null)}</code></td>
               <td class="px-4 py-3">
                 <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs">
@@ -403,7 +409,7 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
               <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap align-top">Arguments</td>
               <td class="px-4 py-3">
                 <div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
-                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${escapeHtml(JSON.stringify(sortObjectKeys((result.test.expectedCall?.[0] as FunctionCall)?.arguments) || null, null, 2))}</pre>
+                  <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${escapeHtml(JSON.stringify(sortObjectKeys(expected?.arguments) || null, null, 2))}</pre>
                 </div>
               </td>
               <td class="px-4 py-3">
@@ -417,6 +423,45 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
                 </span>
               </td>
             </tr>
+            ${
+              hasResultRow
+                ? `
+            <tr class="hover:bg-slate-50/30">
+              <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap align-top">Result</td>
+              <td class="px-4 py-3">
+                ${
+                  hasExpectedResult
+                    ? `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
+                        <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${escapeHtml(
+                          typeof expected?.result === "object"
+                            ? JSON.stringify(sortObjectKeys(expected.result), null, 2)
+                            : String(expected?.result ?? null),
+                        )}</pre>
+                      </div>`
+                    : `<span class="text-xs text-slate-400 italic">Unconstrained</span>`
+                }
+              </td>
+              <td class="px-4 py-3">
+                ${
+                  hasActualResult
+                    ? `<div class="bg-slate-800 rounded-md p-3 overflow-x-auto max-w-md">
+                        <pre class="text-xs text-slate-200 font-mono m-0 leading-relaxed">${escapeHtml(
+                          typeof result.response?.result === "object"
+                            ? JSON.stringify(sortObjectKeys(result.response.result), null, 2)
+                            : String(result.response?.result ?? null),
+                        )}</pre>
+                      </div>`
+                    : `<span class="text-xs text-slate-400 italic">None</span>`
+                }
+              </td>
+              <td class="px-4 py-3 align-top">
+                <span class="${resultOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs mt-2 inline-block">
+                  ${resultOutcome.toUpperCase()}
+                </span>
+              </td>
+            </tr>`
+                : ""
+            }
           </tbody>
         </table>
       </div>

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -78,6 +78,16 @@ describe("BrowserToolRegistry", () => {
     assert.deepStrictEqual(page.evaluateCalls[0].args[1], { id: "btn-1" });
   });
 
+  it("should return 'pending form submission' when tool result data is 'pending form submission'", async () => {
+    const page = new MockBrowserPage();
+    page.evaluateResult = { success: true, data: "pending form submission" };
+
+    const registry = new BrowserToolRegistry(page);
+    const result = await registry.executeTool("book_table", { guests: 2 });
+
+    assert.strictEqual(result, "pending form submission");
+  });
+
   it("should return error if page execution reports success: false", async () => {
     const page = new MockBrowserPage();
     page.evaluateResult = { success: false };

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -97,4 +97,51 @@ describe("BrowserToolRegistry", () => {
 
     assert.deepStrictEqual(result, { error: 'no tool named "click_button" was found' });
   });
+
+  it("should execute page script, handle toolactivated, and resolve pending form submission on timeout", async () => {
+    const page = new MockBrowserPage();
+    page.evaluate = async (fn: any, ...args: any[]) => {
+      const listeners: Record<string, Function[]> = {};
+      const fakeWindow = {
+        addEventListener: (event: string, cb: Function) => {
+          listeners[event] = listeners[event] || [];
+          listeners[event].push(cb);
+        },
+        removeEventListener: (event: string, cb: Function) => {
+          if (listeners[event]) {
+            listeners[event] = listeners[event].filter((l) => l !== cb);
+          }
+        },
+      };
+      const fakeDocument = {
+        modelContext: {
+          getTools: async () => [{ name: "book_table" }],
+          executeTool: async () => {
+            // Trigger toolactivated event
+            const activatedCb = listeners["toolactivated"]?.[0];
+            if (activatedCb) {
+              activatedCb({ toolName: "book_table" });
+            }
+            // Return a promise that never resolves (simulating manual form submit wait)
+            return new Promise(() => {});
+          },
+        },
+      };
+
+      // Execute in fake environment with 10ms timeout for test speed
+      const fnStr = fn.toString();
+      const testFn = new Function(
+        "window",
+        "document",
+        "name",
+        "callArgs",
+        `return (${fnStr.replace("1000", "10")})(name, callArgs);`,
+      );
+      return testFn(fakeWindow, fakeDocument, args[0], args[1]);
+    };
+
+    const registry = new BrowserToolRegistry(page);
+    const result = await registry.executeTool("book_table", { guests: 2 });
+    assert.strictEqual(result, "pending form submission");
+  });
 });

--- a/evals-cli/src/test/utils.test.ts
+++ b/evals-cli/src/test/utils.test.ts
@@ -624,6 +624,33 @@ describe("functionCallOutcome", () => {
       "pass",
     );
   });
+
+  it("passes when expected.result matches actual.result", () => {
+    assert.strictEqual(
+      functionCallOutcome(
+        { functionName: "foo", result: "pending form submission" },
+        { functionName: "foo", args: {}, result: "pending form submission" },
+      ),
+      "pass",
+    );
+    assert.strictEqual(
+      functionCallOutcome(
+        { functionName: "foo", result: { $contains: "confirmed" } },
+        { functionName: "foo", args: {}, result: "Reservation confirmed for 2 people" },
+      ),
+      "pass",
+    );
+  });
+
+  it("fails when expected.result does not match actual.result", () => {
+    assert.strictEqual(
+      functionCallOutcome(
+        { functionName: "foo", result: "pending form submission" },
+        { functionName: "foo", args: {}, result: "Reservation confirmed" },
+      ),
+      "fail",
+    );
+  });
 });
 
 describe("countExpectedCalls with optional", () => {

--- a/evals-cli/src/test/vercel.test.ts
+++ b/evals-cli/src/test/vercel.test.ts
@@ -177,5 +177,64 @@ describe("VercelBackend", () => {
       assert.strictEqual(capturedPayload.messages[3].role, "user");
       assert.strictEqual(capturedPayload.messages[3].content, "Remove it.");
     });
+
+    it("should match tool result strictly by toolCallId when the same tool is called multiple times", async (t) => {
+      const dummyPage: any = {
+        evaluate: async (fn: any) => {
+          if (fn.toString().includes("getTools")) {
+            return [
+              {
+                name: "load_next_results",
+                description: "Loads results",
+                inputSchema: { type: "object" },
+              },
+            ];
+          }
+          return {};
+        },
+      };
+
+      t.mock.method(ai.ToolLoopAgent.prototype, "generate", async () => {
+        return {
+          steps: [
+            {
+              toolCalls: [
+                { toolName: "load_next_results", toolCallId: "call-1", input: { page: 1 } },
+                { toolName: "load_next_results", toolCallId: "call-2", input: { page: 2 } },
+              ],
+              toolResults: [
+                { toolName: "load_next_results", toolCallId: "call-1", result: "Page 1 items" },
+                { toolName: "load_next_results", toolCallId: "call-2", result: "Page 2 items" },
+              ],
+            },
+          ],
+          text: "Done loading",
+        };
+      });
+
+      const backend = new VercelBackend({
+        model: "gemini-3-flash-preview",
+        url: "http://localhost:3000",
+      } as any);
+
+      const evalTest: Eval = {
+        name: "Duplicate tool call test case",
+        messages: [{ role: "user", type: "message", content: "Load pages 1 and 2" }],
+        expectedCall: [],
+      };
+
+      const result = await backend.executeInBrowserEval(evalTest, dummyPage, {
+        url: "http://localhost:3000",
+      } as any);
+
+      assert.strictEqual(result.toolCalls.length, 2);
+      assert.strictEqual(result.toolCalls[0].functionName, "load_next_results");
+      assert.deepStrictEqual(result.toolCalls[0].args, { page: 1 });
+      assert.strictEqual(result.toolCalls[0].result, "Page 1 items");
+
+      assert.strictEqual(result.toolCalls[1].functionName, "load_next_results");
+      assert.deepStrictEqual(result.toolCalls[1].args, { page: 2 });
+      assert.strictEqual(result.toolCalls[1].result, "Page 2 items");
+    });
   });
 });

--- a/evals-cli/src/types/evals.ts
+++ b/evals-cli/src/types/evals.ts
@@ -43,6 +43,9 @@ export type FunctionCall = {
   // Optional: when omitted (or explicitly null), the eval imposes no
   // constraint on the tool call's arguments — any actual args are accepted.
   arguments?: object | null;
+  // Optional: when specified, checks whether the actual tool execution result
+  // matches this expected value or constraint.
+  result?: unknown;
   // Optional: mock output returned to the model when it invokes this tool
   // during a local (non-browser) multi-step trajectory. When omitted, an
   // empty object `{}` is returned. Only consulted by `executeLocalEvals` —

--- a/evals-cli/src/types/tools.ts
+++ b/evals-cli/src/types/tools.ts
@@ -6,6 +6,7 @@
 export type ToolCall = {
   args: object;
   functionName: string;
+  result?: unknown;
 };
 
 export type Tool = {

--- a/evals-cli/src/utils.ts
+++ b/evals-cli/src/utils.ts
@@ -49,9 +49,16 @@ export function functionCallOutcome(
   // An eval that omits `arguments` (or sets it to null) imposes no constraint
   // on the tool call's arguments. Treat any actual args — including the empty
   // object `{}` that most SDKs emit for no-arg tool calls — as a match.
-  if (expected.arguments == null) return "pass";
+  if (expected.arguments != null) {
+    if (!matchesArgument(expected.arguments, actual.args)) return "fail";
+  }
 
-  return matchesArgument(expected.arguments, actual.args) ? "pass" : "fail";
+  // An eval that specifies `result` imposes a constraint on the tool execution result.
+  if (expected.result !== undefined) {
+    if (!matchesArgument(expected.result, actual.result)) return "fail";
+  }
+
+  return "pass";
 }
 
 export interface TrajectoryResult {


### PR DESCRIPTION
## Summary

Fixes #66

When WebMCP forms do not use the `toolautosubmit` attribute, the browser activates the form and fires a `toolactivated` DOM event rather than automatically submitting. In a headless `evals-cli` session, this previously caused the browser evaluation to hang indefinitely.

This PR addresses the issue by handling `toolactivated` events gracefully, adding tool execution result verification to evals, and reflecting result comparisons in both the console and HTML reports.

## Changes

1. **Graceful `toolactivated` Handling in `BrowserToolRegistry`**:
   - Listens for the `toolactivated` DOM event when executing browser tools.
   - If no auto-submission occurs within a 1-second timeout after `toolactivated` fires, resolves the tool execution with `"pending form submission"`.
   - Cleans up unused `listToolsFromPage` function.

2. **Tool Execution Result Matching (`result` in `expectedCall`)**:
   - Added an optional `result?: unknown;` field to `FunctionCall` and `ToolCall` types.
   - Updated `VercelBackend` to capture the tool execution return value on each executed `ToolCall`.
   - Updated `functionCallOutcome` in `utils.ts` to evaluate `expected.result` against `actual.result` using `matchesArgument` (supports exact match, objects, regex `$pattern`, `$contains`, etc.).

3. **Report and Console Enhancements**:
   - Added a "Result" comparison row to the HTML report's Step Details table.
   - Added a "Details" column to the console summary table to clearly display failure reasons (such as result mismatches).

4. **Example Evals for French Bistro Demo**:
   - Updated `evals.json` to assert `"result": "pending form submission"` when testing manual form submission behavior.
   - Added `evals-toolautosubmit.json` to assert `"result": { "$contains": "welcoming you" }` when testing auto-submission behavior.

## Examples

Expecting manual form submission:

<img width="969" height="492" alt="manual-submission-success" src="https://github.com/user-attachments/assets/e3ab42a9-387b-4189-ba4a-931561570ba2" />

Expected auto form submission:

<img width="970" height="531" alt="toolautosubmit-success" src="https://github.com/user-attachments/assets/438282e4-42e8-4677-99be-991efe4cfc6f" />

Expecting manual form submission on a form with `toolautosubmit` results in an error:

<img width="968" height="687" alt="expected-manual-submission-but-got-autosubmit" src="https://github.com/user-attachments/assets/cb6b361b-cc87-40b5-b7f1-a96fb7988bb9" />

Expecting auto form submission ohn a form without `toolautosubmit` results in an error:

<img width="972" height="665" alt="Screenshot 2026-07-20 at 15 36 24" src="https://github.com/user-attachments/assets/7bf9946a-8e60-4f10-8b0b-4bb29ce24f92" />

