### PR TITLE
refactor(evals): remove null result navigation fallback

### DIFF
--- a/evals-cli/examples/french-bistro/evals-toolautosubmit.json
+++ b/evals-cli/examples/french-bistro/evals-toolautosubmit.json
@@ -28,9 +28,13 @@
             "$contains": "anniversary"
           }
         },
-        "result": {
-          "$contains": "welcoming you"
-        }
+        "result": [
+          {
+            "@context": "https://schema.org",
+            "@type": "Message",
+            "text": "Hello Bob Smith,\nWe look forward to welcoming you on:\n\n2026-08-08 at 18:30\nParty of 2 • Terrace"
+          }
+        ]
       }
     ]
   },
@@ -56,9 +60,13 @@
           "guests": "6",
           "seating": "Private Booth"
         },
-        "result": {
-          "$contains": "welcoming you"
-        }
+        "result": [
+          {
+            "@context": "https://schema.org",
+            "@type": "Message",
+            "text": "Hello Alice Wong,\nWe look forward to welcoming you on:\n\n2026-08-07 at 20:00\nParty of 6 • Private Booth"
+          }
+        ]
       }
     ]
   }

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -121,27 +121,9 @@ export class BrowserToolRegistry implements ToolRegistry {
           return { success: false, error: `Tool execution status: ${res.status}` };
         }
       }
-      // If executionResult.result is null, it is due to a navigation happening.
-      if (executionResult.result == null) {
-        await this.page.waitForNavigation();
-        executionResult = await this.page.evaluate(() => {
-          const result = document.querySelector('script[type="application/ld+json"]')?.textContent;
-          return { result, crossDocument: true };
-        });
-      }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      if (
-        message.includes("Execution context was destroyed") ||
-        message.includes("Target closed") ||
-        message.includes("navigating")
-      ) {
-        await new Promise((r) => setTimeout(r, 500));
-        executionResult = {
-          result: `Tool ${name} executed and triggered a page navigation.`,
-        };
-        return { success: false, error: message };
-      }
+      return { success: false, error: `Tool execution error: ${message}` };
     }
 
     let r = executionResult.result;

--- a/evals-cli/src/evaluator/browser.ts
+++ b/evals-cli/src/evaluator/browser.ts
@@ -80,7 +80,10 @@ export class BrowserToolRegistry implements ToolRegistry {
                 if (timer) clearTimeout(timer);
                 this.page.webmcp.off("toolinvoked", onToolInvoked);
                 if (res.status === "Completed") {
-                  resolve({ success: true, data: res.output ?? "Success" });
+                  resolve({
+                    success: true,
+                    data: res.output !== undefined ? res.output : "Success",
+                  });
                 } else if (res.status === "Error") {
                   resolve({
                     success: false,
@@ -152,6 +155,6 @@ export class BrowserToolRegistry implements ToolRegistry {
   async executeTool(name: string, args: Record<string, unknown> = {}): Promise<any> {
     const outcome = await this.executeToolChecked(name, args);
     if (!outcome.success) return { error: outcome.error };
-    return outcome.result ?? "Success";
+    return outcome.result !== undefined ? outcome.result : "Success";
   }
 }

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -120,6 +120,33 @@ describe("BrowserToolRegistry", () => {
     assert.deepStrictEqual(result, { error: "Execution failed in page context" });
   });
 
+  it("should preserve null return values in executeTool and executeToolChecked", async () => {
+    const page = new MockBrowserPage();
+    page.webmcp = {
+      tools: () => [
+        {
+          name: "null_tool",
+          description: "Tool that returns explicit null output",
+          inputSchema: { type: "object" },
+          execute: async () => ({
+            status: "Completed",
+            output: null,
+          }),
+        },
+      ],
+    };
+
+    const registry = createRegistry(page);
+
+    // 1. Verify executeToolChecked preserves null inside { success: true, result: null }
+    const checkedResult = await registry.executeToolChecked("null_tool", {});
+    assert.deepStrictEqual(checkedResult, { success: true, result: null });
+
+    // 2. Verify executeTool returns null directly (instead of coercing to "Success")
+    const result = await registry.executeTool("null_tool", {});
+    assert.strictEqual(result, null);
+  });
+
   it("should handle declarative tool without autosubmit, listen for toolinvoked, and resolve pending form submission on timeout", async () => {
     const listeners: Record<string, Function[]> = {};
     const page = new MockBrowserPage();

--- a/evals-cli/src/test/browserToolRegistry.test.ts
+++ b/evals-cli/src/test/browserToolRegistry.test.ts
@@ -10,7 +10,6 @@ import { BrowserPage, BrowserToolRegistry } from "../evaluator/browser.js";
 class MockBrowserPage {
   public evaluateResult: unknown = [];
   public evaluateCalls: Array<{ fn: string | Function; args: unknown[] }> = [];
-  public navigationCalls: Array<{ options?: unknown }> = [];
   public webmcp: any = {
     tools: () => [],
   };
@@ -18,11 +17,6 @@ class MockBrowserPage {
   async evaluate(fn: string | Function, ...args: unknown[]): Promise<any> {
     this.evaluateCalls.push({ fn, args });
     return this.evaluateResult;
-  }
-
-  async waitForNavigation(options?: unknown): Promise<any> {
-    this.navigationCalls.push({ options });
-    return {};
   }
 }
 
@@ -124,29 +118,6 @@ describe("BrowserToolRegistry", () => {
     const result = await registry.executeTool("failing_tool", {});
 
     assert.deepStrictEqual(result, { error: "Execution failed in page context" });
-  });
-
-  it("should handle navigation when tool execution output is null", async () => {
-    const page = new MockBrowserPage();
-    page.evaluateResult = { result: '{"type":"JSON-LD"}', crossDocument: true };
-    page.webmcp = {
-      tools: () => [
-        {
-          name: "nav_tool",
-          description: "Navigates page",
-          inputSchema: { type: "object" },
-          execute: async () => {
-            return { status: "Completed", output: null };
-          },
-        },
-      ],
-    };
-
-    const registry = createRegistry(page);
-    const result = await registry.executeTool("nav_tool", {});
-
-    assert.strictEqual(page.navigationCalls.length, 1);
-    assert.deepStrictEqual(result, { type: "JSON-LD" });
   });
 
   it("should handle declarative tool without autosubmit, listen for toolinvoked, and resolve pending form submission on timeout", async () => {

--- a/evals-cli/src/test/smokeEvaluator.test.ts
+++ b/evals-cli/src/test/smokeEvaluator.test.ts
@@ -231,8 +231,6 @@ class FakePage {
     return [];
   }
 
-  async waitForNavigation(): Promise<void> {}
-
   async close(): Promise<void> {
     this.closed = true;
   }


### PR DESCRIPTION
TIL `tool.execute()` can return null for non-navigations, so Puppeteer cannot reliably infer navigation from null outputs. 

Moreover, Puppeteer (using CDP) actually retrieves "automatically" the response after navigation. That's why I'm now removing the `waitForNavigation` handling on null results and clean up mock navigation tests.

/me happy!