### PR TITLE
Add Effectprint to Libraries & Tools in AWESOME_WEBMCP.md

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -78,6 +78,7 @@ A curated list of awesome WebMCP demos, libraries, and tools.
 - [WebMCP - Model Context Tool Inspector](https://github.com/beaufortfrancois/model-context-tool-inspector) - A Chrome Extension to let web developers inspect web pages to verify if WebMCP tools are correctly exposed, visualize the input schema, and debug connection issues directly within the browser.
 - [webmcpify](https://github.com/TueJon/webmcpify) - An agent skill that integrates WebMCP into an existing web app end to end: it inventories the app, proposes a tool manifest for approval, integrates the tools, then verifies each one in a real browser and heals failures.
 - [MCP Webcomic Site Server](https://github.com/nearestnabors/mcp-webcomic-site-server) - A template and tutorial for making a webcomic archive visible to AI agents across three surfaces: a static 11ty website, an MCP server, and WebMCP browser tools. Registers tools like `get_current_page`, `get_transcript`, `prev_page`/`next_page`, and `search_comics` via `navigator.modelContext.registerTool()`.
+- [Effectprint](https://github.com/TommyTranX/effectprint) - A CLI and GitHub Action for auditing imperative WebMCP tool behavior by executing eligible tools in fresh guarded browser contexts and checking observed effects against `readOnlyHint` and explicit behavioral contracts.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds [Effectprint](https://github.com/TommyTranX/effectprint) to the **Libraries & Tools** section of `AWESOME_WEBMCP.md`.

Effectprint is an MIT-licensed Node.js CLI and GitHub Action for deterministic behavioral checks of imperative WebMCP tools. It executes eligible tools in fresh guarded browser contexts, records observable effects, and compares them with `readOnlyHint` and explicit allow, forbid, and require contracts. This complements inspectors and schema or model-evaluation tools by checking what one audited invocation actually attempts to change.

I maintain Effectprint.

## Verification

- [v0.2.0 release](https://github.com/TommyTranX/effectprint/releases/tag/v0.2.0)
- [Sample evidence report](https://tommytranx.github.io/effectprint/sample-report.html)
- [Pinned audits of two public WebMCP demos](https://tommytranx.github.io/effectprint/docs/real-world-audits.md)
- This is a documentation-only, one-line change.
- Confirmed Effectprint is not already listed or proposed in another upstream PR.

## CLA

I have reviewed the contribution guidelines and will complete the Google CLA check if prompted.
