### PR TITLE
Improve Dependabot grouping and validate demo builds in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,69 @@
 version: 2
 updates:
+  # Evaluator framework and CLI
+  - package-ecosystem: "npm"
+    directory: "/webmcp-evals"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      ai-sdk:
+        patterns:
+          - "@ai-sdk/*"
+          - "ai"
+      lint-format:
+        patterns:
+          - "oxlint*"
+          - "oxfmt*"
+          - "eslint*"
+          - "@eslint*"
+          - "prettier*"
+      all-other-dependencies:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
+  # Demo applications
   - package-ecosystem: "npm"
     directories:
-      - "/webmcp-evals"
       - "/demos/*"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
     groups:
-      all-dependencies:
+      angular:
+        patterns:
+          - "@angular*"
+          - "@angular-devkit/*"
+      react:
+        patterns:
+          - "react*"
+          - "@types/react*"
+      vite:
+        patterns:
+          - "vite*"
+          - "@vitejs/*"
+          - "vitest*"
+          - "@vitest/*"
+      tailwind-postcss:
+        patterns:
+          - "tailwind*"
+          - "@tailwindcss/*"
+          - "postcss*"
+          - "autoprefixer*"
+      lint-format:
+        patterns:
+          - "eslint*"
+          - "@eslint*"
+          - "typescript-eslint*"
+          - "@typescript-eslint/*"
+          - "prettier*"
+      all-other-dependencies:
         patterns:
           - "*"
-        group-by: "dependency-name"
     cooldown:
       default-days: 7
 
@@ -18,6 +71,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,47 +21,10 @@ jobs:
         with:
           node-version: 22
           cache: "npm"
-          cache-dependency-path: "demos/react-flightsearch/package-lock.json"
+          cache-dependency-path: "demos/*/package-lock.json"
 
       - name: Build Demos
-        run: |
-          cd demos
-
-          cd react-flightsearch
-          npm ci
-          npm run build
-          cd ..
-
-          cd webmcp-maze
-          npm ci
-          npm run build
-          cd ..
-
-          cd sport-shop-angular
-          npm ci
-          npm run build -- --base-href /webmcp-tools/demos/sport-shop-angular/
-          cd ..
-
-          cd hotel-chain
-          npm ci
-          npm run build
-          cd ..
-
-          cd analytics-dashboard
-          npm ci
-          npm run build
-          cd ..
-
-          cd leather-bag
-          npm ci
-          npm run build -- --base-href /webmcp-tools/demos/leather-bag/
-          cd ..
-
-          cd smart-home
-          npm ci
-          npm run build
-          cd ..
-
+        run: ./build-demos.sh
 
       - name: Assemble Public Folder
         run: |
@@ -84,7 +47,6 @@ jobs:
           cp -r demos/smart-home/dist deployment-root/demos/smart-home
           cp -r demos/page-agent deployment-root/demos/page-agent
           cp -r demos/explainer deployment-root/demos/explainer
-
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,6 +11,23 @@ permissions:
   contents: read
 
 jobs:
+  build-demos:
+    name: Build All Demos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: "demos/*/package-lock.json"
+
+      - name: Build all demos
+        run: ./build-demos.sh
+
   smoke-test:
     name: Smoke Test (${{ matrix.name }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR addresses two related issues with dependency updates and CI testing:

1. **Dependabot PR explosion**:
   - Removes `group-by: "dependency-name"` which was causing individual PRs to be generated for every package (and separating closely tied packages like `@angular/core`, `@angular/common`, etc.).
   - Separates `/webmcp-evals` and `/demos/*` into distinct update configs with tailored semantic groups (e.g. `angular`, `react`, `vite`, `tailwind-postcss`, `lint-format`, `ai-sdk`).
   - Schedules Dependabot runs for Mondays with an open PR limit of 10.

2. **Catch demo build failures earlier in PR CI**:
   - Adds a `build-demos` job to `smoke-tests.yml` that runs `./build-demos.sh` on every pull request. This ensures all 7 demos build with `npm ci && npm run build`, catching `ERESOLVE` peer-dependency issues or compilation errors before merging.
   - Refactors `deploy.yml` to reuse `./build-demos.sh` and caches across all demo lockfiles.