### PR TITLE
Add QR Code Crafter to Awesome WebMCP

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -67,6 +67,8 @@ A curated list of awesome WebMCP demos, libraries, and tools.
   - **Example Prompt:** "Load dataset https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/lfsi_emp_a?lang=en&lastTimePeriod=3&indic_em=ACT&age=Y15-64&unit=THS_PER and select the data for Germany and Ireland and the last period available. Display a cross-tabulation with sex as rows and countries as columns and download a CSV file with this info."
 - [Stacktree](https://stacktr.ee/) - Private hosting for the HTML that AI agents generate. Registers `stacktree_publish_html` via `document.modelContext`, so a browser agent can hand over a complete HTML document and get back a live, shareable URL with no account or sign-in. Anonymous sites are unlisted and the response includes a claim URL to keep the page permanently in a free account.
   - **Example Prompt:** "Build a simple one-page site for a coffee shop called Crema and publish it so I can share the link."
+- [QR Code Crafter](https://qrcodecrafter.com/?webmcp=on) - A QR-code generator exposing declarative generator forms and supplemental runtime tools so agents can create static QR codes locally in the browser without an account.
+  - **Example Prompt:** "Create an SVG QR code for https://example.com."
 
 ## Libraries & Tools
 


### PR DESCRIPTION
## Summary

- add QR Code Crafter to the curated WebMCP demos list
- link the explicit WebMCP origin-trial path
- include a nonsensitive static SVG example prompt

## Verification

- production URL returns HTTP 200 over HTTPS
- strict live verification passed for the declarative tool, visible forms, WebAPI schema, `Permissions-Policy: tools=(self)`, origin isolation, and the WebMCP Origin-Trial header
- static QR generation runs locally in the browser and does not require an account

Disclosure: I maintain QR Code Crafter through Brand Aspect Ltd.