### PR TITLE
Evals CLI: Leverage Puppeteer WebMCP API

### DIFF
--- a/evals-cli/src/backends/index.ts
+++ b/evals-cli/src/backends/index.ts
@@ -11,6 +11,7 @@ import { ToolRegistry } from "../evaluator/toolRegistry.js";
 export interface BrowserPage {
   evaluate(fn: string | Function, ...args: any[]): Promise<any>;
   waitForNavigation(options?: any): Promise<any>;
+  webmcp?: any;
 }
 
 /**

--- a/evals-cli/src/backends/index.ts
+++ b/evals-cli/src/backends/index.ts
@@ -12,7 +12,7 @@ import { ToolRegistry } from "../evaluator/toolRegistry.js";
 export interface BrowserPage {
   evaluate(fn: string | Function, ...args: any[]): Promise<any>;
   waitForNavigation(options?: any): Promise<any>;
-  webmcp?: WebMCP;
+  webmcp: WebMCP;
 }
 
 /**

--- a/evals-cli/src/backends/index.ts
+++ b/evals-cli/src/backends/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { WebMCP } from "puppeteer-core";
 import { WebmcpConfig } from "../types/config.js";
 import { Eval, TestResult, TestResults, TrajectoryStep } from "../types/evals.js";
 import { ToolCall } from "../types/tools.js";
@@ -11,7 +12,7 @@ import { ToolRegistry } from "../evaluator/toolRegistry.js";
 export interface BrowserPage {
   evaluate(fn: string | Function, ...args: any[]): Promise<any>;
   waitForNavigation(options?: any): Promise<any>;
-  webmcp?: any;
+  webmcp?: WebMCP;
 }
 
 /**

--- a/evals-cli/src/backends/vercel.ts
+++ b/evals-cli/src/backends/vercel.ts
@@ -130,7 +130,7 @@ export class VercelBackend implements Backend {
 
     try {
       const registry = new BrowserToolRegistry(page);
-      let currentTools = await registry.syncTools();
+      let currentTools = registry.syncTools();
 
       if (currentTools.length === 0) {
         const executablePath = await findChromePath();
@@ -185,7 +185,7 @@ export class VercelBackend implements Backend {
           });
         },
         prepareStep: async (_opts: any): Promise<any> => {
-          currentTools = await registry.syncTools();
+          currentTools = registry.syncTools();
           rebuildTools(currentTools);
           availableToolsPerStep.push([...currentTools]);
           return _opts;

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -7,20 +7,12 @@
 /// <reference path="../../../demos/shared/types/webmcp.d.ts" />
 
 import puppeteer, { Browser } from "puppeteer-core";
+import type { WebMCPToolCall, WebMCPToolCallResult } from "puppeteer-core";
 import { Tool } from "../types/tools.js";
 import { mapRawBrowserToolsToConfig } from "./mappers.js";
 import { findChromePath } from "../utils.js";
 import { BrowserPage } from "../backends/index.js";
 import { ToolRegistry } from "./toolRegistry.js";
-
-export async function getToolsFromBrowserPage(page: BrowserPage): Promise<any[]> {
-  const tools = page.webmcp?.tools() || [];
-  return tools.map((t: any) => ({
-    name: t.name,
-    description: t.description,
-    inputSchema: t.inputSchema,
-  }));
-}
 
 export const PUPPETEER_FLAGS = [
   "--enable-features=WebMCP",
@@ -43,7 +35,7 @@ export class BrowserToolRegistry implements ToolRegistry {
   constructor(private page: BrowserPage) {}
 
   async syncTools(): Promise<Tool[]> {
-    const rawTools = await getToolsFromBrowserPage(this.page);
+    const rawTools = this.page.webmcp?.tools() || [];
     this.currentTools = mapRawBrowserToolsToConfig(rawTools, this.currentTools);
     return this.currentTools;
   }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -36,7 +36,7 @@ export class BrowserToolRegistry implements ToolRegistry {
 
   syncTools(): Tool[] {
     const rawTools = this.page.webmcp.tools();
-    this.currentTools = mapRawBrowserToolsToConfig(rawTools, this.currentTools);
+    this.currentTools = mapRawBrowserToolsToConfig(rawTools);
     return this.currentTools;
   }
 

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -23,7 +23,7 @@ export async function getToolsFromBrowserPage(page: BrowserPage): Promise<any[]>
 }
 
 export const PUPPETEER_FLAGS = [
-  "--enable-features=WebMCPTesting,DevToolsWebMCPSupport,WebMCP",
+  "--enable-features=WebMCP",
   "--no-sandbox",
   "--disable-setuid-sandbox",
 ];

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -35,7 +35,7 @@ export class BrowserToolRegistry implements ToolRegistry {
   constructor(private page: BrowserPage) {}
 
   async syncTools(): Promise<Tool[]> {
-    const rawTools = this.page.webmcp?.tools() || [];
+    const rawTools = this.page.webmcp.tools() || [];
     this.currentTools = mapRawBrowserToolsToConfig(rawTools, this.currentTools);
     return this.currentTools;
   }
@@ -44,12 +44,12 @@ export class BrowserToolRegistry implements ToolRegistry {
     return this.currentTools;
   }
 
-  async executeTool(name: string, args: any): Promise<any> {
-    let executionResult: any = {};
+  async executeTool(name: string, args: Record<string, unknown> = {}): Promise<any> {
+    let executionResult: { result?: any; error?: string } = {};
 
     try {
-      const tools = this.page.webmcp?.tools() || [];
-      const tool = tools.find((t: any) => t.name === name);
+      const tools = this.page.webmcp.tools() || [];
+      const tool = tools.find((t) => t.name === name);
       if (!tool) {
         return { error: `no tool named "${name}" was found` };
       }
@@ -101,14 +101,14 @@ export class BrowserToolRegistry implements ToolRegistry {
             });
         });
 
-        const toolResult: any = await toolPromise;
+        const toolResult = await toolPromise;
         if (toolResult && toolResult.success) {
           executionResult.result = toolResult.data;
         } else {
           return { error: toolResult?.error || `Error executing tool "${name}"` };
         }
       } else {
-        const res = await tool.execute(args || {});
+        const res = await tool.execute(args);
         if (res.status === "Completed") {
           executionResult.result = res.output !== undefined ? res.output : "Success";
         } else if (res.status === "Error") {
@@ -126,18 +126,19 @@ export class BrowserToolRegistry implements ToolRegistry {
           return { result, crossDocument: true };
         });
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
       if (
-        e.message.includes("Execution context was destroyed") ||
-        e.message.includes("Target closed") ||
-        e.message.includes("navigating")
+        message.includes("Execution context was destroyed") ||
+        message.includes("Target closed") ||
+        message.includes("navigating")
       ) {
         await new Promise((r) => setTimeout(r, 500));
         executionResult = {
           result: `Tool ${name} executed and triggered a page navigation.`,
         };
       } else {
-        executionResult = { error: e.message || String(e) };
+        executionResult = { error: message };
       }
     }
 

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -62,13 +62,68 @@ export class BrowserToolRegistry implements ToolRegistry {
         return { error: `no tool named "${name}" was found` };
       }
 
-      const res = await tool.execute(args || {});
-      if (res.status === "Completed") {
-        executionResult.result = res.output !== undefined ? res.output : "Success";
-      } else if (res.status === "Error") {
-        return { error: res.errorText || `Error executing tool "${name}"` };
+      const isDeclarativeWithoutAutosubmit =
+        Boolean(await tool.formElement) && !tool.annotations?.autosubmit;
+
+      if (isDeclarativeWithoutAutosubmit) {
+        const toolPromise = new Promise((resolve) => {
+          let timer: any = null;
+
+          const onToolInvoked = (call: any) => {
+            if (!call.tool || call.tool.name === name) {
+              timer = setTimeout(() => {
+                this.page.webmcp?.off("toolinvoked", onToolInvoked);
+                resolve({ success: true, data: "pending form submission" });
+              }, 1000);
+            }
+          };
+
+          if (this.page.webmcp) {
+            this.page.webmcp.on("toolinvoked", onToolInvoked);
+          }
+
+          tool
+            .execute(args || {})
+            .then((res: any) => {
+              if (timer) clearTimeout(timer);
+              if (this.page.webmcp) {
+                this.page.webmcp.off("toolinvoked", onToolInvoked);
+              }
+              if (res.status === "Completed") {
+                resolve({ success: true, data: res.output ?? "Success" });
+              } else if (res.status === "Error") {
+                resolve({
+                  success: false,
+                  error: res.errorText || `Error executing tool "${name}"`,
+                });
+              } else {
+                resolve({ success: false, error: `Tool execution status: ${res.status}` });
+              }
+            })
+            .catch((err: any) => {
+              if (timer) clearTimeout(timer);
+              if (this.page.webmcp) {
+                this.page.webmcp.off("toolinvoked", onToolInvoked);
+              }
+              resolve({ success: false, error: err?.message || String(err) });
+            });
+        });
+
+        const toolResult: any = await toolPromise;
+        if (toolResult && toolResult.success) {
+          executionResult.result = toolResult.data;
+        } else {
+          return { error: toolResult?.error || `Error executing tool "${name}"` };
+        }
       } else {
-        return { error: `Tool execution status: ${res.status}` };
+        const res = await tool.execute(args || {});
+        if (res.status === "Completed") {
+          executionResult.result = res.output !== undefined ? res.output : "Success";
+        } else if (res.status === "Error") {
+          return { error: res.errorText || `Error executing tool "${name}"` };
+        } else {
+          return { error: `Tool execution status: ${res.status}` };
+        }
       }
 
       // If executionResult.result is null, it is due to a navigation happening.

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -34,8 +34,8 @@ export class BrowserToolRegistry implements ToolRegistry {
 
   constructor(private page: BrowserPage) {}
 
-  async syncTools(): Promise<Tool[]> {
-    const rawTools = this.page.webmcp.tools() || [];
+  syncTools(): Tool[] {
+    const rawTools = this.page.webmcp.tools();
     this.currentTools = mapRawBrowserToolsToConfig(rawTools, this.currentTools);
     return this.currentTools;
   }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -58,48 +58,44 @@ export class BrowserToolRegistry implements ToolRegistry {
         Boolean(await tool.formElement) && !tool.annotations?.autosubmit;
 
       if (isDeclarativeWithoutAutosubmit) {
-        const toolPromise = new Promise((resolve) => {
-          let timer: any = null;
+        const toolPromise = new Promise<{ success: boolean; data?: any; error?: string }>(
+          (resolve) => {
+            let timer: NodeJS.Timeout | null = null;
 
-          const onToolInvoked = (call: any) => {
-            if (!call.tool || call.tool.name === name) {
-              timer = setTimeout(() => {
-                this.page.webmcp?.off("toolinvoked", onToolInvoked);
-                resolve({ success: true, data: "pending form submission" });
-              }, 1000);
-            }
-          };
+            const onToolInvoked = (call: WebMCPToolCall) => {
+              if (!call.tool || call.tool.name === name) {
+                timer = setTimeout(() => {
+                  resolve({ success: true, data: "pending form submission" });
+                }, 1000);
+              }
+            };
 
-          if (this.page.webmcp) {
-            this.page.webmcp.on("toolinvoked", onToolInvoked);
-          }
+            this.page.webmcp.once("toolinvoked", onToolInvoked);
 
-          tool
-            .execute(args || {})
-            .then((res: any) => {
-              if (timer) clearTimeout(timer);
-              if (this.page.webmcp) {
+            tool
+              .execute(args)
+              .then((res: WebMCPToolCallResult) => {
+                if (timer) clearTimeout(timer);
                 this.page.webmcp.off("toolinvoked", onToolInvoked);
-              }
-              if (res.status === "Completed") {
-                resolve({ success: true, data: res.output ?? "Success" });
-              } else if (res.status === "Error") {
-                resolve({
-                  success: false,
-                  error: res.errorText || `Error executing tool "${name}"`,
-                });
-              } else {
-                resolve({ success: false, error: `Tool execution status: ${res.status}` });
-              }
-            })
-            .catch((err: any) => {
-              if (timer) clearTimeout(timer);
-              if (this.page.webmcp) {
+                if (res.status === "Completed") {
+                  resolve({ success: true, data: res.output ?? "Success" });
+                } else if (res.status === "Error") {
+                  resolve({
+                    success: false,
+                    error: res.errorText || `Error executing tool "${name}"`,
+                  });
+                } else {
+                  resolve({ success: false, error: `Tool execution status: ${res.status}` });
+                }
+              })
+              .catch((err: unknown) => {
+                if (timer) clearTimeout(timer);
                 this.page.webmcp.off("toolinvoked", onToolInvoked);
-              }
-              resolve({ success: false, error: err?.message || String(err) });
-            });
-        });
+                const message = err instanceof Error ? err.message : String(err);
+                resolve({ success: false, error: message });
+              });
+          },
+        );
 
         const toolResult = await toolPromise;
         if (toolResult && toolResult.success) {

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -14,25 +14,16 @@ import { BrowserPage } from "../backends/index.js";
 import { ToolRegistry } from "./toolRegistry.js";
 
 export async function getToolsFromBrowserPage(page: BrowserPage): Promise<any[]> {
-  return await page.evaluate(async () => {
-    if (document.modelContext && typeof document.modelContext.getTools === "function") {
-      try {
-        const raw = await document.modelContext.getTools();
-        return (raw || []).map((t) => ({
-          name: t.name,
-          description: t.description,
-          inputSchema: t.inputSchema,
-        }));
-      } catch {
-        return [];
-      }
-    }
-    return [];
-  });
+  const tools = page.webmcp?.tools() || [];
+  return tools.map((t: any) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  }));
 }
 
 export const PUPPETEER_FLAGS = [
-  "--enable-features=WebMCP",
+  "--enable-features=WebMCPTesting,DevToolsWebMCPSupport,WebMCP",
   "--no-sandbox",
   "--disable-setuid-sandbox",
 ];
@@ -65,57 +56,19 @@ export class BrowserToolRegistry implements ToolRegistry {
     let executionResult: any = {};
 
     try {
-      const toolResult = await this.page.evaluate(
-        async (name: string, callArgs: any) => {
-          if (document.modelContext) {
-            const mc = document.modelContext;
-            if (typeof mc.getTools === "function" && typeof mc.executeTool === "function") {
-              const tools = await mc.getTools();
-              const tool = tools.find((item) => item.name === name);
-              if (tool) {
-                return new Promise((resolve) => {
-                  let timer: any = null;
-
-                  const onActivated = (e: any) => {
-                    if (!e.toolName || e.toolName === name) {
-                      timer = setTimeout(() => {
-                        window.removeEventListener("toolactivated", onActivated);
-                        resolve({ success: true, data: "pending form submission" });
-                      }, 1000);
-                    }
-                  };
-
-                  window.addEventListener("toolactivated", onActivated);
-
-                  mc.executeTool(tool, JSON.stringify(callArgs || {}))
-                    .then((resStr: any) => {
-                      if (timer) clearTimeout(timer);
-                      window.removeEventListener("toolactivated", onActivated);
-                      try {
-                        resolve({ success: true, data: JSON.parse(resStr as string) });
-                      } catch {
-                        resolve({ success: true, data: resStr });
-                      }
-                    })
-                    .catch((err: any) => {
-                      if (timer) clearTimeout(timer);
-                      window.removeEventListener("toolactivated", onActivated);
-                      resolve({ success: false, error: err?.message || String(err) });
-                    });
-                });
-              }
-            }
-          }
-          return { success: false };
-        },
-        name,
-        args,
-      );
-
-      if (toolResult && toolResult.success) {
-        executionResult.result = toolResult.data;
-      } else {
+      const tools = this.page.webmcp?.tools() || [];
+      const tool = tools.find((t: any) => t.name === name);
+      if (!tool) {
         return { error: `no tool named "${name}" was found` };
+      }
+
+      const res = await tool.execute(args || {});
+      if (res.status === "Completed") {
+        executionResult.result = res.output !== undefined ? res.output : "Success";
+      } else if (res.status === "Error") {
+        return { error: res.errorText || `Error executing tool "${name}"` };
+      } else {
+        return { error: `Tool execution status: ${res.status}` };
       }
 
       // If executionResult.result is null, it is due to a navigation happening.

--- a/evals-cli/src/evaluator/mappers.ts
+++ b/evals-cli/src/evaluator/mappers.ts
@@ -73,7 +73,7 @@ export function sanitizeSchema(obj: any): any {
  */
 export function mapJsonSchemaToVercelTools(
   inputTools: Tool[],
-  execute?: (functionName: string, args: unknown) => unknown | Promise<unknown>,
+  execute?: (functionName: string, args: Record<string, unknown>) => unknown | Promise<unknown>,
 ): Record<string, any> {
   const tools: Record<string, any> = {};
   inputTools.forEach((toolDef: any) => {

--- a/evals-cli/src/evaluator/mappers.ts
+++ b/evals-cli/src/evaluator/mappers.ts
@@ -4,7 +4,8 @@
  */
 
 import { tool as defineTool, jsonSchema, Tool as VercelTool } from "ai";
-import { Tool } from "../types/tools.js";
+import { Tool, ToolSchema } from "../types/tools.js";
+import type { WebMCPTool } from "puppeteer-core";
 
 export function mapMessages(messages: any[]): any[] {
   return messages.map((m) => {
@@ -94,22 +95,19 @@ export function mapJsonSchemaToVercelTools(
 /**
  * Normalizes raw tool configurations dynamically fetched from the browser loop.
  */
-export function mapRawBrowserToolsToConfig(rawTools: any[], fallbackTools: Tool[]): Tool[] {
-  if (rawTools && Array.isArray(rawTools) && rawTools.length > 0) {
-    return rawTools.map((t: any) => {
-      const schema = t.inputSchema;
-      let parameters;
-      try {
-        parameters = (typeof schema === "string" ? JSON.parse(schema) : schema) || {};
-      } catch {
-        parameters = {};
-      }
-      return {
-        description: t.description,
-        functionName: t.name,
-        parameters,
-      };
-    });
-  }
-  return fallbackTools;
+export function mapRawBrowserToolsToConfig(rawTools: WebMCPTool[]): Tool[] {
+  return rawTools.map((t) => {
+    const schema = t.inputSchema;
+    let parameters;
+    try {
+      parameters = (typeof schema === "string" ? JSON.parse(schema) : schema) || {};
+    } catch {
+      parameters = {};
+    }
+    return {
+      description: t.description,
+      functionName: t.name,
+      parameters,
+    };
+  });
 }

--- a/evals-cli/src/evaluator/toolRegistry.ts
+++ b/evals-cli/src/evaluator/toolRegistry.ts
@@ -8,7 +8,7 @@ import { MockResolver } from "./mockResolver.js";
 
 export interface ToolRegistry {
   getCurrentTools(): Tool[];
-  executeTool(name: string, args: any): Promise<any>;
+  executeTool(name: string, args?: Record<string, unknown>): Promise<any>;
 }
 
 export class LocalToolRegistry implements ToolRegistry {
@@ -21,7 +21,7 @@ export class LocalToolRegistry implements ToolRegistry {
     return this.tools;
   }
 
-  async executeTool(name: string, args: any): Promise<any> {
+  async executeTool(name: string, args: Record<string, unknown> = {}): Promise<any> {
     return this.resolver.resolve(name, args);
   }
 }

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -39,35 +39,6 @@ describe("BrowserToolRegistry", () => {
     assert.deepStrictEqual(registry.getCurrentTools(), []);
   });
 
-  it("should fetch and map tools from page.webmcp", async () => {
-    const page = new MockBrowserPage();
-    page.webmcp = {
-      tools: () => [
-        {
-          name: "page_action",
-          description: "Executes a page action",
-          inputSchema: {
-            type: "object",
-            properties: {
-              elementId: { type: "string" },
-            },
-          },
-        },
-      ],
-    };
-
-    const registry = new BrowserToolRegistry(page);
-    const synced = await registry.syncTools();
-
-    assert.strictEqual(synced.length, 1);
-    assert.strictEqual(synced[0].functionName, "page_action");
-    assert.strictEqual(synced[0].description, "Executes a page action");
-    assert.deepStrictEqual(synced[0].parameters, {
-      type: "object",
-      properties: { elementId: { type: "string" } },
-    });
-  });
-
   it("should execute tool via page.webmcp and return output on Completed status", async () => {
     let executedInput: unknown = null;
     const page = new MockBrowserPage();

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -149,7 +149,7 @@ describe("BrowserToolRegistry", () => {
     const listeners: Record<string, Function[]> = {};
     const page = new MockBrowserPage();
     page.webmcp = {
-      on: (event: string, cb: Function) => {
+      once: (event: string, cb: Function) => {
         listeners[event] = listeners[event] || [];
         listeners[event].push(cb);
       },

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -34,7 +34,7 @@ describe("BrowserToolRegistry", () => {
     const registry = new BrowserToolRegistry(page);
     assert.deepStrictEqual(registry.getCurrentTools(), []);
 
-    const synced = await registry.syncTools();
+    const synced = registry.syncTools();
     assert.deepStrictEqual(synced, []);
     assert.deepStrictEqual(registry.getCurrentTools(), []);
   });

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -144,4 +144,50 @@ describe("BrowserToolRegistry", () => {
     assert.strictEqual(page.navigationCalls.length, 1);
     assert.deepStrictEqual(result, { type: "JSON-LD" });
   });
+
+  it("should handle declarative tool without autosubmit, listen for toolinvoked, and resolve pending form submission on timeout", async () => {
+    const listeners: Record<string, Function[]> = {};
+    const page = new MockBrowserPage();
+    page.webmcp = {
+      on: (event: string, cb: Function) => {
+        listeners[event] = listeners[event] || [];
+        listeners[event].push(cb);
+      },
+      off: (event: string, cb: Function) => {
+        if (listeners[event]) {
+          listeners[event] = listeners[event].filter((l) => l !== cb);
+        }
+      },
+      tools: () => [
+        {
+          name: "book_table",
+          description: "Form-based tool without autosubmit",
+          formElement: Promise.resolve({} as any),
+          annotations: { autosubmit: false },
+          execute: async () => {
+            // Trigger toolinvoked listener like Puppeteer CDP event would
+            const invokedCb = listeners["toolinvoked"]?.[0];
+            if (invokedCb) {
+              invokedCb({ tool: { name: "book_table" } });
+            }
+            // Promise that doesn't resolve immediately (simulating form wait)
+            return new Promise(() => {});
+          },
+        },
+      ],
+    };
+
+    // Override setTimeout in execution context with fast timeout for speed
+    const registry = new BrowserToolRegistry(page);
+
+    // Fast-forward or test using speed up: since code uses 1000ms timeout, let's test execution
+    const origSetTimeout = global.setTimeout;
+    try {
+      global.setTimeout = ((cb: Function, _ms: number) => origSetTimeout(cb, 10)) as any;
+      const result = await registry.executeTool("book_table", { guests: 2 });
+      assert.strictEqual(result, "pending form submission");
+    } finally {
+      global.setTimeout = origSetTimeout;
+    }
+  });
 });

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -12,6 +12,9 @@ class MockBrowserPage implements BrowserPage {
   public evaluateResult: unknown = [];
   public evaluateCalls: Array<{ fn: string | Function; args: unknown[] }> = [];
   public navigationCalls: Array<{ options?: unknown }> = [];
+  public webmcp: any = {
+    tools: () => [],
+  };
 
   async evaluate(fn: string | Function, ...args: unknown[]): Promise<any> {
     this.evaluateCalls.push({ fn, args });
@@ -25,9 +28,8 @@ class MockBrowserPage implements BrowserPage {
 }
 
 describe("BrowserToolRegistry", () => {
-  it("should initialize and return empty list if page returns none", async () => {
+  it("should initialize and return empty list if page returns no tools", async () => {
     const page = new MockBrowserPage();
-    page.evaluateResult = []; // No tools on page
 
     const registry = new BrowserToolRegistry(page);
     assert.deepStrictEqual(registry.getCurrentTools(), []);
@@ -37,20 +39,22 @@ describe("BrowserToolRegistry", () => {
     assert.deepStrictEqual(registry.getCurrentTools(), []);
   });
 
-  it("should fetch and map page-level tools when present", async () => {
+  it("should fetch and map tools from page.webmcp", async () => {
     const page = new MockBrowserPage();
-    page.evaluateResult = [
-      {
-        name: "page_action",
-        description: "Executes a page action",
-        inputSchema: {
-          type: "object",
-          properties: {
-            elementId: { type: "string" },
+    page.webmcp = {
+      tools: () => [
+        {
+          name: "page_action",
+          description: "Executes a page action",
+          inputSchema: {
+            type: "object",
+            properties: {
+              elementId: { type: "string" },
+            },
           },
         },
-      },
-    ];
+      ],
+    };
 
     const registry = new BrowserToolRegistry(page);
     const synced = await registry.syncTools();
@@ -64,33 +68,32 @@ describe("BrowserToolRegistry", () => {
     });
   });
 
-  it("should execute tool inside page context and return success result", async () => {
+  it("should execute tool via page.webmcp and return output on Completed status", async () => {
+    let executedInput: unknown = null;
     const page = new MockBrowserPage();
-    // Simulate modelContext executeTool response:
-    page.evaluateResult = { success: true, data: { status: "clicked" } };
+    page.webmcp = {
+      tools: () => [
+        {
+          name: "click_button",
+          description: "Click a button",
+          inputSchema: { type: "object" },
+          execute: async (input: unknown) => {
+            executedInput = input;
+            return { status: "Completed", output: { status: "clicked" } };
+          },
+        },
+      ],
+    };
 
     const registry = new BrowserToolRegistry(page);
     const result = await registry.executeTool("click_button", { id: "btn-1" });
 
     assert.deepStrictEqual(result, { status: "clicked" });
-    assert.strictEqual(page.evaluateCalls.length, 1);
-    assert.strictEqual(page.evaluateCalls[0].args[0], "click_button");
-    assert.deepStrictEqual(page.evaluateCalls[0].args[1], { id: "btn-1" });
+    assert.deepStrictEqual(executedInput, { id: "btn-1" });
   });
 
-  it("should return 'pending form submission' when tool result data is 'pending form submission'", async () => {
+  it("should return error when tool is not found", async () => {
     const page = new MockBrowserPage();
-    page.evaluateResult = { success: true, data: "pending form submission" };
-
-    const registry = new BrowserToolRegistry(page);
-    const result = await registry.executeTool("book_table", { guests: 2 });
-
-    assert.strictEqual(result, "pending form submission");
-  });
-
-  it("should return error if page execution reports success: false", async () => {
-    const page = new MockBrowserPage();
-    page.evaluateResult = { success: false };
 
     const registry = new BrowserToolRegistry(page);
     const result = await registry.executeTool("click_button", { id: "btn-1" });
@@ -98,50 +101,47 @@ describe("BrowserToolRegistry", () => {
     assert.deepStrictEqual(result, { error: 'no tool named "click_button" was found' });
   });
 
-  it("should execute page script, handle toolactivated, and resolve pending form submission on timeout", async () => {
+  it("should return error when tool execution fails with Error status", async () => {
     const page = new MockBrowserPage();
-    page.evaluate = async (fn: any, ...args: any[]) => {
-      const listeners: Record<string, Function[]> = {};
-      const fakeWindow = {
-        addEventListener: (event: string, cb: Function) => {
-          listeners[event] = listeners[event] || [];
-          listeners[event].push(cb);
-        },
-        removeEventListener: (event: string, cb: Function) => {
-          if (listeners[event]) {
-            listeners[event] = listeners[event].filter((l) => l !== cb);
-          }
-        },
-      };
-      const fakeDocument = {
-        modelContext: {
-          getTools: async () => [{ name: "book_table" }],
-          executeTool: async () => {
-            // Trigger toolactivated event
-            const activatedCb = listeners["toolactivated"]?.[0];
-            if (activatedCb) {
-              activatedCb({ toolName: "book_table" });
-            }
-            // Return a promise that never resolves (simulating manual form submit wait)
-            return new Promise(() => {});
+    page.webmcp = {
+      tools: () => [
+        {
+          name: "failing_tool",
+          description: "Fails always",
+          inputSchema: { type: "object" },
+          execute: async () => {
+            return { status: "Error", errorText: "Execution failed in page context" };
           },
         },
-      };
-
-      // Execute in fake environment with 10ms timeout for test speed
-      const fnStr = fn.toString();
-      const testFn = new Function(
-        "window",
-        "document",
-        "name",
-        "callArgs",
-        `return (${fnStr.replace("1000", "10")})(name, callArgs);`,
-      );
-      return testFn(fakeWindow, fakeDocument, args[0], args[1]);
+      ],
     };
 
     const registry = new BrowserToolRegistry(page);
-    const result = await registry.executeTool("book_table", { guests: 2 });
-    assert.strictEqual(result, "pending form submission");
+    const result = await registry.executeTool("failing_tool", {});
+
+    assert.deepStrictEqual(result, { error: "Execution failed in page context" });
+  });
+
+  it("should handle navigation when tool execution output is null", async () => {
+    const page = new MockBrowserPage();
+    page.evaluateResult = { result: '{"type":"JSON-LD"}', crossDocument: true };
+    page.webmcp = {
+      tools: () => [
+        {
+          name: "nav_tool",
+          description: "Navigates page",
+          inputSchema: { type: "object" },
+          execute: async () => {
+            return { status: "Completed", output: null };
+          },
+        },
+      ],
+    };
+
+    const registry = new BrowserToolRegistry(page);
+    const result = await registry.executeTool("nav_tool", {});
+
+    assert.strictEqual(page.navigationCalls.length, 1);
+    assert.deepStrictEqual(result, { type: "JSON-LD" });
   });
 });

--- a/evals-cli/src/test/mappers.test.ts
+++ b/evals-cli/src/test/mappers.test.ts
@@ -12,6 +12,7 @@ import {
   sanitizeSchema,
 } from "../evaluator/mappers.js";
 import { Tool } from "../types/tools.js";
+import { WebMCPTool } from "puppeteer-core";
 
 describe("mappers", () => {
   describe("sanitizeSchema", () => {
@@ -178,10 +179,9 @@ describe("mappers", () => {
           description: "Get current cart",
           inputSchema: { type: "object" },
         },
-      ];
-      const fallbackTools: Tool[] = [];
+      ] as WebMCPTool[];
 
-      const result = mapRawBrowserToolsToConfig(rawTools, fallbackTools);
+      const result = mapRawBrowserToolsToConfig(rawTools);
 
       assert.deepStrictEqual(result, [
         {
@@ -197,15 +197,6 @@ describe("mappers", () => {
       ]);
     });
 
-    it("should fallback when rawTools is empty or missing", () => {
-      const fallbackTools: Tool[] = [
-        { functionName: "default_tool", description: "Default", parameters: {} },
-      ];
-
-      assert.deepStrictEqual(mapRawBrowserToolsToConfig([], fallbackTools), fallbackTools);
-      assert.deepStrictEqual(mapRawBrowserToolsToConfig(null as any, fallbackTools), fallbackTools);
-    });
-
     it("should handle invalid JSON inputSchema gracefully", () => {
       const rawTools = [
         {
@@ -213,8 +204,8 @@ describe("mappers", () => {
           description: "Faulty schema",
           inputSchema: "invalid-json{",
         },
-      ];
-      const result = mapRawBrowserToolsToConfig(rawTools, []);
+      ] as unknown as WebMCPTool[];
+      const result = mapRawBrowserToolsToConfig(rawTools);
 
       assert.deepStrictEqual(result, [
         {

--- a/evals-cli/src/test/vercel.test.ts
+++ b/evals-cli/src/test/vercel.test.ts
@@ -99,19 +99,16 @@ describe("VercelBackend", () => {
     it("should pass mapped messages array correctly to agentWithExec.generate", async (t) => {
       // Create a dummy page object that returns some dummy registered tools
       const dummyPage: any = {
-        evaluate: async (fn: any, ..._args: any[]) => {
-          // If it evaluates getToolsFromBrowserPage, return the tool metadata
-          if (fn.toString().includes("getTools")) {
-            return [
-              {
-                name: "add_topping",
-                description: "Adds a topping",
-                inputSchema: { type: "object" },
-              },
-            ];
-          }
-          return {};
+        webmcp: {
+          tools: () => [
+            {
+              name: "add_topping",
+              description: "Adds a topping",
+              inputSchema: { type: "object" },
+            },
+          ],
         },
+        evaluate: async () => ({}),
       };
 
       // Mock ToolLoopAgent.generate to intercept the payload sent to it
@@ -180,18 +177,16 @@ describe("VercelBackend", () => {
 
     it("should match tool result strictly by toolCallId when the same tool is called multiple times", async (t) => {
       const dummyPage: any = {
-        evaluate: async (fn: any) => {
-          if (fn.toString().includes("getTools")) {
-            return [
-              {
-                name: "load_next_results",
-                description: "Loads results",
-                inputSchema: { type: "object" },
-              },
-            ];
-          }
-          return {};
+        webmcp: {
+          tools: () => [
+            {
+              name: "load_next_results",
+              description: "Loads results",
+              inputSchema: { type: "object" },
+            },
+          ],
         },
+        evaluate: async () => ({}),
       };
 
       t.mock.method(ai.ToolLoopAgent.prototype, "generate", async () => {


### PR DESCRIPTION
Resolves #325

Addresses feedback on #305 regarding detecting declarative tools.

Successfully tested with the French Bistro example from #305. Examples:

```bash
# Success cases
$ node dist/bin/webmcp-evals.js browser -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/-e examples/french-bistro/evals.json --open # pending form submission
$ node dist/bin/webmcp-evals.js browser -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/?toolautosubmit -e examples/french-bistro/evals-toolautosubmit.json --open # autosubmit

# Fail cases
$ node dist/bin/webmcp-evals.js browser -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/ -e examples/french-bistro/evals-toolautosubmit.json --open # expected autosubmit, got pending form submission
$ node dist/bin/webmcp-evals.js browser -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/?toolautosubmit -e examples/french-bistro/evals.json --open  # expected pending form submission, got autosubmit
```

### Summary of Changes

1. **Leveraging `page.webmcp`**:
   - Updated `PUPPETEER_FLAGS` with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport,WebMCP`.
   - Updated `getToolsFromBrowserPage` to use `page.webmcp.tools()`.
   - Updated `BrowserToolRegistry.executeTool` to use `page.webmcp.tools()` and `tool.execute()`.
2. **Declarative Form Tools**:
   - Handled non-autosubmit declarative form tools (`tool.formElement` && `!tool.annotations?.autosubmit`) via `page.webmcp.on('toolinvoked')` event listener.
3. **Tests**:
   - Updated `BrowserPage` type and test mocks in `vercel.test.ts`.
   - Added unit tests in `browserToolRegistry.test.ts` for native WebMCP tool discovery and execution.