### PR TITLE
Add persistentwidget support to agent

### DIFF
--- a/demos/french-bistro/README.md
+++ b/demos/french-bistro/README.md
@@ -35,6 +35,8 @@ With `index.html?sharedworker`, the demo uses a `SharedWorker` to manage the in-
 
 With `index.html?agentiframe`, the in-page AI agent lives in an `<iframe>`.
 
+With `index.html?agentpersistentwidget`, the in-page AI agent lives in a `<persistentwidget>` that persists across same-origin navigations without reloading. This is particularly useful for maintaining continuity across page navigations (e.g., when combined with `?crossdocument`). It uses the experimental [`<persistentwidget>`](https://github.com/WICG/persistent-iframes) element.
+
 Testing WebMCP audit failures can be streamlined by using specific URL parameters to simulate common tool configuration issues:
 - `index.html?notoolname` removes `toolname` form attribute
 - `index.html?notooldescription` removes `tooldescription` form attribute.

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -155,6 +155,9 @@ agentToggle.addEventListener('click', () => {
     window.frameElement.style.width = isOpen ? '414px' : '100px';
     window.frameElement.style.height = isOpen ? '634px' : '100px';
   }
+  if (window.persistentWidgetOpener) {
+    window.persistentWidgetOpener.postMessage({ type: 'AGENT_VISIBILITY_CHANGE', isOpen }, '*');
+  }
   const win = window.frameElement ? window.parent : window;
   const url = new URL(win.location);
   if (isOpen) {
@@ -316,3 +319,10 @@ if (!window.document.modelContext) {
 if (params.has('agentopened')) {
   agentToggle.click();
 }
+
+window.addEventListener('openerchange', () => {
+  if (window.persistentWidgetOpener) {
+    const isOpen = !agentChat.classList.contains('hidden');
+    window.persistentWidgetOpener.postMessage({ type: 'AGENT_VISIBILITY_CHANGE', isOpen }, '*');
+  }
+});

--- a/demos/french-bistro/index.html
+++ b/demos/french-bistro/index.html
@@ -165,28 +165,6 @@
     </div>
     <script src="../shared/webmcp-polyfill.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module">
-      const params = new URLSearchParams(window.location.search);
-      if (params.has('agentiframe')) {
-        const agentContainer = document.getElementById('agent-container');
-        if (agentContainer) agentContainer.remove();
-
-        const iframe = document.createElement('iframe');
-        iframe.src = 'agent.html' + window.location.search;
-        iframe.style.position = 'fixed';
-        iframe.style.bottom = '0';
-        iframe.style.right = '0';
-        iframe.style.width = '100px';
-        iframe.style.height = '100px';
-        iframe.style.border = 'none';
-        iframe.style.zIndex = '1000';
-        document.body.appendChild(iframe);
-      } else {
-        const script = document.createElement('script');
-        script.type = 'module';
-        script.src = 'agent.js';
-        document.body.appendChild(script);
-      }
-    </script>
+    <script type="module" src="setup-agent.js"></script>
   </body>
 </html>

--- a/demos/french-bistro/result.html
+++ b/demos/french-bistro/result.html
@@ -11,6 +11,7 @@
   <meta http-equiv="origin-trial" content="AkSy8NN0hHVbV1Tcto9+K2cDotMP5NcgNobK+M8bhWqrxefn6KOq0cpv/Glx1A+/1EmTU4KmfdLhdcrIA7L8EwwAAABaeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZWNocm9tZWxhYnMuZ2l0aHViLmlvOjQ0MyIsImZlYXR1cmUiOiJXZWJNQ1AiLCJleHBpcnkiOjE3OTQ4NzM2MDB9">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Le Petit Bistro | WebMCP declarative demo</title>
+  <link rel="expect" href="#agent-persistentwidget" blocking="render">
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -60,29 +61,8 @@
     </div>
   </div>
   <script src="../shared/webmcp-polyfill.js"></script>
+  <script src="setup-agent.js"></script>
   <script>
-    const params = new URLSearchParams(window.location.search);
-    if (params.has('agentiframe')) {
-      const agentContainer = document.getElementById('agent-container');
-      if (agentContainer) agentContainer.remove();
-
-      const iframe = document.createElement('iframe');
-      iframe.src = 'agent.html' + window.location.search;
-      iframe.style.position = 'fixed';
-      iframe.style.bottom = '0';
-      iframe.style.right = '0';
-      iframe.style.width = '100px';
-      iframe.style.height = '100px';
-      iframe.style.border = 'none';
-      iframe.style.zIndex = '1000';
-      document.body.appendChild(iframe);
-    } else {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'agent.js';
-      document.body.appendChild(script);
-    }
-
     const modalDetails = document.getElementById('modalDetails');
     const name = params.get('name');
     const time = params.get('time');

--- a/demos/french-bistro/setup-agent.js
+++ b/demos/french-bistro/setup-agent.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const params = new URLSearchParams(window.location.search);
+const isIframe = params.has('agentiframe');
+const isPersistentWidget = params.has('agentpersistentwidget');
+
+if (isIframe || isPersistentWidget) {
+  document.getElementById('agent-container')?.remove();
+
+  const isOpened = params.has('agentopened');
+  const el = document.createElement(isPersistentWidget ? 'persistentwidget' : 'iframe');
+
+  if (isPersistentWidget) {
+    el.id = 'agent-persistentwidget';
+    // Keep src deterministic across navigations so the browsing context persists.
+    const searchParams = new URLSearchParams();
+    if (params.has('sharedworker')) searchParams.set('sharedworker', '');
+    if (params.has('agentopened')) searchParams.set('agentopened', '');
+    const queryString = searchParams.toString();
+    el.src = 'agent.html' + (queryString ? '?' + queryString : '');
+  } else {
+    el.src = 'agent.html' + window.location.search;
+  }
+
+  el.style.position = 'fixed';
+  el.style.bottom = '0';
+  el.style.right = '0';
+  el.style.width = isOpened ? '414px' : '100px';
+  el.style.height = isOpened ? '634px' : '100px';
+  el.style.border = 'none';
+  el.style.zIndex = '1000';
+  document.body.appendChild(el);
+
+  if (isPersistentWidget) {
+    window.addEventListener('message', (event) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type === 'AGENT_VISIBILITY_CHANGE') {
+        el.style.width = event.data.isOpen ? '414px' : '100px';
+        el.style.height = event.data.isOpen ? '634px' : '100px';
+        const url = new URL(window.location);
+        if (event.data.isOpen) {
+          url.searchParams.set('agentopened', '');
+        } else {
+          url.searchParams.delete('agentopened');
+        }
+        window.history.replaceState({}, '', url.toString().replace(/=(?=&|$)/g, ''));
+      }
+    });
+  }
+} else {
+  const script = document.createElement('script');
+  script.type = 'module';
+  script.src = 'agent.js';
+  document.body.appendChild(script);
+}


### PR DESCRIPTION
This PR adds experimental `<persistentwidget>` support to the french-bistro in-page agent in order to explore this new HTML element (https://github.com/WICG/persistent-iframes)


<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/eb8de320-fd3a-4c98-8437-2b1dc7b68ac2" />

http://localhost:8080/demos/french-bistro/?agentpersistentwidget&crossdocument&agentopened&toolautosubmit

