### PR TITLE
ci(evals): add GitHub Actions workflow for demo app smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -21,17 +21,17 @@ jobs:
           - target: doors
             name: Doors
             dir: demos/doors
-            command: npx serve -l 3000
+            command: npx -y serve -l 3000
             url: http://localhost:3000
           - target: bistro
             name: French Bistro
             dir: demos/french-bistro
-            command: npx serve -l 3000
+            command: npx -y serve -l 3000
             url: http://localhost:3000
           - target: pizza
             name: Pizza Maker
             dir: demos/pizza-maker
-            command: npx serve -l 3000
+            command: npx -y serve -l 3000
             url: http://localhost:3000
           - target: sport-shop
             name: Sport Shop Angular

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,91 @@
+name: Smoke Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Smoke Test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: doors
+            name: Doors
+            dir: demos/doors
+            command: npx serve -l 3000
+            url: http://localhost:3000
+          - target: bistro
+            name: French Bistro
+            dir: demos/french-bistro
+            command: npx serve -l 3000
+            url: http://localhost:3000
+          - target: pizza
+            name: Pizza Maker
+            dir: demos/pizza-maker
+            command: npx serve -l 3000
+            url: http://localhost:3000
+          - target: sport-shop
+            name: Sport Shop Angular
+            dir: demos/sport-shop-angular
+            command: npm start -- --port 3000
+            url: http://localhost:3000
+          - target: hotel-chain
+            name: Hotel Chain
+            dir: demos/hotel-chain
+            command: npm run dev -- --port 3000
+            url: http://localhost:3000
+          - target: smart-home
+            name: Smart Home
+            dir: demos/smart-home
+            command: npm run dev -- --port 3000
+            url: http://localhost:3000
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: |
+            evals-cli/package-lock.json
+            ${{ matrix.dir }}/package-lock.json
+
+      - name: Install evals-cli dependencies
+        working-directory: evals-cli
+        run: npm ci
+
+      - name: Build evals-cli
+        working-directory: evals-cli
+        run: npm run build
+
+      - name: Install demo dependencies
+        if: hashFiles(format('{0}/package.json', matrix.dir)) != ''
+        working-directory: ${{ matrix.dir }}
+        run: npm ci
+
+      - name: Start dev server
+        working-directory: ${{ matrix.dir }}
+        run: |
+          ${{ matrix.command }} &
+          timeout 60s bash -c 'until curl -s ${{ matrix.url }} > /dev/null; do sleep 1; done'
+
+      - name: Run Smoke Test
+        working-directory: evals-cli
+        env:
+          URL: ${{ matrix.url }}
+          CHROME_CHANNEL: chrome
+        run: ./run_smoke.sh ${{ matrix.target }} -v

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "npm"
           cache-dependency-path: |
             evals-cli/package-lock.json

--- a/evals-cli/run_smoke.sh
+++ b/evals-cli/run_smoke.sh
@@ -5,11 +5,13 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-# Always install and build dependencies once at the start of the execution
-echo "📦 Installing dependencies and building project..."
-npm ci
-npm run build
-echo
+# Skip install and build in CI environments where dependencies are pre-installed
+if [ "$CI" != "true" ]; then
+  echo "📦 Installing dependencies and building project..."
+  npm ci
+  npm run build
+  echo
+fi
 
 TARGET="${1}"
 VERBOSE_FLAG=""

--- a/evals-cli/run_smoke.sh
+++ b/evals-cli/run_smoke.sh
@@ -18,13 +18,31 @@ if [ "${2}" = "-v" ] || [ "${2}" = "--verbose" ]; then
   VERBOSE_FLAG="-v"
 fi
 
-ALL_TARGETS=("doors" "bistro" "pizza" "sport-shop" "hotel-chain")
+CHROME_CHANNEL_FLAG=""
+if [ -n "$CHROME_CHANNEL" ]; then
+  CHROME_CHANNEL_FLAG="--chrome-channel $CHROME_CHANNEL"
+fi
+
+ALL_TARGETS=("doors" "bistro" "pizza" "sport-shop" "hotel-chain" "smart-home")
 
 if [ -z "$TARGET" ]; then
   echo "Error: Missing target parameter."
-  echo "Usage: $0 <doors|bistro|pizza|sport-shop|hotel-chain|all> [-v|--verbose]"
+  echo "Usage: $0 <doors|bistro|pizza|sport-shop|hotel-chain|smart-home|all> [-v|--verbose]"
   exit 1
 fi
