### PR TITLE
Add BestPrice.gr production WebMCP site

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -57,6 +57,8 @@ A curated list of awesome WebMCP demos, libraries, and tools.
   - **Example Prompt:** "Find me an apartment in Austin", then "Find me an apartment with AC under $1,000,000."
 - [Luxe Leather](https://googlechromelabs.github.io/webmcp-tools/demos/leather-bag/) - A premium e-commerce site for hand-crafted leather goods built with Angular and WebMCP. This demo showcases how an AI agent can interact with a web application to search products, check policies, and manage a shopping cart using declarative tools.
   - **Example Prompt:** "Find a handmade leather bag, check if they have a 30-day return policy, and if yes, add the brown one to my cart"
+- [BestPrice.gr](https://www.bestprice.gr/) - A live Greek comparison-shopping site with page-aware WebMCP tools. Agents can search the catalog, inspect visible products, use listing filters and sorting, read product specifications, compare current merchant offers, and summarize price history.
+  - **Example Prompt:** "Search BestPrice for an iPhone 16 and show me the most relevant results."
 - [WebMCP Smart Home](https://googlechromelabs.github.io/webmcp-tools/demos/smart-home/) - A sleek, interactive dashboard where an AI agent can dynamically reconfigure home control components (e.g., front door cameras, thermostats, smart lights, energy distribution) based on user intents.
   - **Example Prompt:** "Someone is at the door. Show me."
 - [webmcp.cool](https://webmcp.cool/) - A live, curated directory of WebMCP-enabled websites with a JSON API for agent-side discovery. Also registers its own WebMCP tools so agents can interact with the registry directly.


### PR DESCRIPTION
Adds BestPrice.gr, a live comparison-shopping site that registers page-aware WebMCP tools on its homepage, search/category listings, and product pages.

The entry keeps the claim concrete and includes a prompt that exercises the homepage `search_bestprice` tool. Depending on the open page, the production runtime also exposes tools for visible products, filters, sorting, product details/specifications, offer comparison, and price-history summaries.

Public implementation notes and a page/tool map: https://www.bestprice.gr/mcp#mcp-webmcp
Machine-readable inventory: https://www.bestprice.gr/.well-known/webmcp.json

The runtime was verified in a compatible Chrome session before submission: `navigator.modelContext` is available and tools register by page rather than only publishing an origin-trial token.