### PR TITLE
refactor: update tool inputSchema to support object and string types

### DIFF
--- a/demos/french-bistro/agent-worker.js
+++ b/demos/french-bistro/agent-worker.js
@@ -108,9 +108,10 @@ async function handleUserSubmit(text, port, requestId) {
       const functionDeclarations = tools.map((tool) => ({
         name: tool.name,
         description: tool.description,
-        parametersJsonSchema: tool.inputSchema
-          ? JSON.parse(tool.inputSchema)
-          : { type: 'object', properties: {} },
+        parametersJsonSchema:
+          typeof tool.inputSchema === 'string'
+            ? JSON.parse(tool.inputSchema)
+            : tool.inputSchema || { type: 'object', properties: {} },
       }));
       return { systemInstruction, tools: [{ functionDeclarations }] };
     };

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -32,15 +32,14 @@ async function getConfig() {
   ];
 
   const tools = await getTools();
-  const functionDeclarations = tools.map((tool) => {
-    return {
-      name: tool.name,
-      description: tool.description,
-      parametersJsonSchema: tool.inputSchema
+  const functionDeclarations = tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    parametersJsonSchema:
+      typeof tool.inputSchema === 'string'
         ? JSON.parse(tool.inputSchema)
-        : { type: 'object', properties: {} },
-    };
-  });
+        : tool.inputSchema || { type: 'object', properties: {} },
+  }));
 
   return { systemInstruction, tools: [{ functionDeclarations }] };
 }

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -65,7 +65,10 @@ async function getConfig() {
       .map((tool) => ({
         name: tool.name,
         description: tool.description,
-        parametersJsonSchema: JSON.parse(tool.inputSchema),
+        parametersJsonSchema:
+          typeof tool.inputSchema === 'string'
+            ? JSON.parse(tool.inputSchema)
+            : tool.inputSchema || { type: 'object', properties: {} },
       }));
 
     return { systemInstruction, tools: [{ functionDeclarations }] };
@@ -80,9 +83,10 @@ async function getConfig() {
   const functionDeclarations = tools.map((tool) => ({
     name: tool.name,
     description: tool.description,
-    parametersJsonSchema: tool.inputSchema
-      ? JSON.parse(tool.inputSchema)
-      : { type: 'object', properties: {} },
+    parametersJsonSchema:
+      typeof tool.inputSchema === 'string'
+        ? JSON.parse(tool.inputSchema)
+        : tool.inputSchema || { type: 'object', properties: {} },
   }));
 
   return { systemInstruction, tools: [{ functionDeclarations }] };

--- a/demos/shared/webmcp-polyfill.js
+++ b/demos/shared/webmcp-polyfill.js
@@ -70,7 +70,7 @@
       tools.push({
         name,
         description,
-        inputSchema: JSON.stringify(inputSchema),
+        inputSchema,
         window: win,
         origin: win.origin,
         _form: form,
@@ -149,10 +149,10 @@
         throw new DOMException(`Tool "${name}" is already registered`, 'InvalidStateError');
       }
 
-      let stringifiedInputSchema = '';
-      if (tool.inputSchema) {
+      const inputSchema = tool.inputSchema;
+      if (inputSchema) {
         try {
-          stringifiedInputSchema = JSON.stringify(tool.inputSchema);
+          JSON.stringify(inputSchema);
         } catch (e) {
           throw new TypeError('Failed to stringify inputSchema');
         }
@@ -168,16 +168,16 @@
         });
       }
 
-      // Store a normalized tool copy with a stringified inputSchema
+      // Store a normalized tool copy
       const normalizedTool = {
         name,
         description,
-        inputSchema: stringifiedInputSchema,
+        inputSchema,
         window: window,
         origin: window.origin,
         annotations: tool.annotations,
         _execute: tool.execute,
-      }
+      };
 
       window.__webmcp_registered_tools.set(name, normalizedTool);
       this.dispatchEvent(new Event('toolchange'));

--- a/demos/sport-shop-angular/src/app/services/agent.service.ts
+++ b/demos/sport-shop-angular/src/app/services/agent.service.ts
@@ -109,21 +109,14 @@ export class AgentService {
     ].join(' ');
 
     const tools = await this.getTools();
-    const functionDeclarations = tools.map((tool) => {
-      let parametersJsonSchema: any = { type: 'object', properties: {} };
-      if (tool.inputSchema) {
-        try {
-          parametersJsonSchema = JSON.parse(tool.inputSchema);
-        } catch (e) {
-          console.error('Error parsing tool inputSchema:', e);
-        }
-      }
-      return {
-        name: tool.name,
-        description: tool.description || '',
-        parametersJsonSchema
-      };
-    });
+    const functionDeclarations = tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description || '',
+      parametersJsonSchema:
+        typeof tool.inputSchema === 'string'
+          ? JSON.parse(tool.inputSchema)
+          : tool.inputSchema || { type: 'object', properties: {} },
+    }));
 
     return { systemInstruction, tools: [{ functionDeclarations }] };
   }


### PR DESCRIPTION
Updates the WebMCP polyfill and demo agent implementations to support inputSchema as an object on RegisteredTool (aligning with the updated WebMCP spec), while maintaining backwards-compatibility for stringified schemas.
    
References:
    - https://chromium-review.googlesource.com/c/chromium/src/+/8248081
    - https://github.com/webmachinelearning/webmcp/pull/241
