### PR TITLE
feat(evals): include browser console logs in reports

### DIFF
--- a/webmcp-evals/src/evaluator/browserEvaluator.ts
+++ b/webmcp-evals/src/evaluator/browserEvaluator.ts
@@ -4,7 +4,7 @@
  */
 
 import { WebmcpConfig } from "../types/config.js";
-import { Eval, TestResult, TestResults } from "../types/evals.js";
+import { BrowserLogEntry, Eval, TestResult, TestResults } from "../types/evals.js";
 import { ToolCall } from "../types/tools.js";
 import { countExpectedCalls, evaluateExecutionTrajectory } from "../utils.js";
 
@@ -90,8 +90,14 @@ async function runSingleBrowserTest(
   runIndex: number,
 ): Promise<TestResult[]> {
   let page: BrowserPage | null = null;
+  const browserLogs: BrowserLogEntry[] = [];
   try {
-    page = await setupBrowserPage(browser, config.url);
+    page = await browser.newPage();
+    collectBrowserLogs(page, browserLogs);
+    await page.goto(config.url, {
+      waitUntil: "networkidle2",
+      timeout: 30000,
+    });
     const registry = new BrowserToolRegistry(page);
     const currentTools = registry.getCurrentTools();
 
@@ -113,6 +119,7 @@ async function runSingleBrowserTest(
       { text: evalResult.text },
       evalResult.steps || [],
       runIndex,
+      browserLogs,
     );
   } catch (e: any) {
     logger.warn("Error running browser test:", e);
@@ -123,6 +130,7 @@ async function runSingleBrowserTest(
         outcome: "error",
         runIndex,
         stepIndex: 1,
+        browserLogs,
       },
     ];
   } finally {
@@ -132,13 +140,18 @@ async function runSingleBrowserTest(
   }
 }
 
