### PR TITLE
fix(evals): prevent 30s navigation timeout on valid null tool outputs

### DIFF
--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -50,7 +50,7 @@ export class BrowserToolRegistry implements ToolRegistry {
     let executionResult: { result?: any; error?: string } = {};
 
     try {
-      const tools = this.page.webmcp.tools() || [];
+      const tools = this.page.webmcp?.tools() || [];
       const tool = tools.find((t) => t.name === name);
       if (!tool) {
         return { success: false, error: `no tool named "${name}" was found` };
@@ -64,21 +64,33 @@ export class BrowserToolRegistry implements ToolRegistry {
           (resolve) => {
             let timer: NodeJS.Timeout | null = null;
 
+            const cleanup = () => {
+              if (timer) {
+                clearTimeout(timer);
+                timer = null;
+              }
+              this.page.webmcp?.off?.("toolinvoked", onToolInvoked);
+            };
+
             const onToolInvoked = (call: WebMCPToolCall) => {
               if (!call.tool || call.tool.name === name) {
+                if (timer) clearTimeout(timer);
                 timer = setTimeout(() => {
+                  cleanup();
                   resolve({ success: true, data: "pending form submission" });
                 }, 1000);
               }
             };
 
-            this.page.webmcp.once("toolinvoked", onToolInvoked);
+            const subscribe = this.page.webmcp?.on
+              ? this.page.webmcp.on.bind(this.page.webmcp)
+              : this.page.webmcp?.once?.bind(this.page.webmcp);
+            subscribe?.("toolinvoked", onToolInvoked);
 
             tool
               .execute(args)
               .then((res: WebMCPToolCallResult) => {
-                if (timer) clearTimeout(timer);
-                this.page.webmcp.off("toolinvoked", onToolInvoked);
+                cleanup();
                 if (res.status === "Completed") {
                   resolve({ success: true, data: res.output ?? "Success" });
                 } else if (res.status === "Error") {
@@ -91,10 +103,20 @@ export class BrowserToolRegistry implements ToolRegistry {
                 }
               })
               .catch((err: unknown) => {
-                if (timer) clearTimeout(timer);
-                this.page.webmcp.off("toolinvoked", onToolInvoked);
+                cleanup();
                 const message = err instanceof Error ? err.message : String(err);
-                resolve({ success: false, error: message });
+                if (
+                  message.includes("Execution context was destroyed") ||
+                  message.includes("Target closed") ||
+                  message.includes("navigating")
+                ) {
+                  resolve({
+                    success: true,
+                    data: `Tool ${name} executed and triggered a page navigation.`,
+                  });
+                } else {
+                  resolve({ success: false, error: message });
+                }
               });
           },
         );
@@ -111,7 +133,7 @@ export class BrowserToolRegistry implements ToolRegistry {
       } else {
         const res = await tool.execute(args);
         if (res.status === "Completed") {
-          executionResult.result = res.output !== undefined ? res.output : "Success";
+          executionResult.result = res.output ?? "Success";
         } else if (res.status === "Error") {
           return {
             success: false,
@@ -120,14 +142,6 @@ export class BrowserToolRegistry implements ToolRegistry {
         } else {
           return { success: false, error: `Tool execution status: ${res.status}` };
         }
-      }
-      // If executionResult.result is null, it is due to a navigation happening.
-      if (executionResult.result == null) {
-        await this.page.waitForNavigation();
-        executionResult = await this.page.evaluate(() => {
-          const result = document.querySelector('script[type="application/ld+json"]')?.textContent;
-          return { result, crossDocument: true };
-        });
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
@@ -140,6 +154,7 @@ export class BrowserToolRegistry implements ToolRegistry {
         executionResult = {
           result: `Tool ${name} executed and triggered a page navigation.`,
         };
+      } else {
         return { success: false, error: message };
       }
     }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -82,10 +82,7 @@ export class BrowserToolRegistry implements ToolRegistry {
               }
             };
 
-            const subscribe = this.page.webmcp?.on
-              ? this.page.webmcp.on.bind(this.page.webmcp)
-              : this.page.webmcp?.once?.bind(this.page.webmcp);
-            subscribe?.("toolinvoked", onToolInvoked);
+            this.page.webmcp.on("toolinvoked", onToolInvoked);
 
             tool
               .execute(args)

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -50,7 +50,7 @@ export class BrowserToolRegistry implements ToolRegistry {
     let executionResult: { result?: any; error?: string } = {};
 
     try {
-      const tools = this.page.webmcp?.tools() || [];
+      const tools = this.page.webmcp.tools();
       const tool = tools.find((t) => t.name === name);
       if (!tool) {
         return { success: false, error: `no tool named "${name}" was found` };

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -32,6 +32,15 @@ export async function launchBrowser(
   });
 }
 
+export function isNavigationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Execution context was destroyed") ||
+    message.includes("Target closed") ||
+    message.includes("navigating")
+  );
+}
+
 export class BrowserToolRegistry implements ToolRegistry {
   private currentTools: Tool[] = [];
 
@@ -101,17 +110,13 @@ export class BrowserToolRegistry implements ToolRegistry {
               })
               .catch((err: unknown) => {
                 cleanup();
-                const message = err instanceof Error ? err.message : String(err);
-                if (
-                  message.includes("Execution context was destroyed") ||
-                  message.includes("Target closed") ||
-                  message.includes("navigating")
-                ) {
+                if (isNavigationError(err)) {
                   resolve({
                     success: true,
                     data: `Tool ${name} executed and triggered a page navigation.`,
                   });
                 } else {
+                  const message = err instanceof Error ? err.message : String(err);
                   resolve({ success: false, error: message });
                 }
               });
@@ -141,17 +146,13 @@ export class BrowserToolRegistry implements ToolRegistry {
         }
       }
     } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : String(e);
-      if (
-        message.includes("Execution context was destroyed") ||
-        message.includes("Target closed") ||
-        message.includes("navigating")
-      ) {
+      if (isNavigationError(e)) {
         await new Promise((r) => setTimeout(r, 500));
         executionResult = {
           result: `Tool ${name} executed and triggered a page navigation.`,
         };
       } else {
+        const message = e instanceof Error ? e.message : String(e);
         return { success: false, error: message };
       }
     }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -69,7 +69,7 @@ export class BrowserToolRegistry implements ToolRegistry {
                 clearTimeout(timer);
                 timer = null;
               }
-              this.page.webmcp?.off?.("toolinvoked", onToolInvoked);
+              this.page.webmcp.off("toolinvoked", onToolInvoked);
             };
 
             const onToolInvoked = (call: WebMCPToolCall) => {

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -126,14 +126,13 @@ describe("BrowserToolRegistry", () => {
     assert.deepStrictEqual(result, { error: "Execution failed in page context" });
   });
 
-  it("should handle navigation when tool execution output is null", async () => {
+  it("should return Success and avoid navigation wait when tool execution output is null", async () => {
     const page = new MockBrowserPage();
-    page.evaluateResult = { result: '{"type":"JSON-LD"}', crossDocument: true };
     page.webmcp = {
       tools: () => [
         {
-          name: "nav_tool",
-          description: "Navigates page",
+          name: "null_output_tool",
+          description: "Tool returning null output",
           inputSchema: { type: "object" },
           execute: async () => {
             return { status: "Completed", output: null };
@@ -143,16 +142,41 @@ describe("BrowserToolRegistry", () => {
     };
 
     const registry = createRegistry(page);
-    const result = await registry.executeTool("nav_tool", {});
+    const result = await registry.executeTool("null_output_tool", {});
 
-    assert.strictEqual(page.navigationCalls.length, 1);
-    assert.deepStrictEqual(result, { type: "JSON-LD" });
+    assert.strictEqual(page.navigationCalls.length, 0);
+    assert.strictEqual(result, "Success");
+  });
+
+  it("should handle cross-document navigation when execution context is destroyed during tool call", async () => {
+    const page = new MockBrowserPage();
+    page.webmcp = {
+      tools: () => [
+        {
+          name: "nav_form_tool",
+          description: "Tool triggering page navigation",
+          inputSchema: { type: "object" },
+          execute: async () => {
+            throw new Error("Execution context was destroyed");
+          },
+        },
+      ],
+    };
+
+    const registry = createRegistry(page);
+    const result = await registry.executeTool("nav_form_tool", {});
+
+    assert.strictEqual(result, "Tool nav_form_tool executed and triggered a page navigation.");
   });
 
   it("should handle declarative tool without autosubmit, listen for toolinvoked, and resolve pending form submission on timeout", async () => {
     const listeners: Record<string, Function[]> = {};
     const page = new MockBrowserPage();
     page.webmcp = {
+      on: (event: string, cb: Function) => {
+        listeners[event] = listeners[event] || [];
+        listeners[event].push(cb);
+      },
       once: (event: string, cb: Function) => {
         listeners[event] = listeners[event] || [];
         listeners[event].push(cb);

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from "node:assert";
 import { describe, it } from "node:test";
-import { BrowserPage, BrowserToolRegistry } from "../evaluator/browser.js";
+import { BrowserPage, BrowserToolRegistry, isNavigationError } from "../evaluator/browser.js";
 
 class MockBrowserPage {
   public evaluateResult: unknown = [];
@@ -261,5 +261,20 @@ describe("BrowserToolRegistry", () => {
     const result = await registry.executeTool("bool_tool", {});
 
     assert.strictEqual(result, false);
+  });
+});
+
+describe("isNavigationError", () => {
+  it("should return true for known navigation error strings and Error objects", () => {
+    assert.strictEqual(isNavigationError(new Error("Execution context was destroyed")), true);
+    assert.strictEqual(isNavigationError(new Error("Target closed")), true);
+    assert.strictEqual(isNavigationError("Error: Frame is navigating away"), true);
+  });
+
+  it("should return false for unrelated errors or objects", () => {
+    assert.strictEqual(isNavigationError(new Error("Syntax error")), false);
+    assert.strictEqual(isNavigationError(null), false);
+    assert.strictEqual(isNavigationError(undefined), false);
+    assert.strictEqual(isNavigationError(42), false);
   });
 });


### PR DESCRIPTION
## What this PR does
This PR fixes a bug in [`evals-cli/src/evaluator/browser.ts`](file:///usr/local/google/home/kaskulikowski/Documents/workspaces/google-workspaces/webmcp-tools/evals-cli/src/evaluator/browser.ts) where tools returning `null` or `undefined` caused the test runner to freeze for 30 seconds.

## Why we need this
When a browser tool finished successfully and returned `null`, the code wrongly assumed the web page was opening a new URL. It called `waitForNavigation()`, which waited for 30 seconds until timing out with a `TimeoutError`.

## What changed
- **[`evals-cli/src/evaluator/browser.ts`](file:///usr/local/google/home/kaskulikowski/Documents/workspaces/google-workspaces/webmcp-tools/evals-cli/src/evaluator/browser.ts)**:
  - Updated tool return logic so `null` and `undefined` outputs return `"Success"` right away.
  - Removed the unsafe `waitForNavigation()` call that caused the 30-second hang.
  - Cleaned up event listeners for form tools so they unhook properly after running.
- **[`evals-cli/src/test/browserToolRegistry.test.ts`](file:///usr/local/google/home/kaskulikowski/Documents/workspaces/google-workspaces/webmcp-tools/evals-cli/src/test/browserToolRegistry.test.ts#L130-L150)**:
  - Updated unit tests to check that `null` tool outputs finish immediately without waiting for page navigation.