### PR TITLE
refactor(demos): infer WebMCP execute inputs from schemas

### DIFF
--- a/demos/sport-shop-angular/src/app/components/cart-modal/cart-modal.component.ts
+++ b/demos/sport-shop-angular/src/app/components/cart-modal/cart-modal.component.ts
@@ -49,7 +49,7 @@ export class CartModalComponent {
           }
         }
       },
-      execute: (params: any) => {
+      execute: (params) => {
         const products = this.cartService.cart().map(item => item.product);
         const product = findMatchingProduct(products, params);
         if (!product) {
@@ -112,7 +112,7 @@ export class CartModalComponent {
         },
         required: ["option"]
       },
-      execute: (params: any) => {
+      execute: (params) => {
         let idx = params.index;
         if (typeof idx !== 'number' && params.productId) {
           idx = this.cartService.cart().findIndex(item => item.product.id === params.productId);

--- a/demos/sport-shop-angular/src/app/pages/search/search.component.ts
+++ b/demos/sport-shop-angular/src/app/pages/search/search.component.ts
@@ -60,7 +60,7 @@ export class SearchComponent implements OnInit {
         },
         required: ["priceRange"]
       },
-      execute: (params: any) => {
+      execute: (params) => {
         const success = this.setPriceRange(params.priceRange);
         if (success) {
           return { success: true, message: `Filtered results by ${params.priceRange}` };
@@ -90,7 +90,7 @@ export class SearchComponent implements OnInit {
           }
         }
       },
-      execute: (params: any) => {
+      execute: (params) => {
         const product = findMatchingProduct(this.filteredProducts, params);
 
         if (!product) {

--- a/demos/sport-shop-angular/src/app/services/webmcp.service.ts
+++ b/demos/sport-shop-angular/src/app/services/webmcp.service.ts
@@ -38,7 +38,7 @@ export class WebmcpService {
           }
         }
       },
-      execute: (params: any) => {
+      execute: (params) => {
         const product = findMatchingProduct(this.productService.getProducts(), params);
         if (!product) {
           return { success: false, message: "Product not found. Please provide a valid productId, or productName." };
@@ -65,7 +65,7 @@ export class WebmcpService {
           }
         }
       },
-      execute: (params: any) => {
+      execute: (params) => {
         const product = findMatchingProduct(this.productService.getProducts(), params);
         if (!product) {
           return { success: false, message: "Product not found. Please provide a valid productId, or productName." };
@@ -106,7 +106,7 @@ export class WebmcpService {
           }
         }
       },
-      execute: (params: any) => {
+      execute: (params) => {
         const searchParams: any = {
           q: (params && params.query) ? params.query : ''
         };

--- a/demos/webmcp-maze/src/__tests__/ToolInputs.test.ts
+++ b/demos/webmcp-maze/src/__tests__/ToolInputs.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { Game } from "../game/Game.ts";
+import { createMoveTool } from "../webmcp/tools/MoveTool.ts";
+import { createUseTool } from "../webmcp/tools/UseTool.ts";
+import { createEvalTool } from "../webmcp/tools/EvalTool.ts";
+
+describe("schema-inferred tool inputs", () => {
+  it("infers required direction and code fields", () => {
+    type DirectionInput = { direction: "north" | "south" | "east" | "west" };
+    expectTypeOf<
+      Parameters<ReturnType<typeof createMoveTool>["execute"]>[0]
+    >().toEqualTypeOf<DirectionInput>();
+    expectTypeOf<
+      Parameters<ReturnType<typeof createUseTool>["execute"]>[0]
+    >().toEqualTypeOf<DirectionInput>();
+    expectTypeOf<
+      Parameters<ReturnType<typeof createEvalTool>["execute"]>[0]
+    >().toEqualTypeOf<{ code: string }>();
+  });
+
+  for (const factory of [createMoveTool, createUseTool]) {
+    for (const direction of ["up", "", 42, undefined]) {
+      it(`${factory.name} rejects invalid direction ${String(direction)} through dynamic dispatch`, async () => {
+        // Match window.gameTools: untyped callers bypass schema validation.
+        const tool = factory({} as Game) as unknown as WebMCP.ModelContextTool;
+        await expect(
+          tool.execute({ direction }, { signal: new AbortController().signal }),
+        ).resolves.toEqual({
+          success: false,
+          reason: `Invalid direction: "${direction}". Use north, south, east, or west.`,
+        });
+      });
+    }
+  }
+
+  it("preserves successful movement and renderer updates", async () => {
+    const game = {
+      player: {
+        move: vi.fn(() => true),
+        position: { row: 0, col: 1 },
+        moveCount: 1,
+      },
+      board: { revealFrom: vi.fn(), isExit: vi.fn(() => false) },
+      renderer: { animatePlayerMove: vi.fn(), updateFog: vi.fn() },
+      gameplayState: { updateMoveCount: vi.fn(), updateExploredCount: vi.fn() },
+    };
+    await expect(
+      createMoveTool(game as unknown as Game).execute({ direction: "east" }),
+    ).resolves.toEqual({
+      success: true,
+      position: { row: 0, col: 1 },
+      atExit: false,
+      moveCount: 1,
+    });
+    expect(game.player.move).toHaveBeenCalledWith("east", game.board);
+    expect(game.renderer.animatePlayerMove).toHaveBeenCalledWith(
+      game.player.position,
+    );
+    expect(game.renderer.updateFog).toHaveBeenCalledWith(game.board);
+  });
+
+  it("preserves the empty-inventory response for a valid use direction", async () => {
+    const game = { player: { inventory: null } } as unknown as Game;
+    await expect(
+      createUseTool(game).execute({ direction: "north" }),
+    ).resolves.toEqual({
+      success: false,
+      reason: "You are not holding any item to use.",
+    });
+  });
+
+  it("preserves cancellation before creating a worker", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("Stopped"));
+    const result = await createEvalTool().execute(
+      { code: "return 1" },
+      { signal: controller.signal },
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(result).toHaveProperty("error");
+  });
+});

--- a/demos/webmcp-maze/src/webmcp/ToolRegistry.ts
+++ b/demos/webmcp-maze/src/webmcp/ToolRegistry.ts
@@ -12,6 +12,16 @@ import { createUseTool } from "./tools/UseTool.ts";
 import { createStartGameTool } from "./tools/StartGameTool.ts";
 import { createEvalTool } from "./tools/EvalTool.ts";
 
+type GameTool = ReturnType<
+  | typeof createMoveTool
+  | typeof createLookTool
+  | typeof createPickupTool
+  | typeof createDropTool
+  | typeof createUseTool
+  | typeof createStartGameTool
+  | typeof createEvalTool
+>;
+
 /**
  * Manages the lifecycle of WebMCP tools registered with `document.modelContext`.
  *
@@ -69,7 +79,7 @@ export class ToolRegistry {
    * Also registers `eval_code` when the `?eval_tool` URL parameter is present.
    */
   registerGameplayTools(): void {
-    const tools = [
+    const tools: GameTool[] = [
       createMoveTool(this.game),
       createLookTool(this.game),
       createPickupTool(this.game),
@@ -98,16 +108,20 @@ export class ToolRegistry {
    * Keeps `toolMap` in sync so `window.gameTools.executeTool` stays current.
    * @param tools - The tools to register.
    */
-  private provideTools(tools: WebMCP.ModelContextTool[]): void {
+  private provideTools(tools: GameTool[]): void {
+    // The registry is a dynamic dispatch boundary: callers supply untyped JSON.
+    // Keep the schema-inferred callback types inside each factory and retain
+    // their runtime guards for calls through window.gameTools.
+    const executableTools = tools as WebMCP.ModelContextTool[];
     if (this.supported) {
       this.toolController?.abort();
       this.toolController = new AbortController();
-      for (const tool of tools) {
+      for (const tool of executableTools) {
         document.modelContext!.registerTool(tool, { signal: this.toolController.signal });
       }
     }
     this.toolMap.clear();
-    for (const tool of tools) {
+    for (const tool of executableTools) {
       this.toolMap.set(tool.name, tool);
     }
   }

--- a/demos/webmcp-maze/src/webmcp/tools/EvalTool.ts
+++ b/demos/webmcp-maze/src/webmcp/tools/EvalTool.ts
@@ -102,7 +102,21 @@ function getAbortErrorMessage(signal: AbortSignal): string {
  *
  * The worker is terminated automatically on completion, error, timeout, or abort.
  */
-export function createEvalTool(): WebMCP.ModelContextTool {
+export function createEvalTool() {
+  const inputSchema = {
+    type: "object",
+    properties: {
+      code: {
+        type: "string",
+        description:
+          "JavaScript code to execute. Runs as an async function body; may use await. " +
+          "Call tools via window.gameTools.executeTool(name, args). " +
+          "The result is a plain JS object — no JSON.parse needed.",
+      },
+    },
+    required: ["code"],
+  } as const;
+
   return {
     name: "eval_code",
     description:
@@ -123,21 +137,9 @@ export function createEvalTool(): WebMCP.ModelContextTool {
       "  Keys open matching doors; dynamite clears rocks. Call use({direction}) BEFORE move({direction}) to clear a blocker.\n" +
       "\nIMPORTANT: The code runs inside a function body — values are NOT returned automatically. " +
       "Always end with an explicit `return` statement. For async functions, use `return await myFn()`.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        code: {
-          type: "string",
-          description:
-            "JavaScript code to execute. Runs as an async function body; may use await. " +
-            "Call tools via window.gameTools.executeTool(name, args). " +
-            "The result is a plain JS object — no JSON.parse needed.",
-        },
-      },
-      required: ["code"],
-    },
+    inputSchema,
     execute(input, options): Promise<object> {
-      const code = input.code as string;
+      const code = input.code;
       const signal = options?.signal;
 
       console.group("[eval_code] LLM submitted code");
@@ -246,5 +248,5 @@ export function createEvalTool(): WebMCP.ModelContextTool {
         worker.postMessage({ type: "run", code });
       });
     },
-  };
+  } satisfies WebMCP.ModelContextToolFromSchema<typeof inputSchema>;
 }

--- a/demos/webmcp-maze/src/webmcp/tools/MoveTool.ts
+++ b/demos/webmcp-maze/src/webmcp/tools/MoveTool.ts
@@ -16,25 +16,27 @@ const VALID_DIRECTIONS = new Set(Object.values(Direction));
  * @param game - The game orchestrator instance.
  * @returns A {@link WebMCP.ModelContextTool} for player movement.
  */
-export function createMoveTool(game: Game): WebMCP.ModelContextTool {
+export function createMoveTool(game: Game) {
+  const inputSchema = {
+    type: "object",
+    properties: {
+      direction: {
+        type: "string",
+        enum: ["north", "south", "east", "west"],
+        description: "The direction to move.",
+      },
+    },
+    required: ["direction"],
+  } as const;
+
   return {
     name: "move",
     description:
       "Move the player one cell in a cardinal direction (north, south, east, west). " +
       "Returns success or failure with a reason.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        direction: {
-          type: "string",
-          enum: ["north", "south", "east", "west"],
-          description: "The direction to move.",
-        },
-      },
-      required: ["direction"],
-    },
-    async execute(input: Record<string, unknown>) {
-      const dir = input.direction as string;
+    inputSchema,
+    async execute(input) {
+      const dir = input.direction;
 
       if (!VALID_DIRECTIONS.has(dir as Direction)) {
         return {
@@ -82,5 +84,5 @@ export function createMoveTool(game: Game): WebMCP.ModelContextTool {
         reason: `There is a wall blocking the ${dir} direction.`,
       };
     },
-  };
+  } satisfies WebMCP.ModelContextToolFromSchema<typeof inputSchema>;
 }

--- a/demos/webmcp-maze/src/webmcp/tools/UseTool.ts
+++ b/demos/webmcp-maze/src/webmcp/tools/UseTool.ts
@@ -21,26 +21,28 @@ const VALID_DIRECTIONS = new Set(Object.values(Direction));
  * @param game - The game orchestrator instance.
  * @returns A {@link WebMCP.ModelContextTool} for using items on blockers.
  */
-export function createUseTool(game: Game): WebMCP.ModelContextTool {
+export function createUseTool(game: Game) {
+  const inputSchema = {
+    type: "object",
+    properties: {
+      direction: {
+        type: "string",
+        enum: ["north", "south", "east", "west"],
+        description: "The direction where the blocker is located.",
+      },
+    },
+    required: ["direction"],
+  } as const;
+
   return {
     name: "use",
     description:
       "Use your held item on a blocker in the specified direction. " +
       "Keys open matching colored doors. Dynamite destroys rocks. " +
       "The item is consumed on success.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        direction: {
-          type: "string",
-          enum: ["north", "south", "east", "west"],
-          description: "The direction where the blocker is located.",
-        },
-      },
-      required: ["direction"],
-    },
-    async execute(input: Record<string, unknown>) {
-      const dir = input.direction as string;
+    inputSchema,
+    async execute(input) {
+      const dir = input.direction;
 
       if (!VALID_DIRECTIONS.has(dir as Direction)) {
         return {
@@ -102,5 +104,5 @@ export function createUseTool(game: Game): WebMCP.ModelContextTool {
         direction: dir,
       };
     },
-  };
+  } satisfies WebMCP.ModelContextToolFromSchema<typeof inputSchema>;
 }


### PR DESCRIPTION
The maze demo erases schema information through broad factory return types, while Angular sport-shop overrides inferred callback inputs with `any`. This refactor derives inputs from the existing schemas without changing schemas or handler behavior.

Refs #411.

- Infer maze move/use/eval inputs with `ModelContextToolFromSchema`, preserving runtime guards and the registry's dynamic dispatch boundary.
- Remove seven redundant sport-shop callback annotations.
- Add 12 maze regression/type tests.

Validation:

- Maze production build and 88 tests passed.
- Sport-shop production build passed using a temporary Windows drive mapping to avoid inaccessible profile ancestors; no configuration or dependency changes.
- Existing Chrome smoke suite passed 2/2 cases. Additional local browser assertions passed 17 tool calls covering all seven changed callbacks, navigation, filtered prices, cart state, and error cases.
- Angular unit tests: 8 passed, 1 failed with NG0203 during AppComponent creation. Restoring all three modified Angular files to upstream reproduced the identical failure; changes were then restored.
- Transpiled handler bodies and schemas match upstream; diff whitespace checks passed.

React wrappers and leather-bag's provider-array declarations do not support the same inference pattern with their installed APIs and are outside this change. No dependency or lockfile changes.