### PR TITLE
Add Is-AI-Native and Kakeklar demos

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -69,6 +69,10 @@ A curated list of awesome WebMCP demos, libraries, and tools.
   - **Example Prompt:** "Load dataset https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/lfsi_emp_a?lang=en&lastTimePeriod=3&indic_em=ACT&age=Y15-64&unit=THS_PER and select the data for Germany and Ireland and the last period available. Display a cross-tabulation with sex as rows and countries as columns and download a CSV file with this info."
 - [Stacktree](https://stacktr.ee/) - Private hosting for the HTML that AI agents generate. Registers `stacktree_publish_html` via `document.modelContext`, so a browser agent can hand over a complete HTML document and get back a live, shareable URL with no account or sign-in. Anonymous sites are unlisted and the response includes a claim URL to keep the page permanently in a free account.
   - **Example Prompt:** "Build a simple one-page site for a coffee shop called Crema and publish it so I can share the link."
+- [Is AI Native](https://isainative.dev/) | [Code](https://github.com/webmaxru/is-ai-native) - Audits public GitHub repositories for AI coding readiness across GitHub Copilot, Claude Code, and Codex using a declarative WebMCP scan tool.
+  - **Example Prompt:** "Scan `GoogleChromeLabs/webmcp-tools` and tell me how AI-native it is."
+- [Kakeklar](https://kakeklar.no/) | [Code](https://github.com/webmaxru/barnebursdag-planlegger) - A Norwegian children's birthday-party planner that exposes WebMCP tools for configuring a party and generating an age-aware shopping list.
+  - **Example Prompt:** "Plan a birthday party for a 7-year-old with 9 children and 2 adults, then show me the shopping list."
 - [**Wordup**](https://github.com/GoogleChromeLabs/web-ai-demos/tree/main/wordup) ([live](https://snugug.github.io/demos/wordup/)): A casual word guessing game using the Prompt API to generate words and can be driven entirely through WebMCP.
   - **Example Prompt:** "Start a new game."
 


### PR DESCRIPTION
Adds two open-source WebMCP projects to the Demos section:

- [Is AI Native](https://isainative.dev/), which exposes a declarative tool for auditing a public GitHub repository's AI coding readiness
- [Kakeklar](https://kakeklar.no/), which exposes imperative tools for configuring a children's birthday party and retrieving its age-aware shopping list

Each entry links to its source repository and includes a sample prompt grounded in the project's exposed WebMCP tools.