### PR TITLE
feat: add AbortSignal support to EvalTool execute

### DIFF
--- a/demos/webmcp-maze/package-lock.json
+++ b/demos/webmcp-maze/package-lock.json
@@ -17,7 +17,7 @@
         "typescript": "~5.9.3",
         "vite": "^8.0.16",
         "vitest": "^4.1.0",
-        "webmcp-types": "^0.1.3"
+        "webmcp-types": "^0.1.6"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/webmcp-types": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.3.tgz",
-      "integrity": "sha512-73B1NGAO6ulK8tKq5bGk/AjPwYpIG7WYr7x18WLEkSOi7cU9ECdquiXIX0HbauDgp+jIk+Wm4/KdVnTJzRts5w==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.6.tgz",
+      "integrity": "sha512-vWYNhhBXQhP4flPIk3sJuzsonPGSTdDyhWgpmPYCNdpIcLHJgjHE51lU0S7gi+UtdxO84FsCnvSJaMfLGWP+3Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/demos/webmcp-maze/package.json
+++ b/demos/webmcp-maze/package.json
@@ -16,7 +16,7 @@
     "typescript": "~5.9.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.0",
-    "webmcp-types": "^0.1.3"
+    "webmcp-types": "^0.1.6"
   },
   "dependencies": {
     "pixi.js": "^8.16.0"

--- a/demos/webmcp-maze/src/webmcp/tools/EvalTool.ts
+++ b/demos/webmcp-maze/src/webmcp/tools/EvalTool.ts
@@ -12,7 +12,7 @@
  * - `connect-src 'self'` in the page CSP prevents arbitrary outbound requests.
  * - `gameTools.executeTool` is a controlled bridge — the worker can only invoke
  *   tools currently registered in the main thread's `toolMap`.
- * - The worker is terminated on completion or after {@link EVAL_TIMEOUT_MS}.
+ * - The worker is terminated on completion, abort, or after {@link EVAL_TIMEOUT_MS}.
  *
  * Message protocol (main ↔ worker):
  * - Main → Worker: `{ type: 'run', code: string }`
@@ -76,6 +76,16 @@ self.onmessage = async (e) => {
 const EVAL_TIMEOUT_MS = 300_000;
 
 /**
+ * Extracts a descriptive error message from an AbortSignal, falling back to a default.
+ */
+function getAbortErrorMessage(signal: AbortSignal): string {
+  return (
+    signal.reason?.message ??
+    (typeof signal.reason === "string" ? signal.reason : "Execution aborted")
+  );
+}
+
+/**
  * Creates the `eval_code` MCP tool.
  *
  * Allows the AI agent to submit JavaScript code that is executed in a
@@ -90,7 +100,7 @@ const EVAL_TIMEOUT_MS = 300_000;
  * The return value of the last expression (or an explicit `return`) is
  * serialised as JSON and sent back to the agent.
  *
- * The worker is terminated automatically on completion, error, or timeout.
+ * The worker is terminated automatically on completion, error, timeout, or abort.
  */
 export function createEvalTool(): WebMCP.ModelContextTool {
   return {
@@ -126,12 +136,20 @@ export function createEvalTool(): WebMCP.ModelContextTool {
       },
       required: ["code"],
     },
-    execute(input: Record<string, unknown>): Promise<object> {
+    execute(input, options): Promise<object> {
       const code = input.code as string;
+      const signal = options?.signal;
 
       console.group("[eval_code] LLM submitted code");
       console.log(code);
       console.groupEnd();
+
+      if (signal?.aborted) {
+        return Promise.resolve({
+          success: false,
+          error: getAbortErrorMessage(signal),
+        });
+      }
 
       return new Promise<object>((resolve) => {
         const blob = new Blob([EVAL_WORKER_SCRIPT], {
@@ -146,11 +164,22 @@ export function createEvalTool(): WebMCP.ModelContextTool {
         const finish = (response: object): void => {
           if (settled) return;
           settled = true;
+          signal?.removeEventListener("abort", onAbort);
           clearTimeout(timeoutId);
           worker.terminate();
           URL.revokeObjectURL(workerUrl);
           resolve(response);
         };
+
+        const onAbort = (): void => {
+          console.error("[eval_code] execution aborted");
+          finish({
+            success: false,
+            error: getAbortErrorMessage(signal!),
+          });
+        };
+
+        signal?.addEventListener("abort", onAbort, { once: true });
 
         const timeoutId = setTimeout(() => {
           console.error(`[eval_code] timed out after ${EVAL_TIMEOUT_MS}ms`);
@@ -190,12 +219,14 @@ export function createEvalTool(): WebMCP.ModelContextTool {
                 name,
                 args ?? {},
               );
+              if (settled) return;
               worker.postMessage({
                 type: "toolResult",
                 id,
                 result: toolResult,
               });
             } catch (err) {
+              if (settled) return;
               const errMsg = err instanceof Error ? err.message : String(err);
               worker.postMessage({ type: "toolResult", id, error: errMsg });
             }


### PR DESCRIPTION
Starting in [Chrome 153.0.8009.0](https://chromiumdash.appspot.com/commit/e18e43744babcbe0d525dc204d18e7b5c36d6ddb), tool execution callbacks registered via `document.modelContext.registerTool()` receive an options object with an `AbortSignal` as their second argument (`execute(inputObject, { signal })`). See [webmachinelearning/webmcp#48](https://github.com/webmachinelearning/webmcp/issues/48) and [webmachinelearning/webmcp#247](https://github.com/webmachinelearning/webmcp/pull/247).

This PR adds `AbortSignal` cancellation support to the Web Worker execution in the maze demo's `eval_code` tool:

- **Bumps `webmcp-types`** to `^0.1.6` for `ToolExecuteCallbackOptions` typing.
- **Pre-aborted check**: If `signal?.aborted` is already set, execution immediately returns without spinning up the worker.
- **In-flight cancellation**: Listens for the `abort` event on `signal` to immediately terminate the worker, clear the timeout, revoke the blob URL, and resolve with an error message.
- **Cleanup**: Removes the `abort` event listener when execution completes naturally.
- **Bridge guard**: Prevents messaging the worker if the execution settled or aborted while an async `window.gameTools.executeTool` call was pending.
