### PR TITLE
fix: pass options to registered tool execution in webmcp-polyfill

### DIFF
--- a/demos/shared/webmcp-polyfill.js
+++ b/demos/shared/webmcp-polyfill.js
@@ -290,7 +290,7 @@
       // 1. Check if it's an imperative tool registered here
       if (win.__webmcp_registered_tools && win.__webmcp_registered_tools.has(tool.name)) {
         const registeredTool = win.__webmcp_registered_tools.get(tool.name);
-        return registeredTool._execute(parsedArgs);
+        return registeredTool._execute(parsedArgs, options);
       }
 
       // 2. Check if it's a declarative tool


### PR DESCRIPTION
This PR passes the `options` parameter to `registeredTool._execute(parsedArgs, options)` in webmcp-polyfill.js so that execution options (e.g. abort signal for now) are properly forwarded to imperative tools as discovered in https://github.com/GoogleChromeLabs/webmcp-tools/pull/403/