+
+get_target_url() {
+  local target_path="${1}"
+  local default_url="${2}"
+
+  if [ -n "$URL" ]; then
+    echo "$URL"
+  elif [ -n "$BASE_URL" ]; then
+    echo "${BASE_URL%/}/${target_path}"
+  else
+    echo "$default_url"
+  fi
+}
 
 run_single_smoke() {
   local t="${1}"
@@ -33,45 +51,59 @@ run_single_smoke() {
       # 1. Doors Demo
       echo "🚪 Running Doors Smoke Test..."
       node dist/bin/webmcp-evals.js smoke \
-        -u https://googlechromelabs.github.io/webmcp-tools/demos/doors \
+        -u "$(get_target_url "doors" "https://googlechromelabs.github.io/webmcp-tools/demos/doors")" \
         -e examples/doors/evals.json \
-        $VERBOSE_FLAG
+        $VERBOSE_FLAG \
+        $CHROME_CHANNEL_FLAG
       ;;
     "bistro")
       # 2. French Bistro Demo
       echo "🇫🇷 Running French Bistro Smoke Test..."
       node dist/bin/webmcp-evals.js smoke \
-        -u https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/ \
+        -u "$(get_target_url "french-bistro/" "https://googlechromelabs.github.io/webmcp-tools/demos/french-bistro/")" \
         -e examples/french-bistro/evals.json \
-        $VERBOSE_FLAG
+        $VERBOSE_FLAG \
+        $CHROME_CHANNEL_FLAG
       ;;
     "pizza")
       # 3. Pizza Maker Demo
       echo "🍕 Running Pizza Maker Smoke Test..."
       node dist/bin/webmcp-evals.js smoke \
-        -u https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/ \
+        -u "$(get_target_url "pizza-maker/" "https://googlechromelabs.github.io/webmcp-tools/demos/pizza-maker/")" \
         -e examples/pizza-maker/evals.json \
-        $VERBOSE_FLAG
+        $VERBOSE_FLAG \
+        $CHROME_CHANNEL_FLAG
       ;;
     "sport-shop")
       # 4. Sport Shop Angular Demo
       echo "🛍️ Running Sport Shop Angular Smoke Test..."
       node dist/bin/webmcp-evals.js smoke \
-        -u https://googlechromelabs.github.io/webmcp-tools/demos/sport-shop-angular/ \
+        -u "$(get_target_url "sport-shop-angular/" "https://googlechromelabs.github.io/webmcp-tools/demos/sport-shop-angular/")" \
         -e examples/sport-shop-angular/evals.json \
-        $VERBOSE_FLAG
+        $VERBOSE_FLAG \
+        $CHROME_CHANNEL_FLAG
       ;;
     "hotel-chain")
       # 5. Hotel Chain Demo
       echo "🏨 Running Hotel Chain Smoke Test..."
       node dist/bin/webmcp-evals.js smoke \
-        -u https://googlechromelabs.github.io/webmcp-tools/demos/hotel-chain/ \
+        -u "$(get_target_url "hotel-chain/" "https://googlechromelabs.github.io/webmcp-tools/demos/hotel-chain/")" \
         -e examples/hotel-chain/evals.json \
-        $VERBOSE_FLAG
+        $VERBOSE_FLAG \
+        $CHROME_CHANNEL_FLAG
+      ;;
+    "smart-home")
+      # 6. Smart Home Demo
+      echo "🏠 Running Smart Home Smoke Test..."
+      node dist/bin/webmcp-evals.js smoke \
+        -u "$(get_target_url "smart-home/" "https://googlechromelabs.github.io/webmcp-tools/demos/smart-home/")" \
+        -e examples/smart-home/evals.json \
+        $VERBOSE_FLAG \
+        $CHROME_CHANNEL_FLAG
       ;;
     *)
       echo "Error: Invalid target '$t'."
-      echo "Supported targets: doors, bistro, pizza, sport-shop, hotel-chain, all"
+      echo "Supported targets: doors, bistro, pizza, sport-shop, hotel-chain, smart-home, all"
       exit 1
       ;;
   esac


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run deterministic WebMCP smoke tests for all demo applications in parallel on CI.

### Key Changes

1. **GitHub Actions Workflow** (`.github/workflows/smoke-tests.yml`)
   - Runs a job matrix across demo applications (`doors`, `bistro`, `pizza`, `sport-shop`, `hotel-chain`, and `smart-home`).
   - Sets up Node.js v22 with npm dependency caching.
   - Installs dependencies and builds `evals-cli`.
   - Starts dev servers (`npx serve` for static apps; `npm start` / `npm run dev` for Angular/Vite apps) and waits until the local endpoint is responsive (`http://localhost:3000`).
   - Runs the smoke test script for each app.

2. **Smoke Test Runner Script** (`evals-cli/run_smoke.sh`)
   - Updated to support configurable target URLs (`URL` / `BASE_URL`) for running against local dev servers.
   - Added support for passing `CHROME_CHANNEL` (e.g. `chrome` on Linux CI).
   - Added `smart-home` target to the supported target list.