### PR TITLE
fix(evals): surface unexpected tool calls in reports

### DIFF
--- a/evals-cli/src/report/report.ts
+++ b/evals-cli/src/report/report.ts
@@ -350,6 +350,7 @@ function renderRunIteration(run: TestRun, totalRuns: number): string {
 function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
   const { stepIndex, result } = stepEval;
   const expected = result.test.expectedCall?.[0] as FunctionCall | undefined;
+  const isUnexpectedCall = expected === undefined && result.response !== null;
 
   const functionNameOutcome =
     expected?.functionName === result.response?.functionName ? "pass" : "fail";
@@ -385,6 +386,14 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
           ${result.outcome.toUpperCase()}
         </span>
       </div>
+      ${
+        isUnexpectedCall
+          ? `<div class="border-b border-rose-200 bg-rose-50 px-4 py-3 text-xs text-rose-800">
+              <strong class="font-semibold">Unexpected tool call</strong>
+              <span class="ml-1">No tool call was expected, but <code class="font-mono font-semibold">${escapeHtml(result.response?.functionName)}</code> was executed.</span>
+            </div>`
+          : ""
+      }
       <div class="overflow-x-auto">
         <table class="w-full text-left text-xs text-slate-600">
           <thead class="bg-slate-50 text-slate-500 border-b border-slate-200 font-medium">
@@ -398,7 +407,11 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
           <tbody class="divide-y divide-slate-100">
             <tr class="hover:bg-slate-50/30">
               <td class="px-4 py-3 font-semibold text-slate-700 whitespace-nowrap">Function Name</td>
-              <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml(expected?.functionName || null)}</code></td>
+              <td class="px-4 py-3">${
+                isUnexpectedCall
+                  ? `<span class="text-xs italic text-slate-500">No call expected</span>`
+                  : `<code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml(expected?.functionName || null)}</code>`
+              }</td>
               <td class="px-4 py-3"><code class="px-1.5 py-0.5 bg-slate-100 text-slate-800 rounded font-mono text-xs">${escapeHtml(result.response?.functionName || null)}</code></td>
               <td class="px-4 py-3">
                 <span class="${functionNameOutcome === "pass" ? "text-emerald-600" : "text-rose-600"} font-bold text-xs">

--- a/evals-cli/src/test/report.test.ts
+++ b/evals-cli/src/test/report.test.ts
@@ -98,6 +98,42 @@ describe("Report Grouping & Rendering", () => {
     assert.match(html, /Fallback Prompt Text/);
   });
 
+  it("labels extra executions as unexpected tool calls", () => {
+    const results: TestResult[] = [
+      {
+        test: {
+          name: "Hallucinated tool",
+          messages: [{ role: "user", type: "message", content: "Summarize the page" }],
+          expectedCall: null,
+        },
+        response: { functionName: "get_page_content", args: {} },
+        outcome: "fail",
+      },
+      {
+        test: {
+          name: "Missing tool",
+          messages: [{ role: "user", type: "message", content: "Search the catalog" }],
+          expectedCall: [{ functionName: "search", arguments: {} }],
+        },
+        response: null,
+        outcome: "fail",
+      },
+    ];
+
+    const html = renderReport(mockConfig, {
+      results,
+      testCount: 2,
+      passCount: 0,
+      failCount: 2,
+      errorCount: 0,
+    });
+
+    assert.match(html, /Unexpected tool call/);
+    assert.match(html, /No call expected/);
+    assert.match(html, /get_page_content/);
+    assert.strictEqual(html.match(/Unexpected tool call/g)?.length, 1);
+  });
+
   it("renders chrome channel in HTML configuration section", () => {
     const testResults: TestResults = {
       results: [],


### PR DESCRIPTION
## Summary

- label extra model executions as `Unexpected tool call` in HTML eval reports
- replace the blank expected-function cell with `No call expected`
- add regression coverage that distinguishes an unexpected call from a missing expected call

## Motivation

The trajectory matcher already fails executions that have no matching expected call, but the HTML report renders an empty expected pattern for those rows. This makes hallucinated or otherwise extra tool calls difficult to identify when reviewing an eval report.

## Design

The existing `TestResult` shape already represents this case unambiguously: it has an actual response and no expected call. The report renderer now detects that combination and adds a focused failure notice while leaving matching, evaluator behavior, JSON output, and report grouping unchanged.

This keeps the presentation fix local to the HTML renderer instead of adding a new reason field to shared trajectory results or trying to infer whether the call was absent from a particular tool registry.

## Testing

- `npm test` — 149 passed, 1 skipped, 0 failed (the browser integration test skipped because no configured browser could be launched)
- `node --test dist/test/report.test.js` — 4 passed
- `npm run build` — passed
- `npm run lint` — passed with 7 pre-existing warnings in untouched files
- `npx oxfmt --check` — passed

## Compatibility and risks

There are no changes to matching semantics, exported types, CLI flags, JSON reports, or persisted formats. The actual function name is escaped before it is included in the HTML notice. The change applies to both local and browser HTML reports through their shared step renderer.

## Scope

This change only clarifies extra-call failures. Broader report redesign and tool-registry-based unknown-tool classification are intentionally out of scope.

Closes #283

