### PR TITLE
feat(evals): populate trajectory for local evals

### DIFF
--- a/webmcp-evals/src/backends/index.ts
+++ b/webmcp-evals/src/backends/index.ts
@@ -23,10 +23,15 @@ export type { BrowserPage } from "../evaluator/browser.js";
  * empty array means the model responded with text and no tool calls.
  *
  * `text` is the model's final natural-language response, if any.
+ *
+ * `steps` is the per-step trajectory — the model's own text, reasoning, tool
+ * calls and tool results for each agent-loop step. Optional so a backend that
+ * cannot expose it still satisfies the interface.
  */
 export type LocalEvalResult = {
   toolCalls: ToolCall[];
   text?: string;
+  steps?: TrajectoryStep[];
 };
 
 export type BrowserEvalResult = {

--- a/webmcp-evals/src/backends/vercel.ts
+++ b/webmcp-evals/src/backends/vercel.ts
@@ -106,7 +106,14 @@ export class VercelBackend implements Backend {
       }
     }
 
-    return { toolCalls, text: aiResult.text };
+    const steps: TrajectoryStep[] = (aiResult.steps ?? []).map((step) => ({
+      text: step.text,
+      reasoningText: step.reasoningText,
+      toolCalls: step.toolCalls,
+      toolResults: step.toolResults,
+    }));
+
+    return { toolCalls, text: aiResult.text, steps };
   }
 
   async executeInBrowserEval(test: Eval, registry: ToolRegistry): Promise<BrowserEvalResult> {

--- a/webmcp-evals/src/evaluator/localEvaluator.ts
+++ b/webmcp-evals/src/evaluator/localEvaluator.ts
@@ -54,6 +54,7 @@ export async function executeLocalEvals(
             test,
             response: null,
             outcome: "pass",
+            trajectory: response.steps,
             runIndex: r + 1,
             stepIndex: 1,
           };
@@ -73,6 +74,7 @@ export async function executeLocalEvals(
               },
               response: traj.actual,
               outcome: traj.outcome,
+              trajectory: response.steps,
               runIndex: r + 1,
               stepIndex: stepIndex++,
             };


### PR DESCRIPTION
> **Disclosure:** this change was written by an AI agent (Claude Opus 5 via [Pi](https://github.com/badlogic/pi-mono)), directed and reviewed by @yoavweiss. The verification numbers below were produced by real runs, not estimated. Please review accordingly.

## Problem

`TestResult.trajectory` and the report's **Trajectory** section (Thoughts / Tool Calls / Tool Results) already exist, and `BrowserEvalResult` carries `steps` to populate them.

`LocalEvalResult` has no equivalent field, so nothing ever sets `trajectory` on the local path. `renderTrajectory()` returns early for every local run and the section never appears.

The data is already in hand — `executeLocalEvals` iterates `aiResult.steps` to gather tool calls, then drops the per-step text and results.

## Why it matters

Without it, a failing local eval can only report which tool call was expected and which arrived.

A case where the model answers in text instead of calling a tool reports:

```
expected=add_to_cart  actual=null
```

...and nothing about why. The model's closing message — the thing that actually explains it, e.g. asking a clarifying question instead of acting — is computed and then discarded. Diagnosing one failing case in CI currently means downloading the HTML artifact and reading it by hand.

## Change

- Add `steps?: TrajectoryStep[]` to `LocalEvalResult`, mirroring `BrowserEvalResult`.
- Map `aiResult.steps` to `TrajectoryStep[]` in the Vercel backend.
- Attach it as `trajectory` on both local `TestResult` shapes.

The field is optional, so backends that cannot expose steps are unaffected — `gemini` and `ollama` are untouched.

## Verification

Run against a 20-case suite through an OpenAI-compatible endpoint:

- **40/40** results carry a trajectory (previously 0).
- The HTML report renders **22** Trajectory sections and 38 Tool Calls / Tool Results blocks, where it previously rendered none.
- `tsc --noEmit` reports the same 3 pre-existing errors in `executeInBrowserEval` before and after; this change adds none.

## Notes

Happy to add the same wiring to the `gemini` and `ollama` backends if you'd like it in one PR — I left them alone since I have no way to test them.
