### PR TITLE
Add Signett to Libraries & Tools

### DIFF
--- a/AWESOME_WEBMCP.md
+++ b/AWESOME_WEBMCP.md
@@ -123,6 +123,7 @@ A curated list of awesome WebMCP demos, libraries, and tools.
 - [WindTunnel](https://github.com/nekuda-ai/WindTunnel) - An open-source benchmark comparing WebMCP with other browser-agent interfaces across task success, execution time, token usage, and cost.
 - [webmcp-kit](https://www.npmjs.com/package/@ashraf009/webmcp-kit) ([code](https://github.com/AshrafAhmed9/webmcp-kit)) - A small typed WebMCP library: `defineTool`/`registerTools` with full JSON-Schema-to-TS inference, React hooks (`useWebMCPTool`, `useScopedTools` for dynamic tool sets tied to component state), `withConfirmation` for consequential actions, and a subscribable activity log. Used by Cadence, Consequence, and Relay above.
 - [DeepDeck](https://github.com/jo32/DeepDeck) - MIT-licensed macOS desktop client based on DeepSeek Harness that discovers and calls website-provided WebMCP tools. Its Builder lets an agent explore a site, generate and verify tools, and save versioned source per site for reuse in the DeepDeck browser.
+- [Signett](https://github.com/signettai/signett) - TypeScript SDK for registering application functions as native WebMCP tools, with JSON Schema input validation, lifecycle cleanup, authorization, human confirmation, idempotency, recovery, verification, testing, and observability.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Add [Signett](https://github.com/signettai/signett) to the WebMCP Libraries & Tools list.

## Why it fits

Signett is an open-source TypeScript SDK built specifically for registering application functions as native WebMCP tools. The entry highlights its documented validation, lifecycle, safety, testing, and observability capabilities.

## Affiliation

I am affiliated with the Signett project and am submitting this entry on its behalf.