-async function setupBrowserPage(browser: Browser, url: string): Promise<BrowserPage> {
-  const page = await browser.newPage();
-  await page.goto(url, {
-    waitUntil: "networkidle2",
-    timeout: 30000,
+function collectBrowserLogs(page: BrowserPage, logs: BrowserLogEntry[]): void {
+  page.on("console", (message) => {
+    const type = message.type();
+    if (type === "error" || type === "warn" || type === "assert") {
+      logs.push({ type, text: message.text() });
+    }
   });
-  return page;
+
+  page.on("pageerror", (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    logs.push({ type: "pageerror", text: message });
+  });
 }
 
 function buildTestResults(
@@ -147,6 +160,7 @@ function buildTestResults(
   resultPayload: { text?: string },
   trajectory: any[],
   runIndex: number,
+  browserLogs: BrowserLogEntry[],
 ): TestResult[] {
   const testResults: TestResult[] = [];
   const trajectories = test.expectedCall
@@ -162,6 +176,7 @@ function buildTestResults(
       trajectory,
       runIndex,
       stepIndex: 1,
+      browserLogs,
     });
   } else {
     let stepIndex = 1;
@@ -184,6 +199,7 @@ function buildTestResults(
         trajectory,
         runIndex,
         stepIndex: stepIndex++,
+        browserLogs,
       });
     }
   }

--- a/webmcp-evals/src/report/report.ts
+++ b/webmcp-evals/src/report/report.ts
@@ -4,7 +4,7 @@
  */
 
 import { Config, WebmcpConfig } from "../types/config.js";
-import { Message, TestResult, TestResults, FunctionCall } from "../types/evals.js";
+import { BrowserLogEntry, Message, TestResult, TestResults, FunctionCall } from "../types/evals.js";
 import { matchesArgument } from "../matcher.js";
 import { sortObjectKeys } from "../utils.js";
 
@@ -340,6 +340,7 @@ function renderRunIteration(run: TestRun, totalRuns: number): string {
             ${run.steps.map((step) => renderStepDetails(step, run.steps.length)).join("")}
           </div>
 
+          ${renderBrowserLogs(run.steps[0]?.result.browserLogs)}
           ${renderTrajectory(run.trajectory)}
         </div>
       </details>
@@ -480,6 +481,44 @@ function renderStepDetails(stepEval: TestStep, totalSteps: number): string {
         </table>
       </div>
     </div>
+  `;
+}
+
+function renderBrowserLogs(logs?: BrowserLogEntry[]): string {
+  if (!logs || logs.length === 0) return "";
+
+  const errorCount = logs.filter((log) => log.type === "error" || log.type === "pageerror").length;
+  const hasErrors = errorCount > 0;
+
+  const badgeClass = hasErrors
+    ? "bg-rose-100 text-rose-800 border-rose-200"
+    : "bg-amber-100 text-amber-800 border-amber-200";
+
+  return `
+    <details class="group/logs bg-white rounded border ${hasErrors ? "border-rose-200" : "border-amber-200"} mt-6">
+      <summary class="p-3 font-medium text-sm text-slate-700 cursor-pointer hover:bg-slate-50 border-b border-transparent group-open/logs:border-slate-200 flex items-center justify-between">
+        <span>Browser Console Logs</span>
+        <span class="px-2 py-0.5 rounded text-[10px] font-semibold border ${badgeClass}">
+          ${logs.length} message${logs.length !== 1 ? "s" : ""} (${errorCount} error${errorCount !== 1 ? "s" : ""})
+        </span>
+      </summary>
+      <div class="p-4 space-y-2">
+        ${logs
+          .map((log) => {
+            const isError = log.type === "error" || log.type === "pageerror";
+            return `
+              <div class="flex items-start space-x-2">
+                <span class="px-1.5 py-0.5 rounded text-[10px] font-semibold border shrink-0 mt-0.5 ${
+                  isError
+                    ? "bg-rose-100 text-rose-800 border-rose-200"
+                    : "bg-amber-100 text-amber-800 border-amber-200"
+                } uppercase">${escapeHtml(log.type)}</span>
+                <pre class="whitespace-pre-wrap text-xs ${isError ? "text-rose-700" : "text-amber-700"} bg-slate-50 p-3 rounded-md border border-slate-200 font-mono m-0 flex-1">${escapeHtml(log.text)}</pre>
+              </div>`;
+          })
+          .join("")}
+      </div>
+    </details>
   `;
 }
 

--- a/webmcp-evals/src/test/report.test.ts
+++ b/webmcp-evals/src/test/report.test.ts
@@ -152,4 +152,64 @@ describe("Report Grouping & Rendering", () => {
     const htmlDefault = renderReport(mockConfig, testResults);
     assert.match(htmlDefault, /chrome-canary/);
   });
+
+  it("renders browser console logs per run with error counts", () => {
+    const results: TestResult[] = [
+      {
+        test: {
+          name: "Console errors",
+          messages: [{ role: "user", type: "message", content: "Load the page" }],
+          expectedCall: [{ functionName: "load", arguments: {} }],
+        },
+        response: { functionName: "load", args: {} },
+        outcome: "pass",
+        browserLogs: [
+          { type: "warning", text: "deprecated API usage" },
+          { type: "error", text: "TypeError: x is not a function" },
+          { type: "pageerror", text: "Uncaught ReferenceError: foo is not defined" },
+        ],
+      },
+    ];
+
+    const html = renderReport(mockConfig, {
+      results,
+      testCount: 1,
+      passCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+
+    assert.match(html, /Browser Console Logs/);
+    assert.match(html, /3 messages \(2 errors\)/);
+    assert.match(html, /deprecated API usage/);
+    assert.match(html, /TypeError: x is not a function/);
+    assert.match(html, /Uncaught ReferenceError: foo is not defined/);
+    assert.match(html, />warning</);
+    assert.match(html, />error</);
+    assert.match(html, />pageerror</);
+  });
+
+  it("omits the browser console logs section when no logs were captured", () => {
+    const results: TestResult[] = [
+      {
+        test: {
+          name: "Clean page",
+          messages: [{ role: "user", type: "message", content: "Load the page" }],
+          expectedCall: [{ functionName: "load", arguments: {} }],
+        },
+        response: { functionName: "load", args: {} },
+        outcome: "pass",
+      },
+    ];
+
+    const html = renderReport(mockConfig, {
+      results,
+      testCount: 1,
+      passCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+
+    assert.doesNotMatch(html, /Browser Console Logs/);
+  });
 });

--- a/webmcp-evals/src/types/evals.ts
+++ b/webmcp-evals/src/types/evals.ts
@@ -68,6 +68,13 @@ export interface TrajectoryStep {
   availableTools?: Tool[];
 }
 
+export type BrowserLogEntry = {
+  // Console message type: "log" | "debug" | "info" | "error" | "warning" | ...
+  // or "pageerror" for uncaught JavaScript exceptions.
+  type: string;
+  text: string;
+};
+
 export type TestResult = {
   test: Eval;
   response: ToolCall | null;
@@ -75,6 +82,9 @@ export type TestResult = {
   trajectory?: TrajectoryStep[];
   runIndex?: number;
   stepIndex?: number;
+  // Browser console messages and uncaught page errors collected while the
+  // test page was open (browser evals only).
+  browserLogs?: BrowserLogEntry[];
 };
 
 export type TestResults = {


### PR DESCRIPTION
## Summary

Closes #62

Browser evaluations can trigger JavaScript code on the target page that logs errors or warnings to the developer tools console. These failures were previously invisible in evals reports, making it hard to diagnose why an otherwise passing test misbehaved.

This PR captures browser console messages (`error`, `warn`, `assert`) and uncaught page errors (`pageerror`) during each browser eval and surfaces them in the HTML and JSON reports.

## Changes

- **types/evals.ts**: added `BrowserLogEntry` type and `browserLogs?: BrowserLogEntry[]` on `TestResult`.
- **evaluator/browserEvaluator.ts**: attach `console` and `pageerror` listeners on the test page before navigation, collect relevant messages per test run.
- **report/report.ts**: render a collapsible "Browser Console Logs" section per run, with error/pageerror entries highlighted in red and warnings in amber, plus a message/error count badge.
- **test/report.test.ts**: unit tests for rendering the logs section and omitting it when no logs were captured.

## Notes

- Only `error`, `warn`, `assert` console types and `pageerror` events are captured to keep report noise low.
- JSON reporter picks up `browserLogs` automatically since it serializes `TestResults`.
- Console logs are collected per page (one page per test), so all steps of a run share the same logs.