### PR TITLE
refactor: update tool execution to support object arguments

### DIFF
--- a/demos/french-bistro/agent-worker.js
+++ b/demos/french-bistro/agent-worker.js
@@ -134,7 +134,7 @@ async function handleUserSubmit(text, port, requestId) {
             const tool = tools.find((t) => t.name == name);
             if (!tool) throw new Error(`Tool ${name} not found`);
             
-            const { result, error, aborted } = await requestToolExecution(port, tool, JSON.stringify(args));
+            const { result, error, aborted } = await requestToolExecution(port, tool, args);
             if (aborted) {
               appendMessage('System', `⚙️ Aborted tool: ${name}`, 'system');
               finalResponseGiven = true;

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -122,9 +122,21 @@ function initSharedWorker(apiKey) {
           agentSendBtn.textContent = 'Abort';
           agentSendBtn.disabled = false;
 
-          const result = await document.modelContext.executeTool(tool, payload.args, {
-            signal: abortController.signal,
-          });
+          let result;
+          try {
+            result = await document.modelContext.executeTool(tool, payload.args, {
+              signal: abortController.signal,
+            });
+          } catch (e) {
+            // TODO: Remove this when executeTool doesn't accept JSON stringified inputArgs anymore in Chrome Stable.
+            if (e.message.startsWith('Failed to parse input')) {
+              result = await document.modelContext.executeTool(tool, JSON.stringify(payload.args), {
+                signal: abortController.signal,
+              });
+            } else {
+              throw e;
+            }
+          }
           worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: { result }, id });
         } catch (error) {
           const aborted = abortController?.signal.aborted;
@@ -256,9 +268,21 @@ async function handleUserSubmit() {
             agentSendBtn.textContent = 'Abort';
             agentSendBtn.disabled = false;
 
-            const result = await document.modelContext.executeTool(tool, JSON.stringify(args), {
-              signal: abortController.signal,
-            });
+            let result;
+            try {
+              result = await document.modelContext.executeTool(tool, args, {
+                signal: abortController.signal,
+              });
+            } catch (e) {
+              // TODO: Remove this when executeTool doesn't accept JSON stringified inputArgs anymore in Chrome Stable.
+              if (e.message.startsWith('Failed to parse input')) {
+                result = await document.modelContext.executeTool(tool, JSON.stringify(args), {
+                  signal: abortController.signal,
+                });
+              } else {
+                throw e;
+              }
+            }
             toolResponses.push({ functionResponse: { name, response: { result } } });
           } catch (error) {
             if (abortController?.signal.aborted) {

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -184,12 +184,21 @@ async function handleUserSubmit() {
       } else {
         const toolResponses = [];
         for (const { name, args } of functionCalls) {
-          const inputArgs = JSON.stringify(args);
           try {
             appendMessage('System', `⚙️ Executing tool: ${name}...`, 'tool-indicator');
             const tools = await getTools();
             const tool = tools.find((t) => t.name == name);
-            const result = await document.modelContext.executeTool(tool, inputArgs);
+            let result;
+            try {
+              result = await document.modelContext.executeTool(tool, args);
+            } catch (e) {
+              // TODO: Remove this when executeTool doesn't accept JSON stringified inputArgs anymore in Chrome Stable.
+              if (e.message.startsWith('Failed to parse input')) {
+                result = await document.modelContext.executeTool(tool, JSON.stringify(args));
+              } else {
+                throw e;
+              }
+            }
 
             if (codeModeCheckbox.checked && name === 'execute_batch' && result && Array.isArray(result.outputs)) {
               for (const out of result.outputs) {

--- a/demos/shared/webmcp-batch.js
+++ b/demos/shared/webmcp-batch.js
@@ -119,7 +119,18 @@ export function registerExecuteBatchTool(options) {
         if (!targetTool) {
           throw new Error(`Tool ${toolName} not found`);
         }
-        return await document.modelContext.executeTool(targetTool, JSON.stringify(args || {}));
+        let result;
+        try {
+          result = await document.modelContext.executeTool(targetTool, args || {});
+        } catch (e) {
+          // TODO: Remove this when executeTool doesn't accept JSON stringified inputArgs anymore in Chrome Stable.
+          if (e.message.startsWith('Failed to parse input')) {
+            result = await document.modelContext.executeTool(targetTool, JSON.stringify(args || {}));
+          } else {
+            throw e;
+          }
+        }
+        return result;
       };
       
       const outputs = await executeDeclarativeBatch(steps, executeToolFn);

--- a/demos/sport-shop-angular/src/app/services/agent.service.ts
+++ b/demos/sport-shop-angular/src/app/services/agent.service.ts
@@ -180,10 +180,20 @@ export class AgentService {
               const tool = tools.find((t) => t.name === name);
               if (!tool) throw new Error(`Tool ${name} not found`);
 
-              const rawResult = await (modelContext as any).executeTool(
-                tool,
-                JSON.stringify(args)
-              );
+              let rawResult: any;
+              try {
+                rawResult = await (modelContext as any).executeTool(tool, args);
+              } catch (e: any) {
+                // TODO: Remove this when executeTool doesn't accept JSON stringified inputArgs anymore in Chrome Stable.
+                if (e.message.startsWith('Failed to parse input')) {
+                  rawResult = await (modelContext as any).executeTool(
+                    tool,
+                    JSON.stringify(args)
+                  );
+                } else {
+                  throw e;
+                }
+              }
               toolResponses.push({
                 functionResponse: { name, response: { result: rawResult } }
               });


### PR DESCRIPTION
Updates tool execution for in-page agent demos to pass parsed input arguments to document.modelContext.executeTool, while retaining backward compatibility for versions of Chrome that still expect a JSON string.

References:
- https://chromium-review.googlesource.com/c/chromium/src/+/8250826
- https://github.com/webmachinelearning/webmcp/pull/246