### PR TITLE
docs: add DeepDeck WebMCP desktop client

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -122,6 +122,7 @@ A curated list of awesome WebMCP demos, libraries, and tools.
 - [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) - A plugin for coding agents with an interactive visual Explorer that maps a site's user journeys to proposed WebMCP tools for review and approval, then implements and verifies them in a real browser.
 - [WindTunnel](https://github.com/nekuda-ai/WindTunnel) - An open-source benchmark comparing WebMCP with other browser-agent interfaces across task success, execution time, token usage, and cost.
 - [webmcp-kit](https://www.npmjs.com/package/@ashraf009/webmcp-kit) ([code](https://github.com/AshrafAhmed9/webmcp-kit)) - A small typed WebMCP library: `defineTool`/`registerTools` with full JSON-Schema-to-TS inference, React hooks (`useWebMCPTool`, `useScopedTools` for dynamic tool sets tied to component state), `withConfirmation` for consequential actions, and a subscribable activity log. Used by Cadence, Consequence, and Relay above.
+- [DeepDeck](https://github.com/jo32/DeepDeck) - MIT-licensed macOS desktop client based on DeepSeek Harness that discovers and calls website-provided WebMCP tools. Its Builder lets an agent explore a site, generate and verify tools, and save versioned source per site for reuse in the DeepDeck browser.
 
 ## Contributing
 


### PR DESCRIPTION
Adds DeepDeck to the Libraries & Tools section. DeepDeck is an MIT-licensed macOS desktop client built on DeepSeek Harness, with a WebMCP consumer and a Builder that explores pages, verifies operations, and stores tool source and versions per site. Generated tools run in the DeepDeck browser and are shown separately from website-provided tools.

I maintain DeepDeck. The [illustrated walkthrough](https://github.com/deepseek-ai/deepseek-harness/discussions/5856) shows discovery of a website tool, creation of 23 tools for X, and use of a tool to fill a draft. The draft example does not publish a post. The entry makes no benchmark or general compatibility claims.

Validation: checked the existing list for duplicate entries, verified the project and walkthrough links, and ran `git diff --check`.
