### PR TITLE
Add CliDeck network evidence WebMCP demo

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -69,6 +69,8 @@ A curated list of awesome WebMCP demos, libraries, and tools.
   - **Example Prompt:** "Load dataset https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/lfsi_emp_a?lang=en&lastTimePeriod=3&indic_em=ACT&age=Y15-64&unit=THS_PER and select the data for Germany and Ireland and the last period available. Display a cross-tabulation with sex as rows and countries as columns and download a CSV file with this info."
 - [Stacktree](https://stacktr.ee/) - Private hosting for the HTML that AI agents generate. Registers `stacktree_publish_html` via `document.modelContext`, so a browser agent can hand over a complete HTML document and get back a live, shareable URL with no account or sign-in. Anonymous sites are unlisted and the response includes a claim URL to keep the page permanently in a free account.
   - **Example Prompt:** "Build a simple one-page site for a coffee shop called Crema and publish it so I can share the link."
+- [CliDeck MCP — Network Evidence Workbench](https://mcp.clideck.com/demo) ([code](https://github.com/SmartRoot7/clideck-mcp)) - A live, read-only networking knowledge demo that exposes version-aware lookup, change review, snapshot analysis, upgrade guidance, and topology analysis through WebMCP tools.
+  - **Example Prompt:** "Compare the behavior of a network feature across two software releases and show the supporting evidence."
 - [**Wordup**](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/wordup) ([live](https://snugug.github.io/demos/wordup/)): A casual word guessing game using the Prompt API to generate words and can be driven entirely through WebMCP.
   - **Example Prompt:** "Start a new game."
 


### PR DESCRIPTION
Adds the live, read-only CliDeck network evidence workbench to the third-party WebMCP demos list. The entry links to the public demo and source repository and includes a concrete example prompt.

Disclosure: submitted on behalf of the CliDeck maintainer.