### PR TITLE
simplify tool parameter descriptions for reservation date and time

### DIFF
--- a/demos/french-bistro/index.html
+++ b/demos/french-bistro/index.html
@@ -77,7 +77,7 @@
               id="date"
               name="date"
               required
-              toolparamdescription="Reservation date (YYYY-MM-DD). Must be today or future."
+              toolparamdescription="Reservation date. Must be today or future."
             />
             <span class="error-msg">Please select a future date.</span>
           </div>
@@ -88,7 +88,7 @@
               id="time"
               name="time"
               required
-              toolparamdescription="Reservation time (HH:MM)"
+              toolparamdescription="Reservation time"
             />
             <span class="error-msg">Please select a valid time.</span>
           </div>


### PR DESCRIPTION
As noted in https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/forms/form_mcp_schema.cc;l=583;drc=519653dfe228949fce89c3cf8f7a6152f5531fcb, reservation date toolparamdescription doesn't need to include spefically `(YYYY-MM-DD)`.
I've tried without `(HH:MM)` and it worked great as well with Gemini 3.5 Flash Lite and Gemini 3.6