### PR TITLE
refactor: pass inputObject in executeTool() with backwards compatibility

### DIFF
--- a/demos/french-bistro/agent-worker.js
+++ b/demos/french-bistro/agent-worker.js
@@ -135,7 +135,7 @@ async function handleUserSubmit(text, port, requestId) {
             const tool = tools.find((t) => t.name == name);
             if (!tool) throw new Error(`Tool ${name} not found`);
             
-            const { result, error, aborted } = await requestToolExecution(port, tool, JSON.stringify(args));
+            const { result, error, aborted } = await requestToolExecution(port, tool, args);
             if (aborted) {
               appendMessage('System', `⚙️ Aborted tool: ${name}`, 'system');
               finalResponseGiven = true;

--- a/demos/french-bistro/agent.js
+++ b/demos/french-bistro/agent.js
@@ -121,9 +121,22 @@ function initSharedWorker(apiKey) {
           agentSendBtn.textContent = 'Abort';
           agentSendBtn.disabled = false;
 
-          const result = await document.modelContext.executeTool(tool, payload.args, {
-            signal: abortController.signal,
-          });
+          const inputObject = typeof payload.args === 'string' ? JSON.parse(payload.args) : payload.args;
+          let result;
+          try {
+            result = await document.modelContext.executeTool(tool, inputObject, {
+              signal: abortController.signal,
+            });
+          } catch (e) {
+            // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+            if (e.message.startsWith('Failed to parse input')) {
+              result = await document.modelContext.executeTool(tool, JSON.stringify(inputObject), {
+                signal: abortController.signal,
+              });
+            } else {
+              throw e;
+            }
+          }
           worker.port.postMessage({ type: 'TOOL_RESPONSE', payload: { result }, id });
         } catch (error) {
           const aborted = abortController?.signal.aborted;
@@ -255,9 +268,21 @@ async function handleUserSubmit() {
             agentSendBtn.textContent = 'Abort';
             agentSendBtn.disabled = false;
 
-            const result = await document.modelContext.executeTool(tool, JSON.stringify(args), {
-              signal: abortController.signal,
-            });
+            let result;
+            try {
+              result = await document.modelContext.executeTool(tool, args, {
+                signal: abortController.signal,
+              });
+            } catch (e) {
+              // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+              if (e.message.startsWith('Failed to parse input')) {
+                result = await document.modelContext.executeTool(tool, JSON.stringify(args), {
+                  signal: abortController.signal,
+                });
+              } else {
+                throw e;
+              }
+            }
             toolResponses.push({ functionResponse: { name, response: { result } } });
           } catch (error) {
             if (abortController?.signal.aborted) {

--- a/demos/page-agent/script.js
+++ b/demos/page-agent/script.js
@@ -188,12 +188,21 @@ async function handleUserSubmit() {
       } else {
         const toolResponses = [];
         for (const { name, args } of functionCalls) {
-          const inputArgs = JSON.stringify(args);
           try {
             appendMessage('System', `⚙️ Executing tool: ${name}...`, 'tool-indicator');
             const tools = await getTools();
             const tool = tools.find((t) => t.name == name);
-            const result = await document.modelContext.executeTool(tool, inputArgs);
+            let result;
+            try {
+              result = await document.modelContext.executeTool(tool, args);
+            } catch (e) {
+              // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+              if (e.message.startsWith('Failed to parse input')) {
+                result = await document.modelContext.executeTool(tool, JSON.stringify(args));
+              } else {
+                throw e;
+              }
+            }
 
             if (codeModeCheckbox.checked && name === 'execute_batch' && result && Array.isArray(result.outputs)) {
               for (const out of result.outputs) {

--- a/demos/shared/webmcp-batch.js
+++ b/demos/shared/webmcp-batch.js
@@ -119,7 +119,17 @@ export function registerExecuteBatchTool(options) {
         if (!targetTool) {
           throw new Error(`Tool ${toolName} not found`);
         }
-        return await document.modelContext.executeTool(targetTool, JSON.stringify(args || {}));
+        const inputObject = args || {};
+        try {
+          return await document.modelContext.executeTool(targetTool, inputObject);
+        } catch (e) {
+          // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+          if (e.message.startsWith('Failed to parse input')) {
+            return await document.modelContext.executeTool(targetTool, JSON.stringify(inputObject));
+          } else {
+            throw e;
+          }
+        }
       };
       
       const outputs = await executeDeclarativeBatch(steps, executeToolFn);

--- a/demos/shared/webmcp-polyfill.js
+++ b/demos/shared/webmcp-polyfill.js
@@ -249,7 +249,19 @@
       return filteredTools;
     }
 
-    async executeTool(tool, args, options) {
+    async executeTool(tool, inputObject, options) {
+      if (inputObject === undefined) {
+        throw new TypeError('inputObject is undefined');
+      }
+      try {
+        const serialized = JSON.stringify(inputObject);
+        if (serialized === undefined) {
+          throw new TypeError('inputObject could not be serialized to a JSON string');
+        }
+      } catch (e) {
+        throw new TypeError('inputObject could not be serialized to a JSON string');
+      }
+
       const win = tool.window || window;
 
       if (tool._isRemote) {
@@ -271,19 +283,28 @@
             type: 'WEBMCP_EXECUTE_TOOL_REQUEST',
             requestId,
             name: tool.name,
-            args,
+            inputObject,
           }, '*');
         });
       }
 
       if (win !== window && win.document && win.document.modelContext && win.document.modelContext.executeTool) {
-        return win.document.modelContext.executeTool(tool, args, options);
+        try {
+          return await win.document.modelContext.executeTool(tool, inputObject, options);
+        } catch (e) {
+          // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+          if (e.message.startsWith('Failed to parse input')) {
+            return await win.document.modelContext.executeTool(tool, JSON.stringify(inputObject), options);
+          } else {
+            throw e;
+          }
+        }
       }
 
-      let parsedArgs = args;
-      if (typeof args === 'string') {
+      let parsedArgs = inputObject;
+      if (typeof inputObject === 'string') {
         try {
-          parsedArgs = JSON.parse(args);
+          parsedArgs = JSON.parse(inputObject);
         } catch (e) { }
       }
 
@@ -533,14 +554,25 @@
     }
 
     if (data.type === 'WEBMCP_EXECUTE_TOOL_REQUEST') {
-      const { name, args, requestId } = data;
+      const { name, args, inputObject, requestId } = data;
       try {
         const localTools = getLocalTools(window);
         const tool = localTools.find((t) => t.name === name);
         if (!tool) {
           throw new Error(`Tool ${name} not found`);
         }
-        const result = await modelContext.executeTool(tool, args);
+        const resolvedInput = inputObject !== undefined ? inputObject : args;
+        let result;
+        try {
+          result = await modelContext.executeTool(tool, resolvedInput);
+        } catch (e) {
+          // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+          if (e.message.startsWith('Failed to parse input')) {
+            result = await modelContext.executeTool(tool, JSON.stringify(resolvedInput));
+          } else {
+            throw e;
+          }
+        }
         source.postMessage(
           {
             type: 'WEBMCP_EXECUTE_TOOL_RESPONSE',

--- a/demos/sport-shop-angular/src/app/services/agent.service.ts
+++ b/demos/sport-shop-angular/src/app/services/agent.service.ts
@@ -173,10 +173,17 @@ export class AgentService {
               const tool = tools.find((t) => t.name === name);
               if (!tool) throw new Error(`Tool ${name} not found`);
 
-              const rawResult = await (modelContext as any).executeTool(
-                tool,
-                JSON.stringify(args)
-              );
+              let rawResult: any;
+              try {
+                rawResult = await (modelContext as any).executeTool(tool, args);
+              } catch (e: any) {
+                // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
+                if (e?.message?.startsWith('Failed to parse input')) {
+                  rawResult = await (modelContext as any).executeTool(tool, JSON.stringify(args));
+                } else {
+                  throw e;
+                }
+              }
               toolResponses.push({
                 functionResponse: { name, response: { result: rawResult } }
               });


### PR DESCRIPTION
Following [webmachinelearning/webmcp#246](https://github.com/webmachinelearning/webmcp/pull/246), `executeTool()` now accepts an optional JavaScript object directly instead of a JSON string.

This PR updates `executeTool()` calls across the polyfill and demos to pass `inputObject` directly, while maintaining backwards compatibility for existing Chrome Stable versions that still require JSON stringified input:

```javascript
let result;
try {
  result = await document.modelContext.executeTool(tool, inputObject);
} catch (e) {
  // TODO: Remove when executeTool doesn't accept JSON stringified inputArgs in Chrome Stable.
  if (e.message.startsWith("Failed to parse input")) {
    result = await document.modelContext.executeTool(tool, JSON.stringify(inputObject));
  } else {
    throw e;
  }
}